### PR TITLE
refactor: make media effect reconciliation explicit

### DIFF
--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -13,6 +13,11 @@ import {
   type CollabEventInput,
 } from "./collab"
 import {
+  executeMediaCloseEffects,
+  reconcileMediaCloseResults,
+  snapshotMediaCloseEffects,
+} from "./mediaEffects"
+import {
   normalizeAgentVoiceParticipantMedia,
   normalizeMediaGrants,
   transitionAgentVoiceForRuntimeHostUpdate,
@@ -32,11 +37,9 @@ import {
   resolveAgentPurposePermission,
 } from "./meetingNotesAuth"
 import {
-  closeRealtimeTracks,
   isHumanAudioTrackTarget,
   pendingCleanupHasCapacity,
   queuePendingCleanup,
-  removeConfirmedMids,
   stageAgentMediaRevocation,
   type AgentMediaRevocationDirection,
 } from "./realtimeMedia"
@@ -957,37 +960,29 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
   }
 
-  // Steps 6-7 of the revocation sequence (round 4): the actual Cloudflare
-  // tracks/close attempt(s), performed strictly *after* the caller has
-  // already persisted the revocation (stageAgentMediaRevocation + saveRoom
-  // + scheduleNextAlarm + broadcastState). Takes a read-only snapshot of
-  // the entries to attempt — it never touches the RoomRecord that snapshot
-  // came from. Once every fetch settles, it re-reads the *current*
-  // persisted room fresh and merges in only the specific mids that were
-  // just confirmed closed (removeConfirmedMids), so a concurrent request
-  // that wrote newer state during these fetches is never overwritten with
-  // stale data. Shared by every revocation trigger (Stop, reassignment,
-  // Agent leave, lease expiry) and by alarm()'s periodic retry of whatever
-  // is still outstanding.
+  // The sole Room-side media-effect lifecycle. Every caller has already
+  // staged the revocation and persisted that authoritative state before it
+  // reaches here. This method then has exactly one temporal shape:
+  //
+  // persisted Room decision -> read-only exact effect snapshot -> Cloudflare
+  // close -> fresh Room reload -> narrow confirmed-mid reconciliation.
+  //
+  // It never saves the pre-effect RoomRecord. That is what preserves any
+  // participant, grant, session, or cleanup mutation interleaved while the
+  // external request was in flight. Shared by every Agent revocation path
+  // and by alarm() retries.
   private async attemptCleanupNow(
     entries: PendingMediaCleanup[]
   ): Promise<void> {
-    if (entries.length === 0) return
-    const confirmed: PendingMediaCleanup[] = []
-    for (const entry of entries) {
-      const closed = await closeRealtimeTracks(
-        this.env,
-        entry.sessionId,
-        entry.mids
-      )
-      if (closed) confirmed.push(entry)
-    }
-    if (confirmed.length === 0) return
+    const effects = snapshotMediaCloseEffects(entries)
+    if (effects.length === 0) return
+    const results = await executeMediaCloseEffects(this.env, effects)
+    if (!results.some((result) => result.confirmedMids.length > 0)) return
     const fresh = await this.loadRoom()
     if (!fresh) return // room expired/deleted while these fetches were in flight
-    fresh.pendingMediaCleanup = removeConfirmedMids(
+    fresh.pendingMediaCleanup = reconcileMediaCloseResults(
       fresh.pendingMediaCleanup,
-      confirmed
+      results
     )
     await this.saveRoom(fresh)
     await this.scheduleNextAlarm(fresh)
@@ -1020,9 +1015,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     for (const attachment of room.attachments)
       await this.deleteAttachmentChunks(attachment)
     await this.ctx.storage.delete("room")
-    for (const entry of pendingClose) {
-      await closeRealtimeTracks(this.env, entry.sessionId, entry.mids)
-    }
+    await executeMediaCloseEffects(
+      this.env,
+      snapshotMediaCloseEffects(pendingClose)
+    )
     for (const waiter of this.agentWaiters.values()) {
       if (!waiter) continue
       clearTimeout(waiter.timer)

--- a/app/src/do/mediaEffects.ts
+++ b/app/src/do/mediaEffects.ts
@@ -1,0 +1,160 @@
+import type { PendingMediaCleanup } from "../room/types"
+
+// The external Cloudflare Realtime effect boundary. This module intentionally
+// knows only exact session/mid resources — never Room grants, participants,
+// or other authoritative Room state. RoomSession decides and persists those
+// first, then snapshots effects here, performs I/O, reloads fresh state, and
+// passes only the current pending-cleanup queue back for narrow reconciliation.
+
+export interface RealtimeEnv {
+  SFU_APP_ID?: string
+  SFU_APP_SECRET?: string
+}
+
+export interface MediaCloseEffect {
+  sessionId: string
+  mids: string[]
+}
+
+export interface MediaCloseResult {
+  effect: MediaCloseEffect
+  confirmedMids: string[]
+}
+
+function getRealtimeCredentials(
+  env: RealtimeEnv
+): { appId: string; appSecret: string } | null {
+  const appId = env.SFU_APP_ID
+  const appSecret = env.SFU_APP_SECRET
+  return appId && appSecret ? { appId, appSecret } : null
+}
+
+function exactEffect(effect: MediaCloseEffect): MediaCloseEffect {
+  return {
+    sessionId: effect.sessionId,
+    mids: [...effect.mids],
+  }
+}
+
+/**
+ * Captures the exact resources that are eligible for this close attempt.
+ * Later Room mutations must not change this snapshot, and reconciliation can
+ * therefore only remove mids that this particular effect confirmed.
+ */
+export function snapshotMediaCloseEffects(
+  entries: PendingMediaCleanup[]
+): MediaCloseEffect[] {
+  return entries
+    .map((entry) => exactEffect(entry))
+    .filter((effect) => effect.mids.length > 0)
+}
+
+/**
+ * Performs one server-initiated tracks/close call. Cloudflare exposes the
+ * result as a single HTTP status rather than per-track confirmations, so a
+ * 2xx confirms every requested mid and every other outcome confirms none.
+ * The result still models a subset so fresh-state reconciliation remains
+ * correct if a future effect source has partial confirmation.
+ */
+export async function executeMediaCloseEffect(
+  env: RealtimeEnv,
+  effect: MediaCloseEffect
+): Promise<MediaCloseResult> {
+  const exact = exactEffect(effect)
+  if (exact.mids.length === 0) return { effect: exact, confirmedMids: [] }
+  const credentials = getRealtimeCredentials(env)
+  if (!credentials) return { effect: exact, confirmedMids: [] }
+  try {
+    const response = await fetch(
+      `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
+        credentials.appId
+      )}/sessions/${encodeURIComponent(exact.sessionId)}/tracks/close`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${credentials.appSecret}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tracks: exact.mids.map((mid) => ({ mid })),
+          force: true,
+        }),
+      }
+    )
+    // Never read or log Cloudflare's response body. It can contain upstream
+    // details, and the only authoritative cleanup signal here is 2xx.
+    return {
+      effect: exact,
+      confirmedMids: response.ok ? exact.mids : [],
+    }
+  } catch {
+    return { effect: exact, confirmedMids: [] }
+  }
+}
+
+/** Executes a read-only effect snapshot; it never mutates Room state. */
+export async function executeMediaCloseEffects(
+  env: RealtimeEnv,
+  effects: MediaCloseEffect[]
+): Promise<MediaCloseResult[]> {
+  const results: MediaCloseResult[] = []
+  for (const effect of effects)
+    results.push(await executeMediaCloseEffect(env, effect))
+  return results
+}
+
+function confirmedMidsForEffect(result: MediaCloseResult): string[] {
+  const requested = new Set(result.effect.mids)
+  return [...new Set(result.confirmedMids.filter((mid) => requested.has(mid)))]
+}
+
+/**
+ * Pure fresh-state reconciliation. Call this only with a Room's freshly
+ * loaded pending queue after external I/O. It removes confirmed mids from the
+ * matching session only, retaining failures, partials, and cleanup that was
+ * added while the effect was in flight.
+ */
+export function reconcileMediaCloseResults(
+  entries: PendingMediaCleanup[],
+  results: MediaCloseResult[]
+): PendingMediaCleanup[] {
+  let reconciled = entries
+  for (const result of results) {
+    const confirmedMids = confirmedMidsForEffect(result)
+    if (confirmedMids.length === 0) continue
+    const confirmed = new Set(confirmedMids)
+    reconciled = reconciled
+      .map((entry) =>
+        entry.sessionId === result.effect.sessionId
+          ? {
+              sessionId: entry.sessionId,
+              mids: entry.mids.filter((mid) => !confirmed.has(mid)),
+            }
+          : entry
+      )
+      .filter((entry) => entry.mids.length > 0)
+  }
+  return reconciled
+}
+
+/**
+ * The Worker owns compensation for a just-created Agent resource that the DO
+ * subsequently rejected during post-create registration. Close the exact
+ * resource; if confirmation is absent, hand off only the unresolved mids to
+ * RoomSession, whose cleanup queue is the durable retry authority.
+ */
+export async function compensateUnacceptedAgentMedia(
+  env: RealtimeEnv,
+  effect: MediaCloseEffect,
+  handoffUnresolved: (effect: MediaCloseEffect) => Promise<void>
+): Promise<MediaCloseResult> {
+  const result = await executeMediaCloseEffect(env, effect)
+  const confirmed = new Set(confirmedMidsForEffect(result))
+  const unresolved = result.effect.mids.filter((mid) => !confirmed.has(mid))
+  if (unresolved.length > 0)
+    await handoffUnresolved({
+      sessionId: result.effect.sessionId,
+      mids: unresolved,
+    })
+  return result
+}

--- a/app/src/do/realtimeMedia.test.ts
+++ b/app/src/do/realtimeMedia.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
-  closeRealtimeTracks,
+  executeMediaCloseEffect,
+  reconcileMediaCloseResults,
+} from "./mediaEffects"
+import {
   isHumanAudioTrackTarget,
   pendingCleanupHasCapacity,
   queuePendingCleanup,
-  removeConfirmedMids,
   stageAgentMediaRevocation,
 } from "./realtimeMedia"
 import type { RoomParticipant } from "../room/types"
@@ -58,7 +60,7 @@ function human(): RoomParticipant {
   }
 }
 
-describe("closeRealtimeTracks — fail-closed contract", () => {
+describe("executeMediaCloseEffect — fail-closed external effect contract", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -70,7 +72,12 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
       return new Response("", { status: 200 })
     })
     vi.stubGlobal("fetch", fetchMock)
-    await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(true)
+    await expect(
+      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toEqual({
+      effect: { sessionId: "sess-1", mids: ["1"] },
+      confirmedMids: ["1"],
+    })
     expect(requestedUrl).toBe(
       "https://rtc.live.cloudflare.com/v1/apps/app-id/sessions/sess-1/tracks/close"
     )
@@ -81,7 +88,9 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
       "fetch",
       vi.fn(async () => new Response("", { status: 401 }))
     )
-    await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(false)
+    await expect(
+      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toMatchObject({ confirmedMids: [] })
   })
 
   it("a 429 response is not treated as success", async () => {
@@ -89,7 +98,9 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
       "fetch",
       vi.fn(async () => new Response("", { status: 429 }))
     )
-    await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(false)
+    await expect(
+      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toMatchObject({ confirmedMids: [] })
   })
 
   it("a 500 response is not treated as success", async () => {
@@ -97,7 +108,9 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
       "fetch",
       vi.fn(async () => new Response("", { status: 500 }))
     )
-    await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(false)
+    await expect(
+      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toMatchObject({ confirmedMids: [] })
   })
 
   it("a network failure (fetch throws) is not treated as success", async () => {
@@ -107,18 +120,30 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
         throw new Error("network down")
       })
     )
-    await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(false)
+    await expect(
+      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toMatchObject({ confirmedMids: [] })
   })
 
   it("missing SFU credentials with real mids to close is not treated as success", async () => {
     const fetchMock = vi.fn(async () => new Response("", { status: 200 }))
     vi.stubGlobal("fetch", fetchMock)
-    await expect(closeRealtimeTracks({}, "sess-1", ["1"])).resolves.toBe(false)
+    await expect(
+      executeMediaCloseEffect({}, { sessionId: "sess-1", mids: ["1"] })
+    ).resolves.toMatchObject({ confirmedMids: [] })
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it("an empty mids array is trivially successful (nothing to close) even without credentials", async () => {
-    await expect(closeRealtimeTracks({}, "sess-1", [])).resolves.toBe(true)
+  it("does not issue an external request for an empty effect", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(
+      executeMediaCloseEffect({}, { sessionId: "sess-1", mids: [] })
+    ).resolves.toEqual({
+      effect: { sessionId: "sess-1", mids: [] },
+      confirmedMids: [],
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })
 
@@ -208,25 +233,45 @@ describe("pendingCleanupHasCapacity — the actual bound-enforcement point", () 
   })
 })
 
-describe("removeConfirmedMids — the narrow, merge-only-the-result half of the fetch-then-reload pattern", () => {
+describe("reconcileMediaCloseResults — the narrow, merge-only-the-result half of the fetch-then-reload pattern", () => {
   it("tracks/close 2xx (success) removes exactly the confirmed mids", () => {
     const entries = [{ sessionId: "sess-1", mids: ["1"] }]
     expect(
-      removeConfirmedMids(entries, [{ sessionId: "sess-1", mids: ["1"] }])
+      reconcileMediaCloseResults(entries, [
+        {
+          effect: { sessionId: "sess-1", mids: ["1"] },
+          confirmedMids: ["1"],
+        },
+      ])
     ).toEqual([])
   })
 
   it("an entry that was never confirmed is left untouched — mids retained", () => {
     const entries = [{ sessionId: "sess-1", mids: ["1"] }]
-    expect(removeConfirmedMids(entries, [])).toEqual(entries)
+    expect(reconcileMediaCloseResults(entries, [])).toEqual(entries)
   })
 
   it("only removes the confirmed subset of an entry's mids, keeping the rest", () => {
     const entries = [{ sessionId: "sess-1", mids: ["1", "2", "3"] }]
-    const result = removeConfirmedMids(entries, [
-      { sessionId: "sess-1", mids: ["2"] },
+    const result = reconcileMediaCloseResults(entries, [
+      {
+        effect: { sessionId: "sess-1", mids: ["1", "2", "3"] },
+        confirmedMids: ["2"],
+      },
     ])
     expect(result).toEqual([{ sessionId: "sess-1", mids: ["1", "3"] }])
+  })
+
+  it("never removes a mid outside the exact effect even if a result claims it", () => {
+    const entries = [{ sessionId: "sess-1", mids: ["1", "2"] }]
+    expect(
+      reconcileMediaCloseResults(entries, [
+        {
+          effect: { sessionId: "sess-1", mids: ["1"] },
+          confirmedMids: ["1", "2", "unrelated"],
+        },
+      ])
+    ).toEqual([{ sessionId: "sess-1", mids: ["2"] }])
   })
 
   it("a mixed result only drops the entries that actually got confirmed", () => {
@@ -234,18 +279,24 @@ describe("removeConfirmedMids — the narrow, merge-only-the-result half of the 
       { sessionId: "sess-1", mids: ["1"] },
       { sessionId: "sess-2", mids: ["2"] },
     ]
-    const result = removeConfirmedMids(entries, [
-      { sessionId: "sess-1", mids: ["1"] },
+    const result = reconcileMediaCloseResults(entries, [
+      {
+        effect: { sessionId: "sess-1", mids: ["1"] },
+        confirmedMids: ["1"],
+      },
     ])
     expect(result).toEqual([{ sessionId: "sess-2", mids: ["2"] }])
   })
 
   it("retry-then-success eventually clears an entry that first failed", () => {
     let entries = [{ sessionId: "sess-1", mids: ["1"] }]
-    entries = removeConfirmedMids(entries, []) // first attempt: nothing confirmed
+    entries = reconcileMediaCloseResults(entries, []) // first attempt: nothing confirmed
     expect(entries).toHaveLength(1)
-    entries = removeConfirmedMids(entries, [
-      { sessionId: "sess-1", mids: ["1"] },
+    entries = reconcileMediaCloseResults(entries, [
+      {
+        effect: { sessionId: "sess-1", mids: ["1"] },
+        confirmedMids: ["1"],
+      },
     ]) // retry succeeds
     expect(entries).toHaveLength(0)
   })
@@ -267,7 +318,12 @@ describe("removeConfirmedMids — the narrow, merge-only-the-result half of the 
       { sessionId: "sess-1", mids: ["mid-a"] },
       { sessionId: "sess-2", mids: ["mid-b"] },
     ]
-    const merged = removeConfirmedMids(freshAfterInterleave, preFetchSnapshot)
+    const merged = reconcileMediaCloseResults(freshAfterInterleave, [
+      {
+        effect: preFetchSnapshot[0]!,
+        confirmedMids: ["mid-a"],
+      },
+    ])
     expect(merged).toEqual([{ sessionId: "sess-2", mids: ["mid-b"] }])
   })
 
@@ -278,7 +334,12 @@ describe("removeConfirmedMids — the narrow, merge-only-the-result half of the 
     const freshAfterInterleave = [
       { sessionId: "sess-1", mids: ["mid-a", "mid-b"] },
     ]
-    const merged = removeConfirmedMids(freshAfterInterleave, preFetchSnapshot)
+    const merged = reconcileMediaCloseResults(freshAfterInterleave, [
+      {
+        effect: preFetchSnapshot[0]!,
+        confirmedMids: ["mid-a"],
+      },
+    ])
     expect(merged).toEqual([{ sessionId: "sess-1", mids: ["mid-b"] }])
   })
 })

--- a/app/src/do/realtimeMedia.ts
+++ b/app/src/do/realtimeMedia.ts
@@ -4,11 +4,6 @@ import type {
   RoomParticipant,
 } from "../room/types"
 
-export interface RealtimeEnv {
-  SFU_APP_ID?: string
-  SFU_APP_SECRET?: string
-}
-
 // Enforced by refusing *new* Agent media work once at capacity (see
 // pendingCleanupHasCapacity, checked by RoomSession before admitting new
 // subscriptions/grants) — never by silently evicting an unresolved entry.
@@ -17,74 +12,6 @@ export interface RealtimeEnv {
 // unreachable for an extended period.
 export const MAX_PENDING_CLEANUP_ENTRIES = 16
 export const MAX_PENDING_CLEANUP_MIDS_PER_ENTRY = 64
-
-function getRealtimeCredentials(
-  env: RealtimeEnv
-): { appId: string; appSecret: string } | null {
-  const appId = env.SFU_APP_ID
-  const appSecret = env.SFU_APP_SECRET
-  return appId && appSecret ? { appId, appSecret } : null
-}
-
-// The real server-side revocation boundary for Meeting Notes (#82): mutating
-// room state alone does not stop RTP already flowing over an established
-// PeerConnection — only actively closing the upstream Cloudflare Realtime
-// tracks does. `force: true` because this is a server-initiated close, not
-// one coordinated with the subscribing Agent's own SDP renegotiation (the
-// Agent may be slow, unresponsive, or gone entirely — revocation must not
-// depend on its cooperation).
-//
-// Returns whether the close was *confirmed* — a non-2xx response, a missing
-// SFU credential, or a network failure are all treated as "not confirmed",
-// never as a silent success. Callers must not discard `mids` on a `false`
-// result; queue them with queuePendingCleanup() and retry instead. This is
-// fail-closed by design: the room-visible grant may still be revoked
-// immediately regardless of this result, since the actual per-request
-// security boundary is the independent grant re-check on every subsequent
-// Agent media request (RoomSession's "authorize" action) — this function is
-// only responsible for actually stopping already-flowing RTP, on a
-// best-effort/retry basis.
-//
-// IMPORTANT (Durable Object concurrency): this performs real network I/O.
-// Cloudflare Durable Objects can interleave handling of another incoming
-// request while a request is awaiting non-storage I/O like fetch() — so a
-// caller must never hold an in-memory RoomRecord mutated *before* this call
-// and save it *after* this call resolves, since a concurrent request could
-// have persisted newer state in between. Always persist any mutation before
-// calling this, and re-read fresh state afterward before merging the result
-// — see RoomSession's attemptCleanupNow/stageAgentMediaRevocation split.
-export async function closeRealtimeTracks(
-  env: RealtimeEnv,
-  sessionId: string,
-  mids: string[]
-): Promise<boolean> {
-  if (mids.length === 0) return true
-  const credentials = getRealtimeCredentials(env)
-  if (!credentials) return false
-  try {
-    const response = await fetch(
-      `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
-        credentials.appId
-      )}/sessions/${encodeURIComponent(sessionId)}/tracks/close`,
-      {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${credentials.appSecret}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          tracks: mids.map((mid) => ({ mid })),
-          force: true,
-        }),
-      }
-    )
-    // Deliberately never reads/logs the response body — it's Cloudflare's
-    // upstream API response and may carry details not meant for our logs.
-    return response.ok
-  } catch {
-    return false
-  }
-}
 
 // Pure decision logic (directly unit-testable, unlike RoomSession itself —
 // see roomExpiry.ts/meetingNotesAuth.ts for why): merges newly-failed mids
@@ -130,36 +57,6 @@ export function pendingCleanupHasCapacity(
     )
   }
   return entries.length < MAX_PENDING_CLEANUP_ENTRIES
-}
-
-// Pure decision logic: removes exactly the mids that were just *confirmed*
-// closed from the given entries — never the whole matching entry outright,
-// since a concurrent request could have queued additional mids for the same
-// sessionId while the close attempt was in flight (Durable Object
-// interleaving — see closeRealtimeTracks's own comment). An entry that
-// still has mids left over after the removal is kept; one that's now empty
-// is dropped. This is the "merge only the cleanup result" half of the
-// fetch-then-reload-then-narrow-merge pattern RoomSession uses everywhere
-// it calls closeRealtimeTracks.
-export function removeConfirmedMids(
-  entries: PendingMediaCleanup[],
-  confirmed: PendingMediaCleanup[]
-): PendingMediaCleanup[] {
-  let result = entries
-  for (const { sessionId, mids } of confirmed) {
-    const confirmedSet = new Set(mids)
-    result = result
-      .map((entry) =>
-        entry.sessionId === sessionId
-          ? {
-              sessionId,
-              mids: entry.mids.filter((mid) => !confirmedSet.has(mid)),
-            }
-          : entry
-      )
-      .filter((entry) => entry.mids.length > 0)
-  }
-  return result
 }
 
 // Pure decision logic (#83 review): whether an Agent's exact-track subscribe

--- a/app/src/do/roomSessionMediaEffects.test.ts
+++ b/app/src/do/roomSessionMediaEffects.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+import type { RoomRecord } from "../room/types"
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function roomFixture(): RoomRecord {
+  return {
+    createdAt: Date.now(),
+    expiresAt: Date.now() + 60_000,
+    participants: {
+      agent: {
+        id: "agent",
+        name: "Agent",
+        kind: "agent" as const,
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "agent-token",
+        runtimeHostId: "host-a",
+        media: {
+          sessionId: "session-old",
+          muted: true,
+          fileChannelReady: false,
+          tracks: [{ trackName: "agent-voice", kind: "audio" as const }],
+          agentPublishedMid: "mid-old",
+          agentPublishedTrackName: "agent-voice",
+        },
+      },
+    },
+    runtimeHosts: {
+      "host-a": {
+        runtimeHostId: "host-a",
+        speech: { stt: false, tts: true },
+      },
+    },
+    messages: [],
+    attachments: [],
+    nextMessageSequence: 0,
+    meetingNotes: { active: false },
+    agentVoice: { agent: { enabled: true as const, enabledAt: 1 } },
+    pendingMediaCleanup: [{ sessionId: "session-old", mids: ["mid-old"] }],
+  }
+}
+
+function harness(initial: RoomRecord = roomFixture()) {
+  let room = clone(initial)
+  const writes: RoomRecord[] = []
+  const ctx = {
+    storage: {
+      get: async () => clone(room),
+      put: async (_key: string, value: RoomRecord) => {
+        room = clone(value)
+        writes.push(clone(value))
+      },
+      delete: async () => undefined,
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+    getWebSockets: () => [],
+  }
+  const session = new RoomSession(
+    ctx as never,
+    {
+      SFU_ROOM: {},
+      SFU_APP_ID: "app-id",
+      SFU_APP_SECRET: "secret",
+      AGENT_MEDIA_ENABLED: "true",
+    } as never
+  )
+  return {
+    session,
+    writes,
+    room: () => clone(room),
+    replaceRoom: (next: RoomRecord) => {
+      room = clone(next)
+    },
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe("RoomSession media effect lifecycle", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("persists a grant revocation and its exact cleanup before tracks/close runs", async () => {
+    const { session, room } = harness()
+    const fetchMock = vi.fn(async () => {
+      const durableBeforeClose = room()
+      expect(durableBeforeClose.participants.agent).toBeUndefined()
+      expect(durableBeforeClose.agentVoice).toEqual({})
+      expect(durableBeforeClose.pendingMediaCleanup).toEqual([
+        { sessionId: "session-old", mids: ["mid-old"] },
+      ])
+      return new Response("", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "agent-leave",
+          participantId: "agent",
+          token: "agent-token",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(room().pendingMediaCleanup).toEqual([])
+  })
+
+  it("reloads fresh Room state and reconciles only the completed effect after an interleaved mutation", async () => {
+    const { session, room, replaceRoom } = harness()
+    const close = deferred<Response>()
+    const fetchMock = vi.fn(async () => close.promise)
+    vi.stubGlobal("fetch", fetchMock)
+
+    const initial = room()
+    const cleanup = (session as any).attemptCleanupNow(
+      initial.pendingMediaCleanup
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const interleaved = room()
+    replaceRoom({
+      ...interleaved,
+      participants: {
+        ...interleaved.participants,
+        agent: {
+          ...interleaved.participants.agent!,
+          media: {
+            sessionId: "session-new",
+            muted: true,
+            fileChannelReady: false,
+            tracks: [],
+          },
+        },
+        human: {
+          id: "human",
+          name: "Human",
+          kind: "human",
+          connected: true,
+          joinedAt: 2,
+          lastSeenAt: 2,
+          token: "human-token",
+          media: {
+            sessionId: "session-human",
+            muted: false,
+            fileChannelReady: false,
+            tracks: [],
+          },
+        },
+      },
+      pendingMediaCleanup: [
+        ...interleaved.pendingMediaCleanup,
+        { sessionId: "session-new", mids: ["mid-new"] },
+      ],
+    })
+    close.resolve(new Response("", { status: 200 }))
+    await cleanup
+
+    expect(room().participants.human).toMatchObject({ name: "Human" })
+    expect(room().participants.agent?.media?.sessionId).toBe("session-new")
+    expect(room().pendingMediaCleanup).toEqual([
+      { sessionId: "session-new", mids: ["mid-new"] },
+    ])
+  })
+})

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -881,6 +881,74 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     })
   })
 
+  it("compensates the exact newly-created local Agent Voice mid when post-create registration is rejected", async () => {
+    const closeBodies: Array<Record<string, unknown>> = []
+    fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      if (String(url).endsWith("/tracks/close")) {
+        closeBodies.push(JSON.parse(init?.body as string))
+        return new Response("", { status: 200 })
+      }
+      return Response.json({ tracks: [{ mid: "local-mid" }] })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const actions: Array<Record<string, unknown>> = []
+    const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
+      actions.push(body)
+      if (body.action === "authorize")
+        return { status: 200, body: { ok: true, kind: "agent" } }
+      if (body.action === "agent-track-published")
+        return { status: 403, body: { error: "voice_reply_not_authorized" } }
+      return { status: 200, body: { ok: true } }
+    })
+
+    const response = await handleSfuRequest(
+      req("tracks", {
+        body: JSON.stringify(voiceReplyTracksBody([localAudio])),
+      }),
+      env
+    )
+
+    expect(response.status).toBe(403)
+    expect(closeBodies).toEqual([
+      { tracks: [{ mid: "local-mid" }], force: true },
+    ])
+    expect(
+      actions.some((action) => action.action === "agent-media-cleanup-pending")
+    ).toBe(false)
+  })
+
+  it("hands off the exact local Agent Voice mid for durable cleanup when compensation cannot confirm", async () => {
+    fetchMock = vi.fn(async (url: unknown) => {
+      if (String(url).endsWith("/tracks/close"))
+        return new Response("", { status: 500 })
+      return Response.json({ tracks: [{ mid: "local-mid" }] })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const actions: Array<Record<string, unknown>> = []
+    const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
+      actions.push(body)
+      if (body.action === "authorize")
+        return { status: 200, body: { ok: true, kind: "agent" } }
+      if (body.action === "agent-track-published")
+        return { status: 403, body: { error: "voice_reply_not_authorized" } }
+      return { status: 200, body: { ok: true } }
+    })
+
+    const response = await handleSfuRequest(
+      req("tracks", {
+        body: JSON.stringify(voiceReplyTracksBody([localAudio])),
+      }),
+      env
+    )
+
+    expect(response.status).toBe(403)
+    expect(actions).toContainEqual({
+      action: "agent-media-cleanup-pending",
+      sessionId: "sess-1",
+      mids: ["local-mid"],
+    })
+  })
+
   it("confirms an already-booked Agent publication only after Cloudflare reports it active", async () => {
     const roomActions: Array<Record<string, unknown>> = []
     fetchMock.mockResolvedValueOnce(

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -1,7 +1,7 @@
 import type { SfuSessionResponse, SfuTrack } from "./types"
 import { isAllowedOrigin } from "../common/origin"
+import { compensateUnacceptedAgentMedia } from "../do/mediaEffects"
 import { resolveAgentPurposePermission } from "../do/meetingNotesAuth"
-import { closeRealtimeTracks } from "../do/realtimeMedia"
 import type { RoomSession } from "../do/RoomSession"
 
 const MAX_ROOM_LENGTH = 64
@@ -839,16 +839,17 @@ export async function handleSfuRequest(
           announce: false,
         })
         if (!registered.ok) {
-          const closed = await closeRealtimeTracks(env, sessionId, [
-            publishedMid,
-          ])
-          if (!closed) {
-            await roomControl(env, room, {
-              action: "agent-media-cleanup-pending",
-              sessionId,
-              mids: [publishedMid],
-            })
-          }
+          await compensateUnacceptedAgentMedia(
+            env,
+            { sessionId, mids: [publishedMid] },
+            async (effect) => {
+              await roomControl(env, room, {
+                action: "agent-media-cleanup-pending",
+                sessionId: effect.sessionId,
+                mids: effect.mids,
+              })
+            }
+          )
           return registered
         }
       }
@@ -886,28 +887,26 @@ export async function handleSfuRequest(
           // created the subscription upstream, so it must be actively
           // closed rather than left untracked and unrevocable. Never report
           // the original upstream success to the Agent in this case.
-          const closed = await closeRealtimeTracks(env, sessionId, remoteMids)
-          if (!closed) {
-            // The abort-path close itself didn't confirm — hand the mids to
-            // RoomSession's pending-cleanup/retry mechanism rather than
-            // losing track of them. Its result is not ignored: a failure
-            // here means this specific untracked subscription may never
-            // get retried, which is worth surfacing even though the Agent
-            // still correctly receives the original registration failure
-            // either way (never the stale Cloudflare success).
-            const queued = await roomControl(env, room, {
-              action: "agent-media-cleanup-pending",
-              sessionId,
-              mids: remoteMids,
-            })
-            if (!queued.ok) {
-              console.error(
-                "meeting_notes_cleanup_handoff_failed",
-                room,
-                sessionId
-              )
+          await compensateUnacceptedAgentMedia(
+            env,
+            { sessionId, mids: remoteMids },
+            async (effect) => {
+              // The abort-path close itself didn't confirm — hand only its
+              // unresolved mids to RoomSession's durable retry authority.
+              const queued = await roomControl(env, room, {
+                action: "agent-media-cleanup-pending",
+                sessionId: effect.sessionId,
+                mids: effect.mids,
+              })
+              if (!queued.ok) {
+                console.error(
+                  "meeting_notes_cleanup_handoff_failed",
+                  room,
+                  effect.sessionId
+                )
+              }
             }
-          }
+          )
           return registerResponse
         }
       }


### PR DESCRIPTION
## Summary

PR 3 of #182. This is behavior-preserving: it makes the Agent-media external-effect and fresh-state reconciliation boundary explicit without changing Room grants, runtime-host state, or Agent Voice transport behavior.

## Effect inventory

- Room-initiated grant revocation, Agent departure/expiry, pending-cleanup retries, and Agent session rotation stage exact Agent session/mid cleanup before invoking Cloudflare tracks/close.
- Agent remote subscription and Agent Voice local publication both create resources through Cloudflare tracks/new, then perform the existing mandatory post-create Room registration/recheck.
- Rejected post-create registration now uses one explicit exact-resource compensation path: close the created mid, or hand only unresolved mids to RoomSession pendingMediaCleanup.
- Human tracks/close behavior and all browser readiness behavior remain untouched.

## Ownership and temporal contract

- Runtime Host decisions remain in runtimeHost.ts (PR 1 boundary preserved).
- Agent Voice and Meeting Notes grant decisions remain in mediaGrantTransitions.ts (PR 2 boundary preserved).
- RoomSession remains authoritative: it stages and persists the Room mutation, snapshots exact close effects, executes them, reloads fresh Room state, and reconciles only confirmed mids from that effect.
- mediaEffects.ts owns exact Cloudflare tracks/close execution plus pure confirmed-mid reconciliation; it never owns Room grants or participants.
- sfu/server.ts remains an external API executor only. It does not acquire Room lifecycle authority.

## Failure and TOCTOU behavior

- A 2xx close confirms the requested effect mids; all other outcomes retain them for retry.
- Fresh reconciliation removes only confirmed mids from the matching session, preserving partial failures and cleanup added during the effect.
- Post-create Agent remote-subscribe and local-publish rejection closes the exact new mid; a failed close is durably handed to the existing Room cleanup queue.
- Existing preflight cleanup-capacity admission before tracks/new is unchanged.

## Coverage

- New RoomSession concurrency tests prove revocation is durable before tracks/close and that an interleaved participant, new Agent session, and new cleanup entry survive old-session reconciliation.
- Reconciliation tests cover partial confirmation, failure/retry, duplicate-safe cleanup, same-session interleaving, and rejection of confirmations outside the exact effect.
- Server tests cover local Agent Voice and remote subscription post-create compensation, including failed-close durable handoff.
- Agent Voice 0.5.8 readiness and browser ACK/re-ACK tests remain unchanged and green.

## Validation

- yarn prettier --check .
- yarn eslint src
- yarn type-check
- yarn test (438 passed)
- yarn cf-build
- Focused media suites repeated twice: 117 passed each run

Refs #182