### PR TITLE
chore(agent): prepare 0.5.7 release

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.6"
+var Version = "0.5.7"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary
- advance the canonical Go Agent Runtime source version to 0.5.7
- reserve a new immutable official release line for the merged macOS Keychain read fix

## Verification
- go test ./... (run from agent/)

The public agent bootstrap remains pinned to the already published 0.5.6 until the 0.5.7 tag and release artifacts have been built and verified.