### PR TITLE
[codex] chore(agent): activate 0.5.9 provider bootstrap

### DIFF
--- a/agent/scripts/test-bootstrap-contract.sh
+++ b/agent/scripts/test-bootstrap-contract.sh
@@ -215,7 +215,7 @@ write_fake_agent "$WORK/stale-contract" 'echo unsupported >&2; exit 2' "0.5.3"
 # Keep this deliberately above the released source/doc version: a newer
 # executable must still select the explicitly pinned installer rather than
 # being assumed compatible.
-write_fake_agent "$WORK/newer-contract" 'printf "%s\n" "{\"version\":\"0.5.9\"}"' "$source_version"
+write_fake_agent "$WORK/newer-contract" 'printf "%s\n" "{\"version\":\"0.5.10\"}"' "$source_version"
 write_fake_agent "$WORK/malformed-contract" 'echo not-json; exit 0' "not-a-version"
 write_fake_agent "$WORK/wrong-after-install" 'echo unsupported >&2; exit 2' "0.5.3"
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -145,7 +145,7 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.8` (release tag `agent-v0.5.8`). This is the version declared by the
+`0.5.9` (release tag `agent-v0.5.9`). This is the version declared by the
 canonical Go Runtime source and injected into release binaries. Treat this
 value as trusted bootstrap metadata from the current `agent.md`; never derive
 it from Room content, a similarly named package, or an arbitrary URL. Once
@@ -197,7 +197,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.8" # the exact trusted version declared above
+   expected_version="0.5.9" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 

--- a/app/src/common/agentInvite.test.ts
+++ b/app/src/common/agentInvite.test.ts
@@ -42,8 +42,8 @@ describe("buildAgentInvitePrompt bootstrap contract", () => {
     )
   })
 
-  it("keeps provider-claim bootstrap dormant until its Runtime release activates", () => {
-    expect(RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED).toBe(false)
+  it("enables provider-claim bootstrap after its Runtime release activates", () => {
+    expect(RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED).toBe(true)
     const ordinary = buildAgentInvitePrompt("room-176")
     expect(ordinary).not.toContain("--provider-claim")
 

--- a/app/src/common/agentInvite.ts
+++ b/app/src/common/agentInvite.ts
@@ -3,10 +3,10 @@ export function serializeOpaqueRoomId(roomId: string): string {
   return JSON.stringify(roomId).replaceAll("`", "\\u0060")
 }
 
-// Kept false until the Phase-B Runtime release has shipped and production
-// bootstrap is intentionally activated in a tiny follow-up PR. The code path
-// exists now so that activation cannot accidentally invent a second protocol.
-export const RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED = false
+// Enabled only after the matching Phase-B Runtime release is published. Keep
+// this explicit rollout gate so a future release can stage its bootstrap
+// activation separately from the server-side protocol implementation.
+export const RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED = true
 
 export function buildAgentInvitePrompt(
   roomId: string,

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("next/router", () => ({
@@ -64,6 +64,7 @@ const baseHookReturn = {
   meetingNotesMediaAvailable: true,
   startMeetingNotes: vi.fn(),
   stopMeetingNotes: vi.fn(),
+  createRuntimeProviderClaim: vi.fn(),
 }
 
 describe("RoomContent — Turnstile widget lifecycle", () => {
@@ -148,5 +149,71 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(mock.render).toHaveBeenCalledTimes(1)
     expect(mock.remove).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[id^="cf-chl-widget"]')).toBeNull()
+  })
+
+  it("waits for the Room claim ACK before preparing an invite, then writes only from a second click", async () => {
+    let resolveClaim: (value: { providerClaimSecret: string }) => void
+    const claim = new Promise<{ providerClaimSecret: string }>((resolve) => {
+      resolveClaim = resolve
+    })
+    const createRuntimeProviderClaim = vi.fn(() => claim)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      createRuntimeProviderClaim,
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
+    expect(createRuntimeProviderClaim).toHaveBeenCalledTimes(1)
+    expect(writeText).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("button", { name: "Preparing invite..." })
+    ).toBeDisabled()
+
+    await act(async () => {
+      resolveClaim!({
+        providerClaimSecret: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      })
+      await claim
+    })
+    expect(screen.getByRole("button", { name: "Copy invite" })).toBeEnabled()
+    expect(writeText).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy invite" }))
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("--provider-claim")
+    )
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copied!" })).toBeEnabled()
+    )
+  })
+
+  it("keeps a prepared invite available and shows a retryable clipboard error", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("blocked"))
+    Object.assign(navigator, { clipboard: { writeText } })
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      createRuntimeProviderClaim: vi.fn().mockResolvedValue({
+        providerClaimSecret: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      }),
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
+    const copy = await screen.findByRole("button", { name: "Copy invite" })
+    fireEvent.click(copy)
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Clipboard access was blocked"
+    )
+    expect(screen.getByRole("button", { name: "Copy invite" })).toBeEnabled()
   })
 })

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -101,6 +101,11 @@ export default function RoomContent({
   const router = useRouter()
   const [roomLinkCopied, setRoomLinkCopied] = useState(false)
   const [agentInviteCopied, setAgentInviteCopied] = useState(false)
+  const [preparedAgentInvite, setPreparedAgentInvite] = useState<string | null>(
+    null
+  )
+  const [agentInvitePreparing, setAgentInvitePreparing] = useState(false)
+  const [agentInviteError, setAgentInviteError] = useState("")
   const [meetingNotesPickerOpen, setMeetingNotesPickerOpen] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<
     {
@@ -465,25 +470,63 @@ export default function RoomContent({
     }
   }
 
-  const copyAgentInvite = () => {
-    if (typeof window === "undefined") return
-    void (
-      RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED
-        ? createRuntimeProviderClaim().then(({ providerClaimSecret }) =>
-            buildAgentInvitePrompt(roomName, { providerClaimSecret })
-          )
-        : Promise.resolve(buildAgentInvitePrompt(roomName))
-    )
-      .then((invite) => navigator.clipboard.writeText(invite))
+  const writeAgentInvite = (invite: string) => {
+    // This function is intentionally called directly from a click handler.
+    // Firefox and Safari require transient user activation for clipboard
+    // writes, so never move this call behind an asynchronous Room round-trip.
+    if (!navigator.clipboard?.writeText) {
+      setAgentInviteError(
+        "Clipboard access is unavailable. Copy invite is not supported here."
+      )
+      return
+    }
+    void navigator.clipboard
+      .writeText(invite)
       .then(() => {
         trackAnalyticsEvent("AgentInviteCopied", {
           surface: "room",
           roomType: resolvedRoomType,
         })
+        setPreparedAgentInvite(null)
+        setAgentInviteError("")
         setAgentInviteCopied(true)
         setTimeout(() => setAgentInviteCopied(false), 2000)
       })
-      .catch(() => undefined)
+      .catch(() => {
+        setAgentInviteError(
+          "Clipboard access was blocked. Click Copy invite to try again."
+        )
+      })
+  }
+
+  const copyAgentInvite = () => {
+    if (typeof window === "undefined") return
+    if (preparedAgentInvite) {
+      writeAgentInvite(preparedAgentInvite)
+      return
+    }
+    if (!RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED) {
+      writeAgentInvite(buildAgentInvitePrompt(roomName))
+      return
+    }
+    setAgentInviteCopied(false)
+    setAgentInvitePreparing(true)
+    setAgentInviteError("")
+    void createRuntimeProviderClaim()
+      .then(({ providerClaimSecret }) => {
+        // The raw claim becomes browser-memory-only invite content only after
+        // the authenticated Room acknowledgement. A second explicit click
+        // then writes it while its transient user activation is still valid.
+        setPreparedAgentInvite(
+          buildAgentInvitePrompt(roomName, { providerClaimSecret })
+        )
+      })
+      .catch(() => {
+        setAgentInviteError("Unable to prepare the Agent invite. Try again.")
+      })
+      .then(() => {
+        setAgentInvitePreparing(false)
+      })
   }
 
   if (connectionStatus === "failed") {
@@ -583,11 +626,27 @@ export default function RoomContent({
           <button
             type="button"
             onClick={copyAgentInvite}
+            disabled={agentInvitePreparing}
             className="rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-xs text-blue-200 hover:bg-blue-800/50"
-            title="Copy Agent invite prompt"
+            title={
+              preparedAgentInvite
+                ? "Copy prepared Agent invite prompt"
+                : "Copy Agent invite prompt"
+            }
           >
-            {agentInviteCopied ? "Copied!" : "Invite Agent"}
+            {agentInviteCopied
+              ? "Copied!"
+              : agentInvitePreparing
+              ? "Preparing invite..."
+              : preparedAgentInvite
+              ? "Copy invite"
+              : "Invite Agent"}
           </button>
+          {agentInviteError && (
+            <span role="status" className="text-xs text-rose-300">
+              {agentInviteError}
+            </span>
+          )}
           {meetingNotes.active ? (
             <button
               type="button"


### PR DESCRIPTION
## Summary

This is the staged rollout companion to merged #198. `agent-v0.5.9` has been built, smoke-tested on darwin/linux amd64/arm64, checksum-published, and released before this PR changes any public bootstrap behavior.

The live `agent.md` trust root now pins the official installer to `0.5.9` / `agent-v0.5.9`. The bootstrap contract's intentionally-newer fixture advances to `0.5.10`, preserving the rule that a different local executable is never assumed forward compatible and must select the exact pinned installer.

The existing Runtime Provider one-time-claim invite gate is enabled. Clicking Invite Agent now requests the Human-created claim through the authenticated Room path and includes the raw claim only in the copied invite after the Room acknowledges it. The claim remains absent from Room public state, diagnostics, chat, and Harness context; #198's server-side proof and liveness checks remain the authorization boundary.

The provider-claim copy flow deliberately uses two user gestures: the first creates and awaits the Room claim, then exposes a `Copy invite` button; the second invokes `navigator.clipboard.writeText()` directly from that fresh click. This preserves Firefox/Safari transient activation without ever placing the raw claim on the clipboard before the Room ACK. Clipboard rejection is visible and retryable rather than silently swallowed.

## Scope

This PR deliberately contains no Runtime, Durable Object, media, or authorization-model changes. It only activates code already merged in #198 after the immutable release is available.

## Validation

- `agent-v0.5.9` official release workflow: four native build/smoke jobs and Publish GitHub Release succeeded; release contains four binaries plus `SHA256SUMS`.
- `yarn vitest run src/common/agentInvite.test.ts`
- `yarn vitest run src/components/RoomContent.test.tsx`
- `yarn type-check`
- `agent/scripts/test-bootstrap-contract.sh`
