### PR TITLE
fix(agent): preserve first Voice utterance during subscriber startup

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.7"
+var Version = "0.5.8"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -23,6 +23,12 @@ const (
 	// maxPendingVoicePcmBytes bounds buffered real PCM while publication
 	// activation is pending.
 	maxPendingVoicePcmBytes = 8 * 1024 * 1024
+	// A completed TTS turn must not silently discard its buffered prefix when a
+	// Human subscription is slow or unavailable. This is a bounded safety
+	// valve for the explicit readiness handshake; cancellation/revocation
+	// still unblocks it immediately through turn admission.
+	voiceDownstreamReadyWait       = 10 * time.Second
+	voiceDownstreamReadyPollPeriod = 250 * time.Millisecond
 )
 
 // EngineLike is the in-process Pion engine boundary (fake-able for tests).
@@ -140,7 +146,6 @@ type Bridge struct {
 	// voice publication state
 	voiceAnnounced       bool
 	voicePrimingSent     bool
-	voicePadSent         bool
 	voiceConfirmFlight   chan struct{}
 	pendingVoicePCM      []pendingPcmItem
 	pendingVoicePCMBytes int
@@ -620,7 +625,6 @@ func (b *Bridge) ActivateVoicePublish() error {
 	engine := b.engine
 	b.voiceAnnounced = false
 	b.voicePrimingSent = false
-	b.voicePadSent = false
 	b.pendingVoicePCM = nil
 	b.pendingVoicePCMBytes = 0
 	b.mu.Unlock()
@@ -670,6 +674,18 @@ func (b *Bridge) ActivateVoicePublish() error {
 		return fail("activate-publish", err)
 	}
 	diagnostic["activate_publish_ok"] = "1"
+	// Emit one bounded silent frame while the publication is still being
+	// announced. This prewarms Cloudflare's publisher state before the Human
+	// browser starts tracks/new, without ever putting user speech on an
+	// un-negotiated downstream path.
+	if err := b.primeVoicePublication(); err != nil {
+		return fail("prime-publish", err)
+	}
+	diagnostic["prime_publish_ok"] = "1"
+	// Promote the now-primed publication to the Human-visible track as soon as
+	// Cloudflare confirms it. If the control-plane check is still inactive,
+	// the first PCM/flush path retries it without draining user speech.
+	b.confirmVoicePublicationActive()
 	b.log("voice_publish_succeeded", diagnostic)
 	return nil
 }
@@ -680,7 +696,6 @@ func (b *Bridge) DeactivateVoicePublish() {
 	engine := b.engine
 	b.voiceAnnounced = false
 	b.voicePrimingSent = false
-	b.voicePadSent = false
 	b.pendingVoicePCM = nil
 	b.pendingVoicePCMBytes = 0
 	b.mu.Unlock()
@@ -738,6 +753,16 @@ func (b *Bridge) FlushVoice(token uint64) error {
 		return err
 	}
 	b.confirmVoicePublicationActive()
+	// A short TTS response can reach EndTurn before the browser has completed
+	// its subscription negotiation. Keep every real PCM chunk in the bounded
+	// bridge buffer until the explicit downstream-ready acknowledgement arrives;
+	// never flush it into an unsubscribed Pion writer.
+	if b.pendingVoiceCount() > 0 && !b.voicePublicationAnnounced() {
+		if err := b.waitForVoicePublicationReady(token); err != nil {
+			b.CancelVoiceTurn(token)
+			return err
+		}
+	}
 	if err := b.drainPendingVoicePcm(token); err != nil {
 		return err
 	}
@@ -816,31 +841,6 @@ func (b *Bridge) primeVoicePublication() error {
 	return b.writeEnginePcm(make([]byte, voicePrimingSilenceBytes), 0)
 }
 
-// padAfterAnnounce writes a bounded synthetic-silence pad (25 frames =
-// 500 ms) once per publication, AFTER Cloudflare confirms the publisher
-// active. The browser still needs trackPublished -> subscribe ->
-// renegotiate (~1 s) before the SFU routes audio to it; frames sent inside
-// that window are dropped. Padding absorbs the drop window so the first
-// real words survive — production E2E showed the head of the first reply
-// (1-3 words) being lost otherwise, independent of how long the human
-// waited before speaking. The pad is silence, never user speech.
-func (b *Bridge) padAfterAnnounce() {
-	b.mu.Lock()
-	if b.options.Publish == nil || !b.voiceAnnounced || b.voicePadSent {
-		b.mu.Unlock()
-		return
-	}
-	b.voicePadSent = true
-	b.mu.Unlock()
-	const padFrames = 25
-	silence := make([]byte, voicePrimingSilenceBytes)
-	for i := 0; i < padFrames; i++ {
-		if err := b.writeEnginePcm(silence, 0); err != nil {
-			return
-		}
-	}
-}
-
 func (b *Bridge) confirmVoicePublicationActive() {
 	b.mu.Lock()
 	if b.options.Publish == nil || b.voiceAnnounced || b.mySessionID == "" || b.rest == nil {
@@ -872,7 +872,7 @@ func (b *Bridge) confirmVoicePublicationActive() {
 			return
 		}
 		firstAnnounce := false
-		if active {
+		if active && diagnostic.DownstreamReady {
 			b.mu.Lock()
 			if !b.voiceAnnounced {
 				firstAnnounce = true
@@ -880,21 +880,59 @@ func (b *Bridge) confirmVoicePublicationActive() {
 			b.voiceAnnounced = true
 			b.mu.Unlock()
 		}
-		if firstAnnounce {
-			b.padAfterAnnounce()
-		}
 		b.log("voice_publish_cloudflare_check", map[string]string{
 			"publisher_session_lookup_ok": bool01(diagnostic.PublisherSessionLookupOK),
 			"matching_track_found":        bool01(diagnostic.MatchingTrackFound),
 			"matching_track_status":       diagnostic.MatchingTrackStatus,
 			"matching_track_has_mid":      bool01(diagnostic.MatchingTrackHasMid),
 			"active":                      bool01(diagnostic.Active),
+			"downstream_ready":            bool01(diagnostic.DownstreamReady),
+			"first_announce":              bool01(firstAnnounce),
 		})
 		b.mu.Lock()
 		b.voiceConfirmFlight = nil
 		b.mu.Unlock()
 	}()
 	<-flight
+}
+
+// waitForVoicePublicationReady waits for the current publication to be both
+// Cloudflare-active and downstream-ready. The browser ACK is the correctness
+// boundary; the timeout only bounds a broken/no-listener room and prevents an
+// unbounded PCM retention. Turn cancellation/revocation is observed on every
+// iteration, so a superseded turn never holds the host gate for the timeout.
+func (b *Bridge) waitForVoicePublicationReady(token uint64) error {
+	started := time.Now()
+	b.log("voice_downstream_ready_wait", map[string]string{
+		"pending_bytes": fmt.Sprintf("%d", b.pendingVoiceBytes()),
+	})
+	deadline := time.Now().Add(voiceDownstreamReadyWait)
+	for {
+		if !b.validateTurn(token) {
+			return errPublishNotActive
+		}
+		if b.voicePublicationAnnounced() {
+			b.log("voice_downstream_ready", map[string]string{
+				"wait_ms": fmt.Sprintf("%d", time.Since(started)/time.Millisecond),
+			})
+			return nil
+		}
+		b.confirmVoicePublicationActive()
+		if b.voicePublicationAnnounced() {
+			b.log("voice_downstream_ready", map[string]string{
+				"wait_ms": fmt.Sprintf("%d", time.Since(started)/time.Millisecond),
+			})
+			return nil
+		}
+		if time.Now().After(deadline) {
+			b.log("voice_downstream_ready_timeout", map[string]string{
+				"pending_bytes": fmt.Sprintf("%d", b.pendingVoiceBytes()),
+				"wait_ms":       fmt.Sprintf("%d", voiceDownstreamReadyWait/time.Millisecond),
+			})
+			return errors.New("voice_downstream_not_ready")
+		}
+		time.Sleep(voiceDownstreamReadyPollPeriod)
+	}
 }
 
 func bool01(value bool) string {
@@ -926,6 +964,12 @@ func (b *Bridge) pendingVoiceCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return len(b.pendingVoicePCM)
+}
+
+func (b *Bridge) pendingVoiceBytes() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.pendingVoicePCMBytes
 }
 
 func (b *Bridge) enqueuePendingVoicePcm(chunk []byte, token uint64) error {

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -217,27 +217,28 @@ func (f *fakeEngine) snapshotApplied() []Description {
 
 // fakeRest implements RestClientLike with scripted behavior.
 type fakeRest struct {
-	mu                  sync.Mutex
-	sessionID           string
-	establishCalls      int
-	establishDesc       Description
-	establishErr        error
-	roomMediaCalls      int
-	roomMediaReturn     []RoomMediaParticipant
-	roomMediaErr        error
-	subscribeKeys       []string
-	subscribeDesc       Description
-	subscribeMid        string
-	midSequence         []string
-	subscribeErr        error
-	publishCalls        int
-	publishDesc         Description
-	publishErr          error
-	renegotiatePurposes []Purpose
-	confirmCalls        int
-	confirmActive       bool
-	confirmDiagnostic   PublishedAudioDiagnostic
-	confirmErr          error
+	mu                     sync.Mutex
+	sessionID              string
+	establishCalls         int
+	establishDesc          Description
+	establishErr           error
+	roomMediaCalls         int
+	roomMediaReturn        []RoomMediaParticipant
+	roomMediaErr           error
+	subscribeKeys          []string
+	subscribeDesc          Description
+	subscribeMid           string
+	midSequence            []string
+	subscribeErr           error
+	publishCalls           int
+	publishDesc            Description
+	publishErr             error
+	renegotiatePurposes    []Purpose
+	confirmCalls           int
+	confirmActive          bool
+	confirmDownstreamReady bool
+	confirmDiagnostic      PublishedAudioDiagnostic
+	confirmErr             error
 }
 
 func newFakeRest() *fakeRest {
@@ -249,6 +250,7 @@ func newFakeRest() *fakeRest {
 		confirmDiagnostic: PublishedAudioDiagnostic{
 			MatchingTrackStatus: "inactive",
 		},
+		confirmDownstreamReady: true,
 	}
 }
 
@@ -309,7 +311,9 @@ func (f *fakeRest) ConfirmPublishedAudioTrackActive(sessionID, trackName string)
 	if f.confirmErr != nil {
 		return false, PublishedAudioDiagnostic{}, f.confirmErr
 	}
-	return f.confirmActive, f.confirmDiagnostic, nil
+	diagnostic := f.confirmDiagnostic
+	diagnostic.DownstreamReady = f.confirmActive && f.confirmDownstreamReady
+	return f.confirmActive, diagnostic, nil
 }
 
 func (f *fakeRest) snapshotRenegotiations() []Purpose {
@@ -646,26 +650,21 @@ func TestBridgeVoicePublishFlowsAndPrimingDrainsExactlyOnce(t *testing.T) {
 		t.Fatalf("write3: %v", err)
 	}
 	writes = engine.snapshotWrites()
-	if len(writes) != 29 {
-		t.Fatalf("writes after activation = %d, want 29 (priming + 25-frame pad + 3 chunks)", len(writes))
+	if len(writes) != 4 {
+		t.Fatalf("writes after activation = %d, want 4 (priming + 3 chunks)", len(writes))
 	}
-	// 1 priming silence, then the 500ms post-active pad (all silence), then
-	// the real chunks in order.
+	// One priming silence frame is followed by the real chunks in order. The
+	// old guessed 500ms pad is no longer needed once the browser ACKs readiness.
 	if len(writes[0]) != voicePrimingSilenceBytes {
 		t.Fatalf("first write must be the priming silence frame")
 	}
-	for _, pad := range writes[1:26] {
-		if !allZero(pad) {
-			t.Fatal("post-active pad must be synthetic silence, never user audio")
-		}
-	}
-	if string(writes[26]) != "real-pcm-chunk-1" || string(writes[27]) != "real-pcm-chunk-2" ||
-		string(writes[28]) != "real-pcm-chunk-3" {
-		t.Fatalf("pending drain order broken: %q %q %q", writes[26], writes[27], writes[28])
+	if string(writes[1]) != "real-pcm-chunk-1" || string(writes[2]) != "real-pcm-chunk-2" ||
+		string(writes[3]) != "real-pcm-chunk-3" {
+		t.Fatalf("pending drain order broken: %q %q %q", writes[1], writes[2], writes[3])
 	}
 	// Exactly once: no duplicates anywhere.
 	seen := map[string]int{}
-	for _, chunk := range writes[26:] {
+	for _, chunk := range writes[1:] {
 		seen[string(chunk)]++
 	}
 	if seen["real-pcm-chunk-1"] != 1 || seen["real-pcm-chunk-2"] != 1 {
@@ -673,13 +672,46 @@ func TestBridgeVoicePublishFlowsAndPrimingDrainsExactlyOnce(t *testing.T) {
 	}
 }
 
-func allZero(data []byte) bool {
-	for _, b := range data {
-		if b != 0 {
-			return false
-		}
+func TestBridgeBuffersFirstUtteranceUntilDownstreamReady(t *testing.T) {
+	engine := newFakeEngine()
+	engine.mid = "9"
+	rest := newFakeRest()
+	rest.confirmActive = true
+	rest.confirmDiagnostic = PublishedAudioDiagnostic{
+		MatchingTrackStatus: "active",
+		Active:              true,
 	}
-	return true
+	rest.confirmDownstreamReady = false
+	bridge := NewBridge(testBridgeOptions(engine, rest, &PublishConfig{TrackName: "agent-voice"}))
+	if err := bridge.Start(t.Context()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer bridge.Stop()
+	if err := bridge.ActivateVoicePublish(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if err := bridge.WriteVoicePcm([]byte("first sentence"), 1); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if got := engine.snapshotWrites(); len(got) != 1 || len(got[0]) != voicePrimingSilenceBytes {
+		t.Fatalf("unready downstream must receive only priming silence, got %d writes", len(got))
+	}
+
+	// Deliberately exceed the old 500ms guessed padding window. EndTurn must
+	// keep the real prefix buffered until the explicit readiness transition.
+	done := make(chan error, 1)
+	go func() { done <- bridge.FlushVoice(1) }()
+	time.Sleep(750 * time.Millisecond)
+	rest.mu.Lock()
+	rest.confirmDownstreamReady = true
+	rest.mu.Unlock()
+	if err := <-done; err != nil {
+		t.Fatalf("flush after downstream readiness: %v", err)
+	}
+	writes := engine.snapshotWrites()
+	if len(writes) != 2 || string(writes[1]) != "first sentence" {
+		t.Fatalf("first PCM was not preserved across delayed readiness: %#v", writes)
+	}
 }
 
 func TestBridgeRevocationDropsPendingPcm(t *testing.T) {

--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -607,6 +607,8 @@ func safeDiagnosticCode(err error) string {
 		return "timeout"
 	case strings.Contains(message, "unsupported_chunk"):
 		return "unsupported_chunk"
+	case strings.Contains(message, "downstream_not_ready"):
+		return "downstream_not_ready"
 	case strings.Contains(message, "not authorized") ||
 		strings.Contains(message, "not_authorized"):
 		return "not_authorized"

--- a/agent/internal/media/rest.go
+++ b/agent/internal/media/rest.go
@@ -95,6 +95,11 @@ type PublishedAudioDiagnostic struct {
 	MatchingTrackStatus      string `json:"matching_track_status"` // active|inactive|waiting|unknown
 	MatchingTrackHasMid      bool   `json:"matching_track_has_mid"`
 	Active                   bool   `json:"active"`
+	// DownstreamReady is true only after a current Human browser completes the
+	// remote subscription negotiation. It is separate from Cloudflare's
+	// publisher-active signal: an active upstream track can have nowhere
+	// audible to go yet.
+	DownstreamReady bool `json:"downstream_ready"`
 }
 
 // RestClientLike is the REST boundary the bridge depends on (fake-able).
@@ -286,6 +291,11 @@ func (c *SfuRestClient) PublishAudioTrack(sessionID, trackName, mid string, offe
 	body["tracks"] = []any{map[string]any{
 		"location": "local", "trackName": trackName, "kind": "audio", "mid": mid,
 	}}
+	// Keep the booking private until the bridge has emitted its bounded
+	// priming silence and confirmed Cloudflare's publisher active. The follow-up
+	// agent-track-active call then broadcasts trackPublished for Human
+	// subscription prewarming.
+	body["announce"] = false
 	body["sessionDescription"] = map[string]any{"type": offer.Type, "sdp": offer.SDP}
 	data, err := c.request("tracks", http.MethodPost, body)
 	if err != nil {
@@ -319,6 +329,7 @@ func (c *SfuRestClient) ConfirmPublishedAudioTrackActive(sessionID, trackName st
 		MatchingTrackFound:       data["matchingTrackFound"] == true,
 		MatchingTrackHasMid:      data["matchingTrackHasMid"] == true,
 		Active:                   data["active"] == true,
+		DownstreamReady:          data["downstreamReady"] == true,
 	}
 	diagnostic.MatchingTrackStatus = "unknown"
 	if status, ok := data["matchingTrackStatus"].(string); ok &&

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -228,9 +228,20 @@ type ControlRequest =
       sessionId: string
       mid: string
       trackName: string
+      // Runtime may defer the public trackPublished broadcast until its
+      // bounded silent priming packet has reached Cloudflare. This prevents a
+      // Human from attempting tracks/new against a still-inactive booking.
+      announce?: boolean
     }
   | {
       action: "agent-track-active"
+      participantId: string
+      token: string
+      sessionId: string
+      trackName: string
+    }
+  | {
+      action: "agent-track-ready"
       participantId: string
       token: string
       sessionId: string
@@ -456,6 +467,16 @@ type ClientMessage =
       agentParticipantId: string
       enabled: boolean
     }
+  | {
+      // Human-side acknowledgement after the Agent Voice remote subscription
+      // has completed tracks/new + answer + renegotiate. The identifiers are
+      // checked against the current private publication before readiness is
+      // recorded; stale/duplicate acknowledgements are harmless.
+      type: "agent-voice-ready"
+      agentParticipantId: string
+      sessionId: string
+      trackName: string
+    }
 
 /** Storage hygiene for one Agent participant's published voice media. A
  * current per-participant grant is required to retain its revocation handle;
@@ -492,6 +513,7 @@ export function normalizeAgentParticipantMedia(
   const next: RoomParticipant["media"] = { ...media, tracks: [] }
   if (publishedMid !== undefined) delete next.agentPublishedMid
   if (pendingTrackName !== undefined) delete next.agentPublishedTrackName
+  delete next.agentVoiceReady
   return { media: next, changed: true }
 }
 
@@ -935,13 +957,15 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           if (
             !participant.media?.agentSubscribedMids &&
             !participant.media?.agentPublishedMid &&
-            !participant.media?.agentPublishedTrackName
+            !participant.media?.agentPublishedTrackName &&
+            !participant.media?.agentVoiceReady
           )
             return participant
           const {
             agentSubscribedMids: _mids,
             agentPublishedMid: _publishedMid,
             agentPublishedTrackName: _publishedTrackName,
+            agentVoiceReady: _voiceReady,
             ...media
           } = participant.media
           return { ...participant, media }
@@ -1011,6 +1035,17 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       room.pendingMediaCleanup,
       direction
     )
+  }
+
+  // A readiness ACK is intentionally conservative: it means at least one
+  // currently connected Human has a negotiated subscription. If any Human
+  // connection leaves or drops, clear the private bits and require the next
+  // subscriber to ACK again before the Runtime drains a future turn.
+  private clearAgentVoiceReadiness(room: RoomRecord): void {
+    for (const participant of Object.values(room.participants)) {
+      if (participant.kind !== "agent" || !participant.media) continue
+      delete participant.media.agentVoiceReady
+    }
   }
 
   // Steps 6-7 of the revocation sequence (round 4): the actual Cloudflare
@@ -2449,18 +2484,40 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
       )
         return this.json({ error: "agent_media_cleanup_backlog" }, 503)
+      // A replay for an already-visible publication must not retract its
+      // public track merely because the original caller used deferred
+      // announcement.
+      const alreadyVisible =
+        participant.media.tracks.length === 1 &&
+        participant.media.tracks[0]!.trackName === request.trackName &&
+        participant.media.tracks[0]!.kind === "audio"
+      const announce = request.announce !== false || alreadyVisible
       participant.media = {
         ...participant.media,
         agentPublishedMid: request.mid,
-        // Registration is durable revocation bookkeeping only. Do not expose
-        // the track to Humans until the Runtime has successfully written its
-        // first PCM packet; Cloudflare can report a booked track as inactive
-        // before that happens.
+        // Runtime-owned publications may defer the public broadcast until the
+        // bounded silent priming packet makes Cloudflare report the booking
+        // active. The Runtime still holds real speech until the browser sends
+        // the explicit agent-voice-ready acknowledgement.
         agentPublishedTrackName: request.trackName,
-        tracks: [],
+        agentVoiceReady: false,
+        tracks: announce
+          ? [{ trackName: request.trackName, kind: "audio" }]
+          : [],
       }
       participant.lastSeenAt = Date.now()
       await this.saveRoom(room)
+      if (announce)
+        await this.broadcast({
+          type: "trackPublished",
+          participant: {
+            id: participant.id,
+            name: participant.name,
+            kind: participant.kind,
+            sessionId: participant.media.sessionId,
+            track: { trackName: request.trackName, kind: "audio" },
+          },
+        })
       return this.json({ ok: true })
     }
 
@@ -2484,8 +2541,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         participant.media.tracks.length === 1 &&
         participant.media.tracks[0]!.trackName === request.trackName &&
         participant.media.tracks[0]!.kind === "audio"
-      )
+      ) {
+        if (participant.media.agentPublishedTrackName === request.trackName) {
+          delete participant.media.agentPublishedTrackName
+          await this.saveRoom(room)
+        }
         return this.json({ ok: true })
+      }
       if (
         !participant.media.agentPublishedMid ||
         participant.media.agentPublishedTrackName !== request.trackName
@@ -2509,6 +2571,31 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         },
       })
       return this.json({ ok: true })
+    }
+
+    if (request.action === "agent-track-ready") {
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token,
+        request.sessionId
+      )
+      if (!participant || participant.kind !== "agent")
+        return this.json({ error: "unauthorized" }, 401)
+      if (!isAgentAuthorizedForVoice(room.agentVoice, participant.id))
+        return this.json({ error: "voice_reply_not_authorized" }, 403)
+      if (!participant.media)
+        return this.json({ error: "media_unavailable" }, 400)
+      const currentTrackName =
+        participant.media.agentPublishedTrackName ??
+        (participant.media.tracks.length === 1 &&
+        participant.media.tracks[0]!.kind === "audio"
+          ? participant.media.tracks[0]!.trackName
+          : undefined)
+      const ready =
+        participant.media.agentVoiceReady === true &&
+        currentTrackName === request.trackName
+      return this.json({ ready })
     }
 
     if (request.action === "unpublish") {
@@ -2779,6 +2866,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return
     }
     if (message.type === "leave") {
+      this.clearAgentVoiceReadiness(room)
       delete room.participants[participant.id]
       room.runtimeHosts = garbageCollectRuntimeHosts(
         room.runtimeHosts,
@@ -2889,6 +2977,54 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.scheduleNextAlarm(room)
       await this.broadcastState(room)
       await this.attemptCleanupNow(room.pendingMediaCleanup)
+      return
+    }
+    if (message.type === "agent-voice-ready") {
+      if (participant.kind !== "human") {
+        socket.send(JSON.stringify({ type: "error", error: "human_only" }))
+        return
+      }
+      const agent = room.participants[message.agentParticipantId]
+      if (!agent || agent.kind !== "agent" || !agent.connected) {
+        socket.send(
+          JSON.stringify({ type: "error", error: "agent_not_in_room" })
+        )
+        return
+      }
+      if (!isAgentAuthorizedForVoice(room.agentVoice, agent.id)) {
+        socket.send(
+          JSON.stringify({ type: "error", error: "voice_reply_not_authorized" })
+        )
+        return
+      }
+      const media = agent.media
+      const currentTrackName =
+        media?.agentPublishedTrackName ??
+        (media?.tracks.length === 1 && media.tracks[0]!.kind === "audio"
+          ? media.tracks[0]!.trackName
+          : undefined)
+      if (
+        !media ||
+        media.sessionId !== message.sessionId ||
+        !media.agentPublishedMid ||
+        currentTrackName !== message.trackName
+      ) {
+        socket.send(
+          JSON.stringify({
+            type: "error",
+            error: "agent_publication_not_ready",
+          })
+        )
+        return
+      }
+      // Idempotent duplicate acknowledgements are harmless. The private
+      // readiness bit is tied to the exact current media session/publication
+      // above, so an old browser subscription cannot arm a new one.
+      if (media.agentVoiceReady !== true) {
+        media.agentVoiceReady = true
+        agent.lastSeenAt = Date.now()
+        await this.saveRoom(room)
+      }
       return
     }
     if (message.type === "agent-voice-set") {
@@ -3382,6 +3518,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participant.connected = false
     participant.lastSeenAt = Date.now()
     participant.connectionNonce = undefined
+    this.clearAgentVoiceReadiness(room)
     await this.saveRoom(room)
     await this.scheduleNextAlarm(room)
     await this.broadcastState(room)

--- a/app/src/do/realtimeMedia.ts
+++ b/app/src/do/realtimeMedia.ts
@@ -241,6 +241,7 @@ export function stageAgentMediaRevocation(
   if (direction !== "subscribed") {
     nextMedia.agentPublishedMid = undefined
     nextMedia.agentPublishedTrackName = undefined
+    nextMedia.agentVoiceReady = undefined
     nextMedia.tracks = nextMedia.tracks.filter(
       (track) => track.kind !== "audio"
     )

--- a/app/src/do/roomSessionAgentVoice.test.ts
+++ b/app/src/do/roomSessionAgentVoice.test.ts
@@ -277,4 +277,86 @@ describe("RoomSession Agent Voice", () => {
     ).toBeUndefined()
     expect(normalized.room.participants.pi.media.tracks).toEqual([])
   })
+
+  it("prewarms the Agent publication and accepts only current Human readiness ACKs", async () => {
+    const { action, session, socket, store } = harness()
+    const room = store.get("room") as any
+    room.agentVoice.pi = { enabled: true, enabledAt: 1 }
+    room.participants.pi.media = {
+      sessionId: "pi-session",
+      muted: false,
+      fileChannelReady: false,
+      tracks: [],
+    }
+    const broadcast = vi
+      .spyOn(session as any, "broadcast")
+      .mockResolvedValue(undefined)
+    const published = await action({
+      action: "agent-track-published",
+      participantId: "pi",
+      token: "pi-token",
+      sessionId: "pi-session",
+      mid: "pub-mid",
+      trackName: "agent-voice",
+      announce: false,
+    })
+    expect(published.status).toBe(200)
+    const savedRoom = store.get("room") as any
+    expect(savedRoom.participants.pi.media.tracks).toEqual([])
+    expect(savedRoom.participants.pi.media.agentVoiceReady).toBe(false)
+
+    const active = await action({
+      action: "agent-track-active",
+      participantId: "pi",
+      token: "pi-token",
+      sessionId: "pi-session",
+      trackName: "agent-voice",
+    })
+    expect(active.status).toBe(200)
+    expect((store.get("room") as any).participants.pi.media.tracks).toEqual([
+      { trackName: "agent-voice", kind: "audio" },
+    ])
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "trackPublished" })
+    )
+
+    await (session as any).handleClientMessage(
+      socket,
+      { participantId: "human", token: "human-token", connectionNonce: "n" },
+      {
+        type: "agent-voice-ready",
+        agentParticipantId: "pi",
+        sessionId: "pi-session",
+        trackName: "agent-voice",
+      }
+    )
+    expect(
+      (store.get("room") as any).participants.pi.media.agentVoiceReady
+    ).toBe(true)
+
+    const ready = await action({
+      action: "agent-track-ready",
+      participantId: "pi",
+      token: "pi-token",
+      sessionId: "pi-session",
+      trackName: "agent-voice",
+    })
+    expect(await ready.json()).toEqual({ ready: true })
+
+    // A duplicate ACK is idempotent; a stale session is rejected and cannot
+    // arm a fresh publication.
+    await (session as any).handleClientMessage(
+      socket,
+      { participantId: "human", token: "human-token", connectionNonce: "n" },
+      {
+        type: "agent-voice-ready",
+        agentParticipantId: "pi",
+        sessionId: "old-session",
+        trackName: "agent-voice",
+      }
+    )
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "error", error: "agent_publication_not_ready" })
+    )
+  })
 })

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -501,6 +501,19 @@ describe("useSfuChatRoom room attachments (#123)", () => {
         )
       ).toBe(true)
     )
+    await waitFor(() =>
+      expect(
+        ws.sent
+          .map((raw) => JSON.parse(raw))
+          .some(
+            (m) =>
+              m.type === "agent-voice-ready" &&
+              m.agentParticipantId === "agent-b" &&
+              m.sessionId === "agent-session" &&
+              m.trackName === "agent-voice"
+          )
+      ).toBe(true)
+    )
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -517,6 +517,229 @@ describe("useSfuChatRoom room attachments (#123)", () => {
     unmount()
   })
 
+  it("re-asserts Agent readiness on resync without repeating a completed subscription", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return jsonResponse({
+          requiresImmediateRenegotiation: true,
+          sessionDescription: { type: "offer", sdp: "fake-sfu-offer" },
+          tracks: [{ mid: "7", trackName: "agent-voice" }],
+        })
+      return jsonResponse({})
+    })
+
+    const { unmount } = await connect("room-readiness-resync")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+    const trackPublished = {
+      type: "trackPublished",
+      participant: {
+        id: "agent-b",
+        name: "Agent B",
+        kind: "agent",
+        sessionId: "agent-session",
+        track: { trackName: "agent-voice", kind: "audio" },
+      },
+    }
+    act(() => ws.onmessage?.({ data: JSON.stringify(trackPublished) }))
+    await waitFor(() =>
+      expect(
+        ws.sent
+          .map((raw) => JSON.parse(raw))
+          .some((message) => message.type === "agent-voice-ready")
+      ).toBe(true)
+    )
+    const remoteTrackCalls = () =>
+      fetchMock.mock.calls.filter(([input, init]) => {
+        if (!String(input).endsWith("/api/sfu/tracks")) return false
+        const body = JSON.parse(init?.body as string) as {
+          tracks?: Array<{ location?: string }>
+        }
+        return body.tracks?.[0]?.location === "remote"
+      }).length
+    const initialRemoteTrackCalls = remoteTrackCalls()
+    const initialRenegotiateCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/api/sfu/renegotiate")
+    ).length
+    ws.sent = []
+
+    // Simulate Room resync after its fail-closed readiness reset. The media
+    // subscription remains valid, so the hook must ACK again without a new
+    // tracks/new or renegotiation request.
+    act(() =>
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 0,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: [
+              {
+                id: "agent-b",
+                name: "Agent B",
+                kind: "agent",
+                connected: true,
+                joinedAt: 0,
+                lastSeenAt: 0,
+                media: {
+                  sessionId: "agent-session",
+                  muted: false,
+                  fileChannelReady: false,
+                  tracks: [{ trackName: "agent-voice", kind: "audio" }],
+                },
+              },
+            ],
+            messages: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: true,
+            agentVoice: { "agent-b": { enabled: true, enabledAt: 1 } },
+            agentVoiceMediaAvailable: true,
+          },
+        }),
+      })
+    )
+    await waitFor(() =>
+      expect(
+        ws.sent
+          .map((raw) => JSON.parse(raw))
+          .some(
+            (message) =>
+              message.type === "agent-voice-ready" &&
+              message.agentParticipantId === "agent-b"
+          )
+      ).toBe(true)
+    )
+    expect(remoteTrackCalls()).toBe(initialRemoteTrackCalls)
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/api/sfu/renegotiate")
+      ).length
+    ).toBe(initialRenegotiateCalls)
+    unmount()
+  })
+
+  it("does not ACK a deduplicated Agent subscription while negotiation is in flight", async () => {
+    let resolveRemoteTracks!: (response: Response) => void
+    const pendingRemoteTracks = new Promise<Response>((resolve) => {
+      resolveRemoteTracks = resolve
+    })
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          })
+        if (url.endsWith("/api/sfu/datachannels/new"))
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        if (url.endsWith("/api/sfu/tracks")) {
+          const body = JSON.parse((init?.body as string | undefined) ?? "{}")
+          if (body.tracks?.[0]?.location === "remote")
+            return pendingRemoteTracks
+        }
+        return jsonResponse({})
+      }
+    )
+
+    const { unmount } = await connect("room-readiness-in-flight")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+    const participant = {
+      id: "agent-b",
+      name: "Agent B",
+      kind: "agent",
+      sessionId: "agent-session",
+      track: { trackName: "agent-voice", kind: "audio" },
+    }
+    act(() =>
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "trackPublished", participant }),
+      })
+    )
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input, init]) => {
+          if (!String(input).endsWith("/api/sfu/tracks")) return false
+          const body = JSON.parse((init?.body as string | undefined) ?? "{}")
+          return body.tracks?.[0]?.location === "remote"
+        })
+      ).toBe(true)
+    )
+
+    // A resync while the first negotiation is pending is still a dedup, but
+    // it is not ACK-safe yet.
+    act(() =>
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 0,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: [
+              {
+                id: "agent-b",
+                name: "Agent B",
+                kind: "agent",
+                connected: true,
+                joinedAt: 0,
+                lastSeenAt: 0,
+                media: {
+                  sessionId: "agent-session",
+                  muted: false,
+                  fileChannelReady: false,
+                  tracks: [{ trackName: "agent-voice", kind: "audio" }],
+                },
+              },
+            ],
+            messages: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: true,
+            agentVoice: { "agent-b": { enabled: true, enabledAt: 1 } },
+            agentVoiceMediaAvailable: true,
+          },
+        }),
+      })
+    )
+    expect(
+      ws.sent
+        .map((raw) => JSON.parse(raw))
+        .some((message) => message.type === "agent-voice-ready")
+    ).toBe(false)
+
+    resolveRemoteTracks(
+      await jsonResponse({
+        requiresImmediateRenegotiation: true,
+        sessionDescription: { type: "offer", sdp: "fake-sfu-offer" },
+        tracks: [{ mid: "7", trackName: "agent-voice" }],
+      })
+    )
+    await waitFor(() =>
+      expect(
+        ws.sent
+          .map((raw) => JSON.parse(raw))
+          .some((message) => message.type === "agent-voice-ready")
+      ).toBe(true)
+    )
+    unmount()
+  })
+
   it("fails closed and leaves an errored remote subscription retryable", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const info = vi.spyOn(console, "info").mockImplementation(() => undefined)

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -301,6 +301,12 @@ export function useSfuChatRoom(
   const remoteScreenStreamsRef = useRef(new Map<string, MediaStream>())
   const participantMapRef = useRef(new Map<string, SfuParticipant>())
   const subscribedTracksRef = useRef(new Set<string>())
+  // `subscribedTracksRef` is admission/in-flight state. Keep a separate set
+  // for subscriptions whose full negotiation completed, so a Room readiness
+  // reset (for example a control WebSocket reconnect) can re-assert the ACK
+  // without issuing a second tracks/new request. In-flight or failed keys
+  // never enter this set and therefore can never ACK early.
+  const readySubscribedTracksRef = useRef(new Set<string>())
   const pendingRemoteTrackRef = useRef<{
     peerId: string
     kind: "audio" | "video"
@@ -389,10 +395,13 @@ export function useSfuChatRoom(
     setParticipants(list)
   }, [nickName, roomName])
 
-  const sendSocketMessage = useCallback((message: object) => {
+  const sendSocketMessage = useCallback((message: object): boolean => {
     const socket = websocketRef.current
-    if (socket?.readyState === WebSocket.OPEN)
+    if (socket?.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify(message))
+      return true
+    }
+    return false
   }, [])
 
   const enqueueNegotiation = useCallback(
@@ -586,6 +595,10 @@ export function useSfuChatRoom(
     for (const key of subscribedTracksRef.current) {
       if (key.startsWith(`${participantId}:`))
         subscribedTracksRef.current.delete(key)
+    }
+    for (const key of readySubscribedTracksRef.current) {
+      if (key.startsWith(`${participantId}:`))
+        readySubscribedTracksRef.current.delete(key)
     }
 
     const channel = remoteFileChannelsRef.current.get(participantId)
@@ -889,6 +902,26 @@ export function useSfuChatRoom(
       if (!session || !pc || !media) return
       const key = `${participant.id}:${media.sessionId}:${track.trackName}`
       if (subscribedTracksRef.current.has(key)) {
+        const current = participantMapRef.current.get(participant.id)
+        if (
+          current?.media?.sessionId === media.sessionId &&
+          readySubscribedTracksRef.current.has(key) &&
+          participant.kind === "agent" &&
+          track.kind === "audio"
+        ) {
+          // The media subscription is still alive, but Room readiness may
+          // have been fail-closed by a control WebSocket close. Re-assert the
+          // ACK on resync without repeating tracks/new or renegotiation.
+          const sent = sendSocketMessage({
+            type: "agent-voice-ready",
+            agentParticipantId: participant.id,
+            sessionId: media.sessionId,
+            trackName: track.trackName,
+          })
+          voiceDownstreamDiagnostic("agent_voice_ready_reasserted", {
+            agent_voice_ready_reasserted: sent ? 1 : 0,
+          })
+        }
         voiceDownstreamDiagnostic("subscribe_dedup_skipped", {})
         return
       }
@@ -902,8 +935,11 @@ export function useSfuChatRoom(
         if (
           participantMapRef.current.get(participant.id)?.media?.sessionId !==
           media.sessionId
-        )
+        ) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
           return
+        }
         pendingRemoteTrackRef.current = {
           peerId: participant.id,
           kind: track.kind,
@@ -956,6 +992,7 @@ export function useSfuChatRoom(
         })
         if (!response.sessionDescription) {
           subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
           console.warn(
             "sfu_remote_subscribe_missing_description",
             summarizeRemoteTrackResponse(response)
@@ -1007,20 +1044,24 @@ export function useSfuChatRoom(
           })
           voiceDownstreamDiagnostic("renegotiate_ok", { renegotiate_ok: 1 })
           if (participant.kind === "agent" && track.kind === "audio") {
+            // Negotiation completion is the ACK-safe boundary. Record it
+            // even if the control WebSocket is briefly unavailable; a later
+            // resync on the new socket will re-assert the same ACK.
+            readySubscribedTracksRef.current.add(key)
             // The Runtime must not drain a first utterance merely because
             // Cloudflare booked its upstream publication. This ACK is sent
             // only after the Human browser has completed the full remote
             // tracks/new + answer + renegotiate path for that exact session
             // and track; the Room validates it against the private current
             // publication before making it visible to the Runtime.
-            sendSocketMessage({
+            const sent = sendSocketMessage({
               type: "agent-voice-ready",
               agentParticipantId: participant.id,
               sessionId: media.sessionId,
               trackName: track.trackName,
             })
             voiceDownstreamDiagnostic("agent_voice_ready_ack_sent", {
-              agent_voice_ready_ack_sent: 1,
+              agent_voice_ready_ack_sent: sent ? 1 : 0,
             })
           }
         } catch (error) {
@@ -1032,6 +1073,7 @@ export function useSfuChatRoom(
         }
       }).catch((error) => {
         subscribedTracksRef.current.delete(key)
+        readySubscribedTracksRef.current.delete(key)
         console.warn("sfu_remote_subscribe_failed", {
           errorType: error instanceof Error ? error.name : typeof error,
         })
@@ -1063,12 +1105,23 @@ export function useSfuChatRoom(
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
       for (const participant of state.participants) {
         const previous = participantMapRef.current.get(participant.id)
+        const previousTracks = previous?.media?.tracks ?? []
+        const currentTracks = participant.media?.tracks ?? []
+        const trackRemoved = previousTracks.some(
+          (previousTrack) =>
+            !currentTracks.some(
+              (currentTrack) =>
+                currentTrack.trackName === previousTrack.trackName &&
+                currentTrack.kind === previousTrack.kind
+            )
+        )
         if (
           previous?.media &&
           participant.media &&
           previous.media.sessionId !== participant.media.sessionId
         )
           resetRemoteParticipant(participant.id)
+        else if (trackRemoved) resetRemoteParticipant(participant.id)
       }
       participantMapRef.current = new Map(
         state.participants.map((participant) => [
@@ -1351,6 +1404,7 @@ export function useSfuChatRoom(
         dataChannelReadyRef.current = false
         localTrackMidsRef.current.clear()
         subscribedTracksRef.current.clear()
+        readySubscribedTracksRef.current.clear()
         remoteAudioStreamsRef.current.clear()
         remoteScreenStreamsRef.current.clear()
         pendingRemoteTrackRef.current = null

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1107,21 +1107,24 @@ export function useSfuChatRoom(
         const previous = participantMapRef.current.get(participant.id)
         const previousTracks = previous?.media?.tracks ?? []
         const currentTracks = participant.media?.tracks ?? []
-        const trackRemoved = previousTracks.some(
-          (previousTrack) =>
-            !currentTracks.some(
-              (currentTrack) =>
-                currentTrack.trackName === previousTrack.trackName &&
-                currentTrack.kind === previousTrack.kind
-            )
-        )
+        const agentAudioTrackRemoved =
+          participant.kind === "agent" &&
+          previousTracks.some(
+            (previousTrack) =>
+              previousTrack.kind === "audio" &&
+              !currentTracks.some(
+                (currentTrack) =>
+                  currentTrack.trackName === previousTrack.trackName &&
+                  currentTrack.kind === previousTrack.kind
+              )
+          )
         if (
           previous?.media &&
           participant.media &&
           previous.media.sessionId !== participant.media.sessionId
         )
           resetRemoteParticipant(participant.id)
-        else if (trackRemoved) resetRemoteParticipant(participant.id)
+        else if (agentAudioTrackRemoved) resetRemoteParticipant(participant.id)
       }
       participantMapRef.current = new Map(
         state.participants.map((participant) => [

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1006,6 +1006,23 @@ export function useSfuChatRoom(
             sessionDescription: { type: answer.type, sdp: answer.sdp },
           })
           voiceDownstreamDiagnostic("renegotiate_ok", { renegotiate_ok: 1 })
+          if (participant.kind === "agent" && track.kind === "audio") {
+            // The Runtime must not drain a first utterance merely because
+            // Cloudflare booked its upstream publication. This ACK is sent
+            // only after the Human browser has completed the full remote
+            // tracks/new + answer + renegotiate path for that exact session
+            // and track; the Room validates it against the private current
+            // publication before making it visible to the Runtime.
+            sendSocketMessage({
+              type: "agent-voice-ready",
+              agentParticipantId: participant.id,
+              sessionId: media.sessionId,
+              trackName: track.trackName,
+            })
+            voiceDownstreamDiagnostic("agent_voice_ready_ack_sent", {
+              agent_voice_ready_ack_sent: 1,
+            })
+          }
         } catch (error) {
           voiceDownstreamDiagnostic("negotiation_failed", {
             stage: "renegotiate",
@@ -1020,7 +1037,7 @@ export function useSfuChatRoom(
         })
       })
     },
-    [apiRequest, enqueueNegotiation, roomName]
+    [apiRequest, enqueueNegotiation, roomName, sendSocketMessage]
   )
 
   const applyRoomState = useCallback(

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -26,9 +26,14 @@ export interface RoomMediaState {
   // track (#83) — the revocation handle for server-side close; never
   // broadcast to clients.
   agentPublishedMid?: string
-  // Kept private until the Runtime confirms that the publication has
-  // accepted its first PCM packet. At that point it is moved into `tracks`.
+  // Private revocation metadata retained while the public `tracks` entry is
+  // announced after the Runtime's bounded silent publisher priming. The
+  // Runtime does not drain user PCM until a Human subscription ACKs readiness.
   agentPublishedTrackName?: string
+  // Set only after a Human has completed the remote-track negotiation for the
+  // current Agent Voice publication. Private readiness bookkeeping; never
+  // broadcast or returned from room_info.
+  agentVoiceReady?: boolean
 }
 
 // #176 Phase A (canonical Room model, #178 review): one coarse, secret-free

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -877,6 +877,7 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
       sessionId: "sess-1",
       mid: "0",
       trackName: "agent-voice",
+      announce: false,
     })
   })
 
@@ -889,6 +890,8 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     )
     const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
       roomActions.push(body)
+      if (body.action === "agent-track-ready")
+        return { status: 200, body: { ready: true } }
       return { status: 200, body: { ok: true } }
     })
     const res = await handleSfuRequest(
@@ -903,6 +906,7 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     )
     expect(res.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect((await json(res)).downstreamReady).toBe(true)
     expect(roomActions).toEqual([
       {
         action: "authorize",
@@ -914,6 +918,13 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
       },
       {
         action: "agent-track-active",
+        participantId: "agent-1",
+        token: "tok-1",
+        sessionId: "sess-1",
+        trackName: "agent-voice",
+      },
+      {
+        action: "agent-track-ready",
         participantId: "agent-1",
         token: "tok-1",
         sessionId: "sess-1",

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -599,6 +599,7 @@ export async function handleSfuRequest(
       matchingTrackStatus: publisher.matchingTrackStatus,
       matchingTrackHasMid: publisher.matchingTrackHasMid,
       active,
+      downstreamReady: false,
     }
     if (!active) return json(diagnostic)
     const activation = await roomControl(env, room, {
@@ -609,6 +610,18 @@ export async function handleSfuRequest(
       trackName,
     })
     if (!activation.ok) return activation
+    const readiness = await roomControl(env, room, {
+      action: "agent-track-ready",
+      participantId,
+      token,
+      sessionId,
+      trackName,
+    })
+    if (!readiness.ok) return readiness
+    const readinessBody = (await readiness.json().catch(() => ({}))) as {
+      ready?: unknown
+    }
+    diagnostic.downstreamReady = readinessBody.ready === true
     return json(diagnostic)
   }
 
@@ -823,6 +836,7 @@ export async function handleSfuRequest(
           sessionId,
           mid: publishedMid,
           trackName: publishTrackName,
+          announce: false,
         })
         if (!registered.ok) {
           const closed = await closeRealtimeTracks(env, sessionId, [


### PR DESCRIPTION
## Summary

Fixes #191. Preserve the beginning of the first Agent Voice utterance when a Human browser is still negotiating its remote subscription.

The production dogfood sequence is Voice OFF, Human enables Voice, the Human waits several seconds, then targets one Agent. The text reply is complete, but the audible reply starts in the middle. This is not a latest-wins or cancellation case.

## Root cause

The previous lifecycle announced the Agent publication only after the first real PCM arrived. The browser then had to receive `trackPublished`, call `tracks/new`, create an answer, and renegotiate while the Runtime was already draining the first speech frames. The existing 500 ms silence pad was only a timing guess and could finish before the browser was downstream-ready.

## Fix

- Keep the Agent publication private during registration and emit one bounded silent priming frame.
- Confirm Cloudflare publisher activation before broadcasting the public Agent audio track.
- Have the Human browser send a private, exact-session readiness acknowledgement after remote subscription negotiation succeeds.
- Buffer real first-utterance PCM (bounded to 8 MiB) until both Cloudflare activation and the current Human readiness acknowledgement are confirmed; drain it FIFO once ready.
- Bound the readiness wait at 10 seconds and fail closed with a diagnostic if no listener becomes ready. Turn cancellation, revocation, and close still invalidate the pending turn and release the host gate.
- Keep the existing per-Agent authorization, host serialization, latest-wins cancellation, and server-side publication cleanup semantics. Private readiness state is never broadcast or returned by `room_info`.

The explicit readiness boundary removes the guessed 500 ms correctness assumption while preserving the existing one-time priming silence and text-only fallback behavior.

## Diagnostics

Runtime logs now identify publisher activation/readiness checks, readiness wait duration, buffered bytes, and bounded timeout/failure (`downstream_not_ready`). Browser diagnostics record the full remote subscription/renegotiation sequence and readiness ACK emission without logging credentials, SDP, track payloads, or room content.

## Runtime release

This changes canonical Go Runtime behavior, so the source version is advanced to `0.5.8`. The public `app/public/agent.md` bootstrap remains pinned to `0.5.7` in this PR; the immutable `agent-v0.5.8` release and bootstrap activation will follow after merge.

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/media -count=1`
- `go vet ./...`
- `go build ./cmd/free4chat-agent`
- `bash agent/scripts/check-cleanup.sh`
- `bash agent/scripts/test-bootstrap-contract.sh`
- `bash agent/scripts/test-install-agent.sh`
- `cd app && yarn test` (41 files, 423 tests)
- `cd app && yarn type-check`
- `cd app && yarn eslint src`
- `cd app && yarn prettier --check ...`
- `cd app && yarn cf-build`

Production Cloudflare/Turnstile dogfood remains the final verification step after merge.
