### PR TITLE
fix(agent): require connected transport before voice

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.5"
+var Version = "0.5.6"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -32,7 +32,7 @@ type EngineLike interface {
 	GatherCompleteOffer() (*Description, error)
 	CreateLocalOffer() (*Description, error)
 	ApplyRemote(remote Description) (string, *Description, error)
-	WaitConnected(timeout time.Duration) error
+	WaitConnected(ctx context.Context, timeout time.Duration) error
 	ArmPublish() error
 	LocalPublishMid() string
 	ActivatePublish() error
@@ -275,7 +275,7 @@ func (b *Bridge) Start(parent context.Context) error {
 	// TrackLocal.WriteSample can accept PCM locally while no RTP is capable of
 	// leaving the Runtime. Do not expose a Voice speaker (or begin Room-media
 	// discovery) until that transport is actually connected.
-	if err := engine.WaitConnected(connectTimeout); err != nil {
+	if err := engine.WaitConnected(ctx, connectTimeout); err != nil {
 		b.log("media_bootstrap_stage", map[string]string{
 			"stage": "peerconnection_connect_failed",
 		})

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -269,6 +269,21 @@ func (b *Bridge) Start(parent context.Context) error {
 			return fail(applyErr)
 		}
 	}
+	// The proven Pion runbook's stage E is a real readiness boundary, not
+	// merely a diagnostic convenience. A successful SDP exchange only means
+	// Cloudflare accepted the description; before ICE/DTLS reaches connected,
+	// TrackLocal.WriteSample can accept PCM locally while no RTP is capable of
+	// leaving the Runtime. Do not expose a Voice speaker (or begin Room-media
+	// discovery) until that transport is actually connected.
+	if err := engine.WaitConnected(connectTimeout); err != nil {
+		b.log("media_bootstrap_stage", map[string]string{
+			"stage": "peerconnection_connect_failed",
+		})
+		return fail(err)
+	}
+	b.log("media_bootstrap_stage", map[string]string{
+		"stage": "peerconnection_connected",
+	})
 
 	if err := b.poll(); err != nil && !isHumanMediaDiscoveryDenied(err) {
 		return fail(err)

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -296,6 +296,12 @@ func (b *Bridge) Start(parent context.Context) error {
 		})
 		return fail(err)
 	}
+	// A Stop can land immediately after Pion reports Connected. Check the
+	// bridge context again before the first RoomMedia request so a cancelled
+	// bootstrap never starts discovery or a subscription negotiation.
+	if err := ctx.Err(); err != nil {
+		return fail(err)
+	}
 	b.log("media_bootstrap_stage", map[string]string{
 		"stage": "peerconnection_connected",
 	})

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -198,6 +198,9 @@ func (b *Bridge) Start(parent context.Context) error {
 		b.resetToStopped()
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return fail(err)
+	}
 
 	engine, err := b.options.CreateEngine(EngineEvents{
 		OnTrack:      b.handleIncomingTrack,
@@ -224,6 +227,9 @@ func (b *Bridge) Start(parent context.Context) error {
 	if err != nil {
 		return fail(err)
 	}
+	if err := ctx.Err(); err != nil {
+		return fail(err)
+	}
 	// Bounded bootstrap stage diagnostics (electric-audio investigation):
 	// presence/attempt/outcome only — never SDP content or IDs.
 	b.log("media_bootstrap_stage", map[string]string{
@@ -232,6 +238,9 @@ func (b *Bridge) Start(parent context.Context) error {
 	})
 	sessionID, err := b.rest.CreateAgentSession()
 	if err != nil {
+		return fail(err)
+	}
+	if err := ctx.Err(); err != nil {
 		return fail(err)
 	}
 	b.mu.Lock()
@@ -248,6 +257,9 @@ func (b *Bridge) Start(parent context.Context) error {
 		})
 		return fail(err)
 	}
+	if err := ctx.Err(); err != nil {
+		return fail(err)
+	}
 	b.log("media_bootstrap_stage", map[string]string{
 		"stage":                 "establish_ok",
 		"establish_result_code": "ok",
@@ -260,6 +272,9 @@ func (b *Bridge) Start(parent context.Context) error {
 				applyErr = errors.New("missing local answer after remote offer")
 			}
 			return fail(applyErr)
+		}
+		if err := ctx.Err(); err != nil {
+			return fail(err)
 		}
 		if err := b.rest.Renegotiate(sessionID, *answer, PurposeAgentTransport); err != nil {
 			return fail(err)

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -25,6 +26,7 @@ type fakeEngine struct {
 	waitCalls       int
 	waitTimeout     time.Duration
 	waitErr         error
+	waitFn          func(context.Context, time.Duration) error
 	armCalls        int
 	mid             string
 	activateCalls   int
@@ -78,12 +80,16 @@ func (f *fakeEngine) ApplyRemote(remote Description) (string, *Description, erro
 	f.mu.Unlock()
 	return applied, answer, err
 }
-func (f *fakeEngine) WaitConnected(timeout time.Duration) error {
+func (f *fakeEngine) WaitConnected(ctx context.Context, timeout time.Duration) error {
 	f.mu.Lock()
 	f.waitCalls++
 	f.waitTimeout = timeout
 	err := f.waitErr
+	waitFn := f.waitFn
 	f.mu.Unlock()
+	if waitFn != nil {
+		return waitFn(ctx, timeout)
+	}
 	return err
 }
 func (f *fakeEngine) ArmPublish() error {
@@ -388,6 +394,38 @@ func TestBridgeBootstrapFailsClosedWhenPeerConnectionNeverConnects(t *testing.T)
 	}
 	if engine.closeCalls != 1 {
 		t.Fatalf("failed connected readiness must close the partial engine, close calls = %d", engine.closeCalls)
+	}
+}
+
+func TestBridgeStopCancelsConnectionWait(t *testing.T) {
+	engine := newFakeEngine()
+	waitStarted := make(chan struct{})
+	engine.waitFn = func(ctx context.Context, _ time.Duration) error {
+		close(waitStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	bridge := NewBridge(testBridgeOptions(engine, newFakeRest(), nil))
+	startDone := make(chan error, 1)
+	go func() { startDone <- bridge.Start(context.Background()) }()
+
+	select {
+	case <-waitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("bridge never reached the connection wait")
+	}
+	bridge.Stop()
+
+	select {
+	case err := <-startDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop must cancel an in-flight connection wait")
+	}
+	if engine.closeCalls != 1 {
+		t.Fatalf("Stop must close the partial engine once, got %d closes", engine.closeCalls)
 	}
 }
 

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -222,6 +222,7 @@ type fakeRest struct {
 	establishCalls      int
 	establishDesc       Description
 	establishErr        error
+	roomMediaCalls      int
 	roomMediaReturn     []RoomMediaParticipant
 	roomMediaErr        error
 	subscribeKeys       []string
@@ -264,6 +265,7 @@ func (f *fakeRest) EstablishDataChannelTransport(sessionID string, offer Descrip
 func (f *fakeRest) RoomMedia() ([]RoomMediaParticipant, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.roomMediaCalls++
 	if f.roomMediaErr != nil {
 		return nil, f.roomMediaErr
 	}
@@ -320,6 +322,12 @@ func (f *fakeRest) snapshotSubscribes() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.subscribeKeys...)
+}
+
+func (f *fakeRest) snapshotRoomMediaCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.roomMediaCalls
 }
 
 func testBridgeOptions(engine *fakeEngine, rest *fakeRest, publish *PublishConfig) BridgeOptions {

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -22,6 +22,9 @@ type fakeEngine struct {
 	applyApplied    string
 	applyAnswer     *Description
 	applyErr        error
+	waitCalls       int
+	waitTimeout     time.Duration
+	waitErr         error
 	armCalls        int
 	mid             string
 	activateCalls   int
@@ -75,7 +78,14 @@ func (f *fakeEngine) ApplyRemote(remote Description) (string, *Description, erro
 	f.mu.Unlock()
 	return applied, answer, err
 }
-func (f *fakeEngine) WaitConnected(timeout time.Duration) error { return nil }
+func (f *fakeEngine) WaitConnected(timeout time.Duration) error {
+	f.mu.Lock()
+	f.waitCalls++
+	f.waitTimeout = timeout
+	err := f.waitErr
+	f.mu.Unlock()
+	return err
+}
 func (f *fakeEngine) ArmPublish() error {
 	f.mu.Lock()
 	f.armCalls++
@@ -357,6 +367,27 @@ func TestBridgeBootstrapSubmitsGatheredLocalOfferAndAppliesAnswer(t *testing.T) 
 	}
 	if len(rest.snapshotRenegotiations()) != 0 {
 		t.Fatal("no renegotiate expected on the answer path")
+	}
+	if engine.waitCalls != 1 || engine.waitTimeout != connectTimeout {
+		t.Fatalf("connected readiness gate = %d calls with %s, want one %s call",
+			engine.waitCalls, engine.waitTimeout, connectTimeout)
+	}
+}
+
+func TestBridgeBootstrapFailsClosedWhenPeerConnectionNeverConnects(t *testing.T) {
+	engine := newFakeEngine()
+	engine.waitErr = errors.New("peer connection timed out")
+	rest := newFakeRest()
+	bridge := NewBridge(testBridgeOptions(engine, rest, nil))
+	if err := bridge.Start(t.Context()); err == nil {
+		t.Fatal("bootstrap must not report a ready bridge before Pion connects")
+	}
+	if engine.waitCalls != 1 || engine.waitTimeout != connectTimeout {
+		t.Fatalf("connected readiness gate = %d calls with %s, want one %s call",
+			engine.waitCalls, engine.waitTimeout, connectTimeout)
+	}
+	if engine.closeCalls != 1 {
+		t.Fatalf("failed connected readiness must close the partial engine, close calls = %d", engine.closeCalls)
 	}
 }
 

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -437,6 +437,41 @@ func TestBridgeStopCancelsConnectionWait(t *testing.T) {
 	}
 }
 
+func TestBridgeStopBeforeConnectedWaitReturnsSkipsDiscovery(t *testing.T) {
+	engine := newFakeEngine()
+	waitEntered := make(chan struct{})
+	allowWaitReturn := make(chan struct{})
+	engine.waitFn = func(context.Context, time.Duration) error {
+		close(waitEntered)
+		<-allowWaitReturn
+		return nil
+	}
+	rest := newFakeRest()
+	bridge := NewBridge(testBridgeOptions(engine, rest, nil))
+	startDone := make(chan error, 1)
+	go func() { startDone <- bridge.Start(context.Background()) }()
+
+	select {
+	case <-waitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("bridge never reached the connection wait")
+	}
+	bridge.Stop()
+	close(allowWaitReturn)
+
+	select {
+	case err := <-startDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled bootstrap did not return")
+	}
+	if got := rest.snapshotRoomMediaCalls(); got != 0 {
+		t.Fatalf("RoomMedia calls after Stop = %d, want 0", got)
+	}
+}
+
 func TestBridgeBootstrapRemoteOfferProducesAnswerAndRenegotiates(t *testing.T) {
 	engine := newFakeEngine()
 	rest := newFakeRest()

--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -93,6 +93,8 @@ type Controller struct {
 	voiceStarting    bool
 	stopped          bool
 	cancel           context.CancelFunc
+	ctx              context.Context
+	bridgeCancel     context.CancelFunc
 	now              func() time.Time
 }
 
@@ -119,17 +121,19 @@ func NewController(options ControllerOptions) *Controller {
 // Start runs the first poll synchronously, then arms the ticker — a caller
 // awaiting Start sees the first authorization check settle deterministically.
 func (c *Controller) Start(parent context.Context) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
 	c.mu.Lock()
 	if !c.stopped {
 		c.mu.Unlock()
+		cancel()
 		return
 	}
 	c.stopped = false
-	c.mu.Unlock()
-
-	ctx, cancel := context.WithCancel(parent)
-	c.mu.Lock()
 	c.cancel = cancel
+	c.ctx = ctx
 	c.mu.Unlock()
 
 	c.poll()
@@ -161,6 +165,7 @@ func (c *Controller) Stop() {
 	c.stopped = true
 	cancel := c.cancel
 	c.cancel = nil
+	c.ctx = nil
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -383,27 +388,45 @@ func (c *Controller) ensureRunning() {
 	c.state = "starting"
 	c.generation++
 	generation := c.generation
+	parent := c.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	bridgeCtx, bridgeCancel := context.WithCancel(parent)
+	c.bridgeCancel = bridgeCancel
 	c.mu.Unlock()
 
 	bridge, err := c.buildBridge()
 	if err != nil {
+		bridgeCancel()
 		c.mu.Lock()
 		if c.generation == generation {
 			c.state = "idle"
+			c.bridgeCancel = nil
 		}
 		c.mu.Unlock()
 		c.log("meeting_notes_media_start_failed", map[string]string{"code": safeDiagnosticCode(err)})
 		return
 	}
 	c.mu.Lock()
+	if c.stopped || c.generation != generation || c.state != "starting" {
+		c.mu.Unlock()
+		bridgeCancel()
+		bridge.Stop()
+		return
+	}
 	c.bridge = bridge
 	c.mu.Unlock()
 
-	if err := bridge.Start(context.Background()); err != nil {
+	if err := bridge.Start(bridgeCtx); err != nil {
+		bridgeCancel()
 		c.mu.Lock()
-		c.bridge = nil
-		if c.generation == generation {
+		if c.bridge == bridge {
+			c.bridge = nil
+		}
+		if c.generation == generation && c.state == "starting" {
 			c.state = "idle"
+			c.bridgeCancel = nil
 		}
 		c.mu.Unlock()
 		c.log("meeting_notes_media_start_failed", map[string]string{
@@ -413,8 +436,9 @@ func (c *Controller) ensureRunning() {
 		return
 	}
 	c.mu.Lock()
-	if c.generation != generation {
+	if c.stopped || c.generation != generation || c.state != "starting" || c.bridge != bridge {
 		c.mu.Unlock()
+		bridgeCancel()
 		bridge.Stop()
 		return
 	}
@@ -551,16 +575,16 @@ func (c *Controller) teardownBridge() {
 	c.teardownVoice()
 	c.mu.Lock()
 	c.generation++
-	if c.state == "idle" {
-		c.mu.Unlock()
-		return
-	}
-	wasRunning := c.state == "running"
 	bridge := c.bridge
+	bridgeCancel := c.bridgeCancel
 	c.bridge = nil
+	c.bridgeCancel = nil
 	c.state = "idle"
 	c.mu.Unlock()
-	if wasRunning && bridge != nil {
+	if bridgeCancel != nil {
+		bridgeCancel()
+	}
+	if bridge != nil {
 		bridge.Stop()
 		c.log("meeting_notes_media_stopped", nil)
 	}

--- a/agent/internal/media/controller_test.go
+++ b/agent/internal/media/controller_test.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -228,6 +229,58 @@ func TestControllerMeetingNotesGrantStartsAndRevocationStopsBridge(t *testing.T)
 	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, nil)
 	controller.poll()
 	waitController(t, 2*time.Second, func() bool { return firstEngine.closeCalls == 1 }, "bridge stop")
+}
+
+func TestControllerStopCancelsStartingBridge(t *testing.T) {
+	client := &fakeRoomClient{}
+	client.setRoom("on", "on", "agent", 111, "off", "on", "agent", 0, nil)
+	engine := newFakeEngine()
+	rest := newFakeRest()
+	waitStarted := make(chan struct{})
+	engine.waitFn = func(ctx context.Context, _ time.Duration) error {
+		close(waitStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	controller := NewController(ControllerOptions{
+		Client:         client,
+		RoomID:         "room",
+		ParticipantID:  "agent",
+		PollIntervalMs: 100,
+		CreateBridge: func() (*Bridge, error) {
+			return NewBridge(testBridgeOptions(engine, rest, nil)), nil
+		},
+	})
+	startDone := make(chan struct{})
+	go func() {
+		controller.Start(context.Background())
+		close(startDone)
+	}()
+
+	select {
+	case <-waitStarted:
+	case <-time.After(time.Second):
+		t.Fatal("controller never reached bridge connection wait")
+	}
+	controller.Stop()
+
+	select {
+	case <-startDone:
+	case <-time.After(time.Second):
+		t.Fatal("Controller.Stop must cancel a starting bridge")
+	}
+	if engine.closeCalls != 1 {
+		t.Fatalf("starting bridge close calls = %d, want 1", engine.closeCalls)
+	}
+	if got := rest.snapshotRoomMediaCalls(); got != 0 {
+		t.Fatalf("RoomMedia calls after cancelled bootstrap = %d, want 0", got)
+	}
+	controller.mu.Lock()
+	state, bridge := controller.state, controller.bridge
+	controller.mu.Unlock()
+	if state != "idle" || bridge != nil {
+		t.Fatalf("controller after Stop = state %q bridge %v, want idle nil", state, bridge)
+	}
 }
 
 func TestControllerRoomInfoFailureFailsClosed(t *testing.T) {

--- a/agent/internal/media/engine.go
+++ b/agent/internal/media/engine.go
@@ -8,6 +8,7 @@
 package media
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"sync"
@@ -336,8 +337,11 @@ func waitAnswerGather(pc *webrtc.PeerConnection) {
 	}
 }
 
-// WaitConnected blocks until connected or timeout.
-func (e *Engine) WaitConnected(timeout time.Duration) error {
+// WaitConnected blocks until connected, cancelled, or timed out.
+func (e *Engine) WaitConnected(ctx context.Context, timeout time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	deadline := time.After(timeout)
 	tick := time.NewTicker(200 * time.Millisecond)
 	defer tick.Stop()
@@ -349,6 +353,8 @@ func (e *Engine) WaitConnected(timeout time.Duration) error {
 		case <-deadline:
 			return fmt.Errorf("peer connection did not reach connected within %s (state=%s ice=%s)",
 				timeout, e.pc.ConnectionState(), e.pc.ICEConnectionState())
+		case <-ctx.Done():
+			return fmt.Errorf("peer connection wait cancelled: %w", ctx.Err())
 		case <-tick.C:
 		}
 	}

--- a/agent/internal/media/engine.go
+++ b/agent/internal/media/engine.go
@@ -346,8 +346,13 @@ func (e *Engine) WaitConnected(ctx context.Context, timeout time.Duration) error
 	tick := time.NewTicker(200 * time.Millisecond)
 	defer tick.Stop()
 	for {
-		if e.pc.ConnectionState() == webrtc.PeerConnectionStateConnected {
+		state := e.pc.ConnectionState()
+		if state == webrtc.PeerConnectionStateConnected {
 			return nil
+		}
+		if state == webrtc.PeerConnectionStateFailed || state == webrtc.PeerConnectionStateClosed {
+			return fmt.Errorf("peer connection stopped before reaching connected (state=%s ice=%s)",
+				state, e.pc.ICEConnectionState())
 		}
 		select {
 		case <-deadline:

--- a/agent/internal/media/engine_test.go
+++ b/agent/internal/media/engine_test.go
@@ -272,10 +272,10 @@ func TestCancelTurnDiscardsCarryKeepsPublicationActive(t *testing.T) {
 	if err := engine.WritePCM(bytes.Repeat([]byte{7}, 500), 0); err != nil {
 		t.Fatalf("WritePCM: %v", err)
 	}
-	waitForFrames(t, engine, 0) // writer drains instantly with the fake clock
-	if engine.PCMCarry() != 0 {
-		t.Fatal("a sub-frame write must leave carry only until flushed")
-	}
+	// WritePCM is asynchronous: wait until the writer has actually accepted
+	// the sub-frame chunk before verifying that CancelTurn clears its carry.
+	// Checking immediately races the writer scheduler and was flaky in CI.
+	waitForPCMCarry(t, engine, 500)
 	engine.CancelTurn(0)
 	if engine.PCMCarry() != 0 {
 		t.Fatal("CancelTurn must discard the buffered partial frame")
@@ -372,6 +372,19 @@ func waitForFrames(t *testing.T, engine *Engine, n uint64) {
 		time.Sleep(2 * time.Millisecond)
 	}
 	t.Fatalf("writer did not emit %d frames (got %d)", n, engine.framesWritten())
+}
+
+// waitForPCMCarry waits for the async writer to hold exactly n partial bytes.
+func waitForPCMCarry(t *testing.T, engine *Engine, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if engine.PCMCarry() == n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("writer carry = %d bytes, want %d", engine.PCMCarry(), n)
 }
 
 // slowMediaTtsProvider keeps a turn's drain active for ~150ms so tests can

--- a/agent/internal/media/engine_test.go
+++ b/agent/internal/media/engine_test.go
@@ -225,6 +225,16 @@ func TestWaitConnectedReturnsPromptlyWhenCancelled(t *testing.T) {
 	}
 }
 
+func TestWaitConnectedFailsPromptlyAfterClose(t *testing.T) {
+	engine := newTestEngine(t)
+	engine.Close()
+
+	err := engine.WaitConnected(context.Background(), time.Minute)
+	if err == nil || !strings.Contains(err.Error(), "state=closed") {
+		t.Fatalf("WaitConnected error = %v, want closed connection state", err)
+	}
+}
+
 func TestWritePCMPacesOutboundFramesWithInjectedClock(t *testing.T) {
 	engine := newTestEngine(t)
 	_ = engine.ArmPublish()

--- a/agent/internal/media/engine_test.go
+++ b/agent/internal/media/engine_test.go
@@ -2,6 +2,7 @@ package media
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"strings"
@@ -210,6 +211,17 @@ func TestWritePCMRequiresActivation(t *testing.T) {
 	engine.DeactivatePublish()
 	if err := engine.WritePCM(make([]byte, 960), 0); !errors.Is(err, errPublishNotActive) {
 		t.Fatal("write after deactivation must fail closed")
+	}
+}
+
+func TestWaitConnectedReturnsPromptlyWhenCancelled(t *testing.T) {
+	engine := newTestEngine(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := engine.WaitConnected(ctx, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitConnected error = %v, want context cancellation", err)
 	}
 }
 


### PR DESCRIPTION
Production dogfood found that Agent Voice grants and local TTS/Pion readiness were healthy in the official 0.5.5 runtime, but Pi text replies never produced a browser-subscribable audio track. The integrated bridge applied the SFU SDP but skipped the Pion runbook transport-connected boundary.

Fix:
- require Engine.WaitConnected after the initial Agent transport SDP exchange and before media discovery or exposing a voice speaker
- fail closed and tear down partial state when ICE or DTLS cannot connect, so a local WriteSample success cannot be mistaken for audible RTP
- cover the connected gate and failure cleanup
- make the existing async-writer carry test deterministic; it now waits until the writer owns the partial frame before testing CancelTurn cleanup
- bump Runtime source version to 0.5.6; live agent.md remains pinned to published 0.5.5 until the 0.5.6 release tag exists

Verification:
- focused media test repeated 100 times
- go test ./... -count=1 -timeout 300s
- go vet ./...
- go build ./cmd/free4chat-agent

Production audio dogfood remains pending the official 0.5.6 release and deployment.