### PR TITLE
chore: disable turnstile for production dogfood

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -72,6 +72,10 @@ jobs:
         working-directory: app
         env:
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          # Keep browser dogfood unblocked while Agent Voice is stabilised.
+          # Re-enable this together with TURNSTILE_DISABLED below once the
+          # production test window is explicitly closed.
+          NEXT_PUBLIC_TURNSTILE_DISABLED: "1"
 
       - name: Validate deployment variables
         run: test -n "$SFU_APP_ID" && test -n "$NEXT_PUBLIC_TURNSTILE_SITE_KEY"
@@ -111,7 +115,8 @@ jobs:
         run: |
           npx wrangler deploy \
             --var "SFU_APP_ID:${SFU_APP_ID}" \
-            --var "AGENT_MEDIA_ENABLED:true"
+            --var "AGENT_MEDIA_ENABLED:true" \
+            --var "TURNSTILE_DISABLED:true"
         working-directory: app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Temporarily keeps both existing Turnstile bypasses enabled during the production Agent Voice dogfood window.

- Browser build injects NEXT_PUBLIC_TURNSTILE_DISABLED=1, so it does not load or wait for the widget.
- Worker deployment injects TURNSTILE_DISABLED=true, so server-side session creation accepts the browser bypass token.

No Turnstile keys or validation code are changed. Re-enable both workflow values together only after the production test window is explicitly closed.