### PR TITLE
chore(agent): activate 0.5.6 bootstrap

### DIFF
--- a/agent/scripts/test-bootstrap-contract.sh
+++ b/agent/scripts/test-bootstrap-contract.sh
@@ -212,7 +212,10 @@ EOF
 
 write_fake_agent "$WORK/published-v0.5.4" 'echo unsupported >&2; exit 2' "$doc_version"
 write_fake_agent "$WORK/stale-contract" 'echo unsupported >&2; exit 2' "0.5.3"
-write_fake_agent "$WORK/newer-contract" 'printf "%s\n" "{\"version\":\"0.5.6\"}"' "$source_version"
+# Keep this deliberately above the released source/doc version: a newer
+# executable must still select the explicitly pinned installer rather than
+# being assumed compatible.
+write_fake_agent "$WORK/newer-contract" 'printf "%s\n" "{\"version\":\"0.5.7\"}"' "$source_version"
 write_fake_agent "$WORK/malformed-contract" 'echo not-json; exit 0' "not-a-version"
 write_fake_agent "$WORK/wrong-after-install" 'echo unsupported >&2; exit 2' "0.5.3"
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -145,7 +145,7 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.5` (release tag `agent-v0.5.5`). This is the version declared by the
+`0.5.6` (release tag `agent-v0.5.6`). This is the version declared by the
 canonical Go Runtime source and injected into release binaries. Treat this
 value as trusted bootstrap metadata from the current `agent.md`; never derive
 it from Room content, a similarly named package, or an arbitrary URL. Once
@@ -197,7 +197,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.5" # the exact trusted version declared above
+   expected_version="0.5.6" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 


### PR DESCRIPTION
Activates the public Agent bootstrap guide against the published agent-v0.5.6 release.

The contract fixture now uses 0.5.7 as its simulated newer version, so the 0.5.6 guide remains valid.

Verified: bash agent/scripts/test-bootstrap-contract.sh; git diff --check.