### PR TITLE
fix(media): retry Agent audio subscription when tracks/new returns no SDP

### DIFF
--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -354,6 +354,122 @@ describe("useSfuChatRoom room attachments (#123)", () => {
     return rendered
   }
 
+  function publishAgentVoice(
+    ws: RecordingWebSocket,
+    sessionId = "agent-session"
+  ) {
+    act(() =>
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "trackPublished",
+          participant: {
+            id: "agent-b",
+            name: "Agent B",
+            kind: "agent",
+            sessionId,
+            track: { trackName: "agent-voice", kind: "audio" },
+          },
+        }),
+      })
+    )
+  }
+
+  function resyncAgentVoice(ws: RecordingWebSocket, sessionId?: string) {
+    act(() =>
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 0,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: sessionId
+              ? [
+                  {
+                    id: "agent-b",
+                    name: "Agent B",
+                    kind: "agent",
+                    connected: true,
+                    joinedAt: 0,
+                    lastSeenAt: 0,
+                    media: {
+                      sessionId,
+                      muted: false,
+                      fileChannelReady: false,
+                      tracks: [{ trackName: "agent-voice", kind: "audio" }],
+                    },
+                  },
+                ]
+              : [],
+            messages: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: true,
+            agentVoice: sessionId
+              ? { "agent-b": { enabled: true, enabledAt: 1 } }
+              : {},
+            agentVoiceMediaAvailable: true,
+          },
+        }),
+      })
+    )
+  }
+
+  function remoteTrackCallCount() {
+    return fetchMock.mock.calls.filter(([input, init]) => {
+      if (!String(input).endsWith("/api/sfu/tracks")) return false
+      const body = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+        tracks?: Array<{ location?: string }>
+      }
+      return body.tracks?.[0]?.location === "remote"
+    }).length
+  }
+
+  function readyMessages(ws: RecordingWebSocket) {
+    return ws.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .filter((message) => message.type === "agent-voice-ready")
+  }
+
+  function installAgentVoiceTrackResponses(responses: Array<object>) {
+    let attempts = 0
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          })
+        if (url.endsWith("/api/sfu/datachannels/new"))
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        if (url.endsWith("/api/sfu/tracks")) {
+          const body = JSON.parse(
+            (init?.body as string | undefined) ?? "{}"
+          ) as { tracks?: Array<{ location?: string }> }
+          if (body.tracks?.[0]?.location === "remote") {
+            const response = responses[attempts] ?? responses.at(-1) ?? {}
+            attempts += 1
+            return jsonResponse(response)
+          }
+        }
+        return jsonResponse({})
+      }
+    )
+    return () => attempts
+  }
+
+  const usableAgentVoiceTrackResponse = {
+    requiresImmediateRenegotiation: true,
+    sessionDescription: { type: "offer", sdp: "fake-sfu-offer" },
+    tracks: [{ mid: "7", trackName: "agent-voice" }],
+  }
+
+  const noSdpAgentVoiceTrackResponse = {
+    requiresImmediateRenegotiation: false,
+    tracks: [{ mid: "7", trackName: "agent-voice" }],
+  }
+
   function makeLogFile() {
     return new File(["line"], "app.log", { type: "" })
   }
@@ -832,6 +948,144 @@ describe("useSfuChatRoom room attachments (#123)", () => {
     expect(JSON.stringify(diagnostics)).not.toContain(
       "secret-sdp-fetch-failure"
     )
+    unmount()
+  })
+
+  it("retries a successful no-SDP Agent audio response and ACKs once after negotiation", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    const trackAttempts = installAgentVoiceTrackResponses([
+      noSdpAgentVoiceTrackResponse,
+      usableAgentVoiceTrackResponse,
+    ])
+    const { unmount } = await connect("room-agent-no-sdp-retry")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(ws)
+    await waitFor(() => expect(trackAttempts()).toBe(1))
+    expect(readyMessages(ws)).toEqual([])
+
+    await waitFor(() => expect(trackAttempts()).toBe(2))
+    expect(remoteTrackCallCount()).toBe(2)
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/api/sfu/renegotiate")
+      )
+    ).toHaveLength(1)
+    expect(readyMessages(ws)).toHaveLength(1)
+    expect(readyMessages(ws)[0]).toMatchObject({
+      agentParticipantId: "agent-b",
+      sessionId: "agent-session",
+      trackName: "agent-voice",
+    })
+    expect(
+      info.mock.calls.map(([message]) => String(message)).join("\n")
+    ).toContain("agent_audio_subscription_retry_scheduled")
+    unmount()
+  })
+
+  it("cancels a pending no-SDP retry when the Agent publication disappears", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    const trackAttempts = installAgentVoiceTrackResponses([
+      noSdpAgentVoiceTrackResponse,
+      usableAgentVoiceTrackResponse,
+    ])
+    const { unmount } = await connect("room-agent-no-sdp-disappear")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(ws)
+    await waitFor(() => expect(trackAttempts()).toBe(1))
+
+    resyncAgentVoice(ws)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    expect(trackAttempts()).toBe(1)
+    expect(readyMessages(ws)).toEqual([])
+    expect(
+      info.mock.calls.map(([message]) => String(message)).join("\n")
+    ).toContain("agent_audio_subscription_retry_cancelled")
+    unmount()
+  })
+
+  it("cancels P1's pending retry when P2 replaces the Agent audio publication", async () => {
+    const trackAttempts = installAgentVoiceTrackResponses([
+      noSdpAgentVoiceTrackResponse,
+      usableAgentVoiceTrackResponse,
+    ])
+    const { unmount } = await connect("room-agent-no-sdp-replacement")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(ws, "agent-session-p1")
+    await waitFor(() => expect(trackAttempts()).toBe(1))
+
+    publishAgentVoice(ws, "agent-session-p2")
+    await waitFor(() => expect(trackAttempts()).toBe(2))
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    expect(trackAttempts()).toBe(2)
+    expect(readyMessages(ws)).toHaveLength(1)
+    expect(readyMessages(ws)[0]).toMatchObject({
+      sessionId: "agent-session-p2",
+    })
+    unmount()
+  })
+
+  it("keeps one no-SDP retry chain while Room state resyncs", async () => {
+    const trackAttempts = installAgentVoiceTrackResponses([
+      noSdpAgentVoiceTrackResponse,
+      usableAgentVoiceTrackResponse,
+    ])
+    const { unmount } = await connect("room-agent-no-sdp-dedup")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(ws)
+    await waitFor(() => expect(trackAttempts()).toBe(1))
+
+    resyncAgentVoice(ws, "agent-session")
+    expect(trackAttempts()).toBe(1)
+    await waitFor(() => expect(trackAttempts()).toBe(2))
+
+    expect(trackAttempts()).toBe(2)
+    expect(readyMessages(ws)).toHaveLength(1)
+    unmount()
+  })
+
+  it("leaves exhausted Agent audio retry state recoverable by a later resync", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    const trackAttempts = installAgentVoiceTrackResponses([
+      noSdpAgentVoiceTrackResponse,
+      noSdpAgentVoiceTrackResponse,
+      noSdpAgentVoiceTrackResponse,
+      usableAgentVoiceTrackResponse,
+    ])
+    const { unmount } = await connect("room-agent-no-sdp-exhausted")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(ws)
+    await waitFor(() => expect(trackAttempts()).toBe(3))
+
+    expect(trackAttempts()).toBe(3)
+    expect(readyMessages(ws)).toEqual([])
+    expect(
+      info.mock.calls.map(([message]) => String(message)).join("\n")
+    ).toContain("agent_audio_subscription_retry_exhausted")
+
+    resyncAgentVoice(ws, "agent-session")
+    await waitFor(() => expect(trackAttempts()).toBe(4))
+    expect(readyMessages(ws)).toHaveLength(1)
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -1089,6 +1089,90 @@ describe("useSfuChatRoom room attachments (#123)", () => {
     unmount()
   })
 
+  it("drops an in-flight retry from a stale Human media session before ACKing", async () => {
+    let sessionAttempts = 0
+    let remoteTrackAttempts = 0
+    const remoteSubscriberSessionIds: string[] = []
+    let resolveRetryTracks!: (response: Response) => void
+    const pendingRetryTracks = new Promise<Response>((resolve) => {
+      resolveRetryTracks = resolve
+    })
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session")) {
+          sessionAttempts += 1
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: `human-session-${sessionAttempts}`,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          })
+        }
+        if (url.endsWith("/api/sfu/datachannels/new"))
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        if (url.endsWith("/api/sfu/tracks")) {
+          const body = JSON.parse(
+            (init?.body as string | undefined) ?? "{}"
+          ) as {
+            sessionId?: string
+            tracks?: Array<{ location?: string }>
+          }
+          if (body.tracks?.[0]?.location !== "remote") return jsonResponse({})
+          remoteTrackAttempts += 1
+          remoteSubscriberSessionIds.push(body.sessionId ?? "")
+          if (remoteTrackAttempts === 1)
+            return jsonResponse(noSdpAgentVoiceTrackResponse)
+          if (remoteTrackAttempts === 2) return pendingRetryTracks
+          return jsonResponse(usableAgentVoiceTrackResponse)
+        }
+        return jsonResponse({})
+      }
+    )
+
+    const { unmount } = await connect("room-agent-no-sdp-stale-media")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const oldPc = FakePeerConnection.instances.at(-1)!
+    const oldSetRemoteDescription = vi.spyOn(oldPc, "setRemoteDescription")
+    const oldWs = RecordingWebSocket.instances.at(-1)!
+
+    publishAgentVoice(oldWs)
+    await waitFor(() => expect(remoteTrackAttempts).toBe(2))
+
+    oldPc.connectionState = "disconnected"
+    act(() => oldPc.onconnectionstatechange?.())
+    await waitFor(() => expect(sessionAttempts).toBe(2))
+
+    // The reconnect's local publication is queued behind the old retry, so
+    // resolve the latter only after the new Human session has replaced it.
+    resolveRetryTracks(await jsonResponse(usableAgentVoiceTrackResponse))
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(1)
+    )
+    const newWs = RecordingWebSocket.instances.at(-1)!
+
+    expect(oldSetRemoteDescription).not.toHaveBeenCalled()
+    expect(readyMessages(newWs)).toEqual([])
+
+    resyncAgentVoice(newWs, "agent-session")
+    await waitFor(() => expect(remoteTrackAttempts).toBe(3))
+    await waitFor(() => expect(readyMessages(newWs)).toHaveLength(1))
+
+    expect(remoteSubscriberSessionIds).toEqual([
+      "human-session-1",
+      "human-session-1",
+      "human-session-2",
+    ])
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/api/sfu/renegotiate")
+      )
+    ).toHaveLength(1)
+    unmount()
+  })
+
   it("observes the complete Agent audio downstream path without exposing secrets", async () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
     fetchMock.mockImplementation((input: RequestInfo | URL) => {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -63,6 +63,12 @@ const AGENT_TEXT_EXTENSIONS = new Set([
   ".yml",
   ".yaml",
 ])
+// Cloudflare can briefly acknowledge a newly re-published Agent audio track
+// before it has an SDP answer for an already-connected Human listener. Keep
+// recovery prompt, bounded, and specific to that publication.
+const AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS = [100, 300] as const
+const MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS =
+  1 + AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS.length
 
 function agentTextMime(file: File): string | undefined {
   if (AGENT_TEXT_TYPES.has(file.type)) return file.type
@@ -105,12 +111,38 @@ interface SfuApiResponse {
   }>
 }
 
+interface AgentAudioSubscriptionRetry {
+  attempt: number
+  timeout: ReturnType<typeof setTimeout>
+}
+
+function hasUsableSessionDescription(response: SfuApiResponse): boolean {
+  const description = response.sessionDescription
+  return Boolean(
+    description &&
+      typeof description.type === "string" &&
+      description.type.length > 0 &&
+      typeof description.sdp === "string" &&
+      description.sdp.length > 0
+  )
+}
+
+function hasRemoteTrackError(response: SfuApiResponse): boolean {
+  return Boolean(
+    response.errorCode ||
+      response.tracks?.some(
+        (track) =>
+          typeof track.errorCode === "string" && track.errorCode.length > 0
+      )
+  )
+}
+
 function summarizeRemoteTrackResponse(response: SfuApiResponse) {
   const tracks = Array.isArray(response.tracks) ? response.tracks : []
   return {
     requiresImmediateRenegotiation:
       response.requiresImmediateRenegotiation === true,
-    hasSessionDescription: Boolean(response.sessionDescription),
+    hasSessionDescription: hasUsableSessionDescription(response),
     sessionDescriptionType: response.sessionDescription?.type ?? null,
     trackResultCount: tracks.length,
     trackHasMid: tracks.some(
@@ -311,6 +343,16 @@ export function useSfuChatRoom(
   // without issuing a second tracks/new request. In-flight or failed keys
   // never enter this set and therefore can never ACK early.
   const readySubscribedTracksRef = useRef(new Set<string>())
+  const agentAudioSubscriptionRetriesRef = useRef(
+    new Map<string, AgentAudioSubscriptionRetry>()
+  )
+  const subscribeTrackRef = useRef<
+    (
+      participant: SfuParticipant,
+      track: SfuTrack,
+      attempt?: number
+    ) => Promise<void>
+  >(async () => undefined)
   const pendingRuntimeProviderClaimsRef = useRef(
     new Map<
       string,
@@ -418,6 +460,53 @@ export function useSfuChatRoom(
     }
     return false
   }, [])
+
+  const isCurrentAgentAudioPublication = useCallback(
+    (participantId: string, sessionId: string, trackName: string): boolean => {
+      const participant = participantMapRef.current.get(participantId)
+      return Boolean(
+        participant?.kind === "agent" &&
+          participant.media?.sessionId === sessionId &&
+          participant.media.tracks.some(
+            (track) => track.kind === "audio" && track.trackName === trackName
+          )
+      )
+    },
+    []
+  )
+
+  const clearAgentAudioSubscriptionRetry = useCallback(
+    (key: string, reason?: string) => {
+      const retry = agentAudioSubscriptionRetriesRef.current.get(key)
+      if (!retry) return
+      clearTimeout(retry.timeout)
+      agentAudioSubscriptionRetriesRef.current.delete(key)
+      if (reason)
+        voiceDownstreamDiagnostic("agent_audio_subscription_retry_cancelled", {
+          attempt: retry.attempt,
+          reason,
+        })
+    },
+    []
+  )
+
+  const clearAgentAudioSubscriptionRetriesForParticipant = useCallback(
+    (participantId: string, reason: string) => {
+      for (const key of agentAudioSubscriptionRetriesRef.current.keys()) {
+        if (key.startsWith(`${participantId}:`))
+          clearAgentAudioSubscriptionRetry(key, reason)
+      }
+    },
+    [clearAgentAudioSubscriptionRetry]
+  )
+
+  const clearAllAgentAudioSubscriptionRetries = useCallback(
+    (reason: string) => {
+      for (const key of agentAudioSubscriptionRetriesRef.current.keys())
+        clearAgentAudioSubscriptionRetry(key, reason)
+    },
+    [clearAgentAudioSubscriptionRetry]
+  )
 
   const enqueueNegotiation = useCallback(
     <T>(operation: () => Promise<T>): Promise<T> => {
@@ -606,40 +695,47 @@ export function useSfuChatRoom(
     [appendEphemeralMessage]
   )
 
-  const resetRemoteParticipant = useCallback((participantId: string) => {
-    for (const key of subscribedTracksRef.current) {
-      if (key.startsWith(`${participantId}:`))
-        subscribedTracksRef.current.delete(key)
-    }
-    for (const key of readySubscribedTracksRef.current) {
-      if (key.startsWith(`${participantId}:`))
-        readySubscribedTracksRef.current.delete(key)
-    }
+  const resetRemoteParticipant = useCallback(
+    (participantId: string) => {
+      clearAgentAudioSubscriptionRetriesForParticipant(
+        participantId,
+        "participant_reset"
+      )
+      for (const key of subscribedTracksRef.current) {
+        if (key.startsWith(`${participantId}:`))
+          subscribedTracksRef.current.delete(key)
+      }
+      for (const key of readySubscribedTracksRef.current) {
+        if (key.startsWith(`${participantId}:`))
+          readySubscribedTracksRef.current.delete(key)
+      }
 
-    const channel = remoteFileChannelsRef.current.get(participantId)
-    if (channel) {
-      channel.close()
-      dataChannelsRef.current.delete(channel)
-    }
-    remoteFileChannelsRef.current.delete(participantId)
-    const channelId = remoteFileChannelIdsRef.current.get(participantId)
-    if (channelId !== undefined) dataChannelIdsRef.current.delete(channelId)
-    remoteFileChannelIdsRef.current.delete(participantId)
-    incomingFilesRef.current.delete(participantId)
+      const channel = remoteFileChannelsRef.current.get(participantId)
+      if (channel) {
+        channel.close()
+        dataChannelsRef.current.delete(channel)
+      }
+      remoteFileChannelsRef.current.delete(participantId)
+      const channelId = remoteFileChannelIdsRef.current.get(participantId)
+      if (channelId !== undefined) dataChannelIdsRef.current.delete(channelId)
+      remoteFileChannelIdsRef.current.delete(participantId)
+      incomingFilesRef.current.delete(participantId)
 
-    remoteAudioStreamsRef.current
-      .get(participantId)
-      ?.getTracks()
-      .forEach((track) => track.stop())
-    remoteScreenStreamsRef.current
-      .get(participantId)
-      ?.getTracks()
-      .forEach((track) => track.stop())
-    remoteAudioStreamsRef.current.delete(participantId)
-    remoteScreenStreamsRef.current.delete(participantId)
-    if (pendingRemoteTrackRef.current?.peerId === participantId)
-      pendingRemoteTrackRef.current = null
-  }, [])
+      remoteAudioStreamsRef.current
+        .get(participantId)
+        ?.getTracks()
+        .forEach((track) => track.stop())
+      remoteScreenStreamsRef.current
+        .get(participantId)
+        ?.getTracks()
+        .forEach((track) => track.stop())
+      remoteAudioStreamsRef.current.delete(participantId)
+      remoteScreenStreamsRef.current.delete(participantId)
+      if (pendingRemoteTrackRef.current?.peerId === participantId)
+        pendingRemoteTrackRef.current = null
+    },
+    [clearAgentAudioSubscriptionRetriesForParticipant]
+  )
 
   const handleFileChannelMessage = useCallback(
     (channelKey: string, peerId: string, name: string, event: MessageEvent) => {
@@ -904,8 +1000,65 @@ export function useSfuChatRoom(
     [apiRequest, enqueueNegotiation, roomName]
   )
 
+  const scheduleAgentAudioSubscriptionRetry = useCallback(
+    (
+      key: string,
+      participantId: string,
+      sessionId: string,
+      trackName: string,
+      attempt: number
+    ) => {
+      const delay = AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS[attempt - 2]
+      if (delay === undefined) return false
+      if (agentAudioSubscriptionRetriesRef.current.has(key)) return true
+      const timeout = setTimeout(() => {
+        const pending = agentAudioSubscriptionRetriesRef.current.get(key)
+        if (!pending || pending.attempt !== attempt) return
+        agentAudioSubscriptionRetriesRef.current.delete(key)
+        if (
+          !isCurrentAgentAudioPublication(participantId, sessionId, trackName)
+        ) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
+          voiceDownstreamDiagnostic(
+            "agent_audio_subscription_retry_cancelled",
+            { attempt, reason: "stale_publication" }
+          )
+          return
+        }
+        const participant = participantMapRef.current.get(participantId)
+        const track = participant?.media?.tracks.find(
+          (candidate) =>
+            candidate.kind === "audio" && candidate.trackName === trackName
+        )
+        if (!participant || !track) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
+          voiceDownstreamDiagnostic(
+            "agent_audio_subscription_retry_cancelled",
+            { attempt, reason: "publication_missing" }
+          )
+          return
+        }
+        // Keep the dedup set occupied until this timer is the sole logical
+        // retry chain. Clearing immediately before the synchronous retry lets
+        // that retry claim it again without a parallel Room-state attempt.
+        subscribedTracksRef.current.delete(key)
+        readySubscribedTracksRef.current.delete(key)
+        void subscribeTrackRef.current(participant, track, attempt)
+      }, delay)
+      agentAudioSubscriptionRetriesRef.current.set(key, { attempt, timeout })
+      voiceDownstreamDiagnostic("agent_audio_subscription_retry_scheduled", {
+        attempt,
+        delay_ms: delay,
+      })
+      return true
+    },
+    [isCurrentAgentAudioPublication]
+  )
+
   const subscribeTrack = useCallback(
-    async (participant: SfuParticipant, track: SfuTrack) => {
+    async (participant: SfuParticipant, track: SfuTrack, attempt = 1) => {
       const session = sessionRef.current
       const pc = peerConnectionRef.current
       const media = participant.media
@@ -940,6 +1093,16 @@ export function useSfuChatRoom(
         voiceDownstreamDiagnostic("subscribe_dedup_skipped", {})
         return
       }
+      if (
+        participant.kind === "agent" &&
+        track.kind === "audio" &&
+        !isCurrentAgentAudioPublication(
+          participant.id,
+          media.sessionId,
+          track.trackName
+        )
+      )
+        return
       if (
         participantMapRef.current.get(participant.id)?.media?.sessionId !==
         media.sessionId
@@ -1005,9 +1168,45 @@ export function useSfuChatRoom(
             ? { track_error_codes: responseSummary.trackErrorCodes }
             : {}),
         })
-        if (!response.sessionDescription) {
+        const isAgentAudioSubscription =
+          participant.kind === "agent" && track.kind === "audio"
+        if (
+          isAgentAudioSubscription &&
+          !isCurrentAgentAudioPublication(
+            participant.id,
+            media.sessionId,
+            track.trackName
+          )
+        ) {
           subscribedTracksRef.current.delete(key)
           readySubscribedTracksRef.current.delete(key)
+          voiceDownstreamDiagnostic(
+            "agent_audio_subscription_retry_cancelled",
+            { attempt, reason: "stale_response" }
+          )
+          return
+        }
+        if (!hasUsableSessionDescription(response)) {
+          const scheduled =
+            isAgentAudioSubscription &&
+            !hasRemoteTrackError(response) &&
+            attempt < MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS &&
+            scheduleAgentAudioSubscriptionRetry(
+              key,
+              participant.id,
+              media.sessionId,
+              track.trackName,
+              attempt + 1
+            )
+          if (!scheduled) {
+            subscribedTracksRef.current.delete(key)
+            readySubscribedTracksRef.current.delete(key)
+            if (isAgentAudioSubscription && !hasRemoteTrackError(response))
+              voiceDownstreamDiagnostic(
+                "agent_audio_subscription_retry_exhausted",
+                { attempt }
+              )
+          }
           console.warn(
             "sfu_remote_subscribe_missing_description",
             summarizeRemoteTrackResponse(response)
@@ -1058,7 +1257,14 @@ export function useSfuChatRoom(
             sessionDescription: { type: answer.type, sdp: answer.sdp },
           })
           voiceDownstreamDiagnostic("renegotiate_ok", { renegotiate_ok: 1 })
-          if (participant.kind === "agent" && track.kind === "audio") {
+          if (
+            isAgentAudioSubscription &&
+            isCurrentAgentAudioPublication(
+              participant.id,
+              media.sessionId,
+              track.trackName
+            )
+          ) {
             // Negotiation completion is the ACK-safe boundary. Record it
             // even if the control WebSocket is briefly unavailable; a later
             // resync on the new socket will re-assert the same ACK.
@@ -1078,6 +1284,13 @@ export function useSfuChatRoom(
             voiceDownstreamDiagnostic("agent_voice_ready_ack_sent", {
               agent_voice_ready_ack_sent: sent ? 1 : 0,
             })
+          } else if (isAgentAudioSubscription) {
+            subscribedTracksRef.current.delete(key)
+            readySubscribedTracksRef.current.delete(key)
+            voiceDownstreamDiagnostic(
+              "agent_audio_subscription_retry_cancelled",
+              { attempt, reason: "stale_before_ack" }
+            )
           }
         } catch (error) {
           voiceDownstreamDiagnostic("negotiation_failed", {
@@ -1094,8 +1307,19 @@ export function useSfuChatRoom(
         })
       })
     },
-    [apiRequest, enqueueNegotiation, roomName, sendSocketMessage]
+    [
+      apiRequest,
+      enqueueNegotiation,
+      isCurrentAgentAudioPublication,
+      roomName,
+      scheduleAgentAudioSubscriptionRetry,
+      sendSocketMessage,
+    ]
   )
+
+  useEffect(() => {
+    subscribeTrackRef.current = subscribeTrack
+  }, [subscribeTrack])
 
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
@@ -1445,6 +1669,7 @@ export function useSfuChatRoom(
         peerConnectionRef.current = null
         dataChannelReadyRef.current = false
         localTrackMidsRef.current.clear()
+        clearAllAgentAudioSubscriptionRetries("media_reconnect")
         subscribedTracksRef.current.clear()
         readySubscribedTracksRef.current.clear()
         remoteAudioStreamsRef.current.clear()
@@ -1530,6 +1755,7 @@ export function useSfuChatRoom(
     },
     [
       closeDataChannels,
+      clearAllAgentAudioSubscriptionRetries,
       connectWebSocket,
       createPeerConnection,
       establishDataChannelTransport,
@@ -1609,6 +1835,7 @@ export function useSfuChatRoom(
 
     return () => {
       closingRef.current = true
+      clearAllAgentAudioSubscriptionRetries("unmount")
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
       if (mediaReconnectTimerRef.current)
         clearTimeout(mediaReconnectTimerRef.current)
@@ -1639,6 +1866,7 @@ export function useSfuChatRoom(
     }
   }, [
     closeDataChannels,
+    clearAllAgentAudioSubscriptionRetries,
     connectMediaSession,
     enabled,
     nickName,

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -114,6 +114,8 @@ interface SfuApiResponse {
 interface AgentAudioSubscriptionRetry {
   attempt: number
   timeout: ReturnType<typeof setTimeout>
+  subscriberSessionId: string
+  subscriberPeerConnection: RTCPeerConnection
 }
 
 function hasUsableSessionDescription(response: SfuApiResponse): boolean {
@@ -472,6 +474,16 @@ export function useSfuChatRoom(
           )
       )
     },
+    []
+  )
+
+  const isCurrentSubscriberSession = useCallback(
+    (
+      subscriberSessionId: string,
+      subscriberPeerConnection: RTCPeerConnection
+    ): boolean =>
+      sessionRef.current?.sessionId === subscriberSessionId &&
+      peerConnectionRef.current === subscriberPeerConnection,
     []
   )
 
@@ -1006,7 +1018,9 @@ export function useSfuChatRoom(
       participantId: string,
       sessionId: string,
       trackName: string,
-      attempt: number
+      attempt: number,
+      subscriberSessionId: string,
+      subscriberPeerConnection: RTCPeerConnection
     ) => {
       const delay = AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS[attempt - 2]
       if (delay === undefined) return false
@@ -1015,6 +1029,18 @@ export function useSfuChatRoom(
         const pending = agentAudioSubscriptionRetriesRef.current.get(key)
         if (!pending || pending.attempt !== attempt) return
         agentAudioSubscriptionRetriesRef.current.delete(key)
+        if (
+          !isCurrentSubscriberSession(
+            pending.subscriberSessionId,
+            pending.subscriberPeerConnection
+          )
+        ) {
+          voiceDownstreamDiagnostic(
+            "agent_audio_subscription_retry_cancelled",
+            { attempt, reason: "stale_subscriber_session" }
+          )
+          return
+        }
         if (
           !isCurrentAgentAudioPublication(participantId, sessionId, trackName)
         ) {
@@ -1047,14 +1073,19 @@ export function useSfuChatRoom(
         readySubscribedTracksRef.current.delete(key)
         void subscribeTrackRef.current(participant, track, attempt)
       }, delay)
-      agentAudioSubscriptionRetriesRef.current.set(key, { attempt, timeout })
+      agentAudioSubscriptionRetriesRef.current.set(key, {
+        attempt,
+        timeout,
+        subscriberSessionId,
+        subscriberPeerConnection,
+      })
       voiceDownstreamDiagnostic("agent_audio_subscription_retry_scheduled", {
         attempt,
         delay_ms: delay,
       })
       return true
     },
-    [isCurrentAgentAudioPublication]
+    [isCurrentAgentAudioPublication, isCurrentSubscriberSession]
   )
 
   const subscribeTrack = useCallback(
@@ -1069,6 +1100,37 @@ export function useSfuChatRoom(
       })
       if (!session || !pc || !media) return
       const key = `${participant.id}:${media.sessionId}:${track.trackName}`
+      const isAgentAudioSubscription =
+        participant.kind === "agent" && track.kind === "audio"
+      const subscriberSessionId = session.sessionId
+      const subscriberPeerConnection = pc
+      const cancelStaleAgentAudioSubscription = (stage: string): boolean => {
+        if (!isAgentAudioSubscription) return false
+        const currentSubscriberSession = isCurrentSubscriberSession(
+          subscriberSessionId,
+          subscriberPeerConnection
+        )
+        const currentPublication = isCurrentAgentAudioPublication(
+          participant.id,
+          media.sessionId,
+          track.trackName
+        )
+        if (currentSubscriberSession && currentPublication) return false
+        // A new Human SFU session can reuse this remote-publication key. Do
+        // not let an old async operation clear that new session's admission.
+        if (currentSubscriberSession) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
+        }
+        voiceDownstreamDiagnostic("agent_audio_subscription_retry_cancelled", {
+          attempt,
+          reason: currentSubscriberSession
+            ? "stale_publication"
+            : "stale_subscriber_session",
+          stage,
+        })
+        return true
+      }
       if (subscribedTracksRef.current.has(key)) {
         const current = participantMapRef.current.get(participant.id)
         if (
@@ -1093,16 +1155,7 @@ export function useSfuChatRoom(
         voiceDownstreamDiagnostic("subscribe_dedup_skipped", {})
         return
       }
-      if (
-        participant.kind === "agent" &&
-        track.kind === "audio" &&
-        !isCurrentAgentAudioPublication(
-          participant.id,
-          media.sessionId,
-          track.trackName
-        )
-      )
-        return
+      if (cancelStaleAgentAudioSubscription("subscribe_entered")) return
       if (
         participantMapRef.current.get(participant.id)?.media?.sessionId !==
         media.sessionId
@@ -1110,6 +1163,7 @@ export function useSfuChatRoom(
         return
       subscribedTracksRef.current.add(key)
       await enqueueNegotiation(async () => {
+        if (cancelStaleAgentAudioSubscription("before_tracks_new")) return
         if (
           participantMapRef.current.get(participant.id)?.media?.sessionId !==
           media.sessionId
@@ -1140,6 +1194,23 @@ export function useSfuChatRoom(
             ],
           })
         } catch (error) {
+          if (
+            isAgentAudioSubscription &&
+            !isCurrentSubscriberSession(
+              subscriberSessionId,
+              subscriberPeerConnection
+            )
+          ) {
+            voiceDownstreamDiagnostic(
+              "agent_audio_subscription_retry_cancelled",
+              {
+                attempt,
+                reason: "stale_subscriber_session",
+                stage: "tracks-new",
+              }
+            )
+            return
+          }
           voiceDownstreamDiagnostic("tracks_new_result", {
             tracks_new_ok: 0,
             stage: "tracks-new",
@@ -1168,24 +1239,7 @@ export function useSfuChatRoom(
             ? { track_error_codes: responseSummary.trackErrorCodes }
             : {}),
         })
-        const isAgentAudioSubscription =
-          participant.kind === "agent" && track.kind === "audio"
-        if (
-          isAgentAudioSubscription &&
-          !isCurrentAgentAudioPublication(
-            participant.id,
-            media.sessionId,
-            track.trackName
-          )
-        ) {
-          subscribedTracksRef.current.delete(key)
-          readySubscribedTracksRef.current.delete(key)
-          voiceDownstreamDiagnostic(
-            "agent_audio_subscription_retry_cancelled",
-            { attempt, reason: "stale_response" }
-          )
-          return
-        }
+        if (cancelStaleAgentAudioSubscription("tracks_new_response")) return
         if (!hasUsableSessionDescription(response)) {
           const scheduled =
             isAgentAudioSubscription &&
@@ -1196,7 +1250,9 @@ export function useSfuChatRoom(
               participant.id,
               media.sessionId,
               track.trackName,
-              attempt + 1
+              attempt + 1,
+              subscriberSessionId,
+              subscriberPeerConnection
             )
           if (!scheduled) {
             subscribedTracksRef.current.delete(key)
@@ -1214,7 +1270,11 @@ export function useSfuChatRoom(
           return
         }
         try {
+          if (cancelStaleAgentAudioSubscription("before_remote_description"))
+            return
           await pc.setRemoteDescription(response.sessionDescription)
+          if (cancelStaleAgentAudioSubscription("remote_description_applied"))
+            return
           voiceDownstreamDiagnostic("remote_description_applied", {
             remote_description_applied: 1,
           })
@@ -1228,6 +1288,7 @@ export function useSfuChatRoom(
         let answer: RTCSessionDescriptionInit
         try {
           answer = await pc.createAnswer()
+          if (cancelStaleAgentAudioSubscription("answer_created")) return
           voiceDownstreamDiagnostic("answer_created", { answer_created: 1 })
         } catch (error) {
           voiceDownstreamDiagnostic("negotiation_failed", {
@@ -1238,6 +1299,8 @@ export function useSfuChatRoom(
         }
         try {
           await pc.setLocalDescription(answer)
+          if (cancelStaleAgentAudioSubscription("local_description_applied"))
+            return
           voiceDownstreamDiagnostic("local_description_applied", {
             local_description_applied: 1,
           })
@@ -1249,6 +1312,7 @@ export function useSfuChatRoom(
           throw error
         }
         try {
+          if (cancelStaleAgentAudioSubscription("before_renegotiate")) return
           await apiRequest("renegotiate", {
             room: roomName,
             participantId: session.participantId,
@@ -1256,15 +1320,9 @@ export function useSfuChatRoom(
             sessionId: session.sessionId,
             sessionDescription: { type: answer.type, sdp: answer.sdp },
           })
+          if (cancelStaleAgentAudioSubscription("renegotiate_complete")) return
           voiceDownstreamDiagnostic("renegotiate_ok", { renegotiate_ok: 1 })
-          if (
-            isAgentAudioSubscription &&
-            isCurrentAgentAudioPublication(
-              participant.id,
-              media.sessionId,
-              track.trackName
-            )
-          ) {
+          if (isAgentAudioSubscription) {
             // Negotiation completion is the ACK-safe boundary. Record it
             // even if the control WebSocket is briefly unavailable; a later
             // resync on the new socket will re-assert the same ACK.
@@ -1284,13 +1342,6 @@ export function useSfuChatRoom(
             voiceDownstreamDiagnostic("agent_voice_ready_ack_sent", {
               agent_voice_ready_ack_sent: sent ? 1 : 0,
             })
-          } else if (isAgentAudioSubscription) {
-            subscribedTracksRef.current.delete(key)
-            readySubscribedTracksRef.current.delete(key)
-            voiceDownstreamDiagnostic(
-              "agent_audio_subscription_retry_cancelled",
-              { attempt, reason: "stale_before_ack" }
-            )
           }
         } catch (error) {
           voiceDownstreamDiagnostic("negotiation_failed", {
@@ -1300,8 +1351,21 @@ export function useSfuChatRoom(
           throw error
         }
       }).catch((error) => {
-        subscribedTracksRef.current.delete(key)
-        readySubscribedTracksRef.current.delete(key)
+        if (
+          !isAgentAudioSubscription ||
+          isCurrentSubscriberSession(
+            subscriberSessionId,
+            subscriberPeerConnection
+          )
+        ) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
+        } else {
+          voiceDownstreamDiagnostic(
+            "agent_audio_subscription_retry_cancelled",
+            { attempt, reason: "stale_subscriber_session", stage: "failed" }
+          )
+        }
         console.warn("sfu_remote_subscribe_failed", {
           errorType: error instanceof Error ? error.name : typeof error,
         })
@@ -1311,6 +1375,7 @@ export function useSfuChatRoom(
       apiRequest,
       enqueueNegotiation,
       isCurrentAgentAudioPublication,
+      isCurrentSubscriberSession,
       roomName,
       scheduleAgentAudioSubscriptionRetry,
       sendSocketMessage,


### PR DESCRIPTION
Fixes #201.

An already-connected Human can receive a successful Agent-audio `tracks/new` response while Cloudflare has not yet attached a usable SDP offer. The prior browser path treated that as a terminal, retryable-on-unrelated-state failure: it cleared the subscription admission key, but did not reconcile the exact publication again. The Agent therefore remained silent until another Room event happened to trigger a new subscription attempt.

This change adds a bounded retry path only for the exact affected case: a current Agent audio publication whose successful `tracks/new` response contains no usable SDP and no top-level or per-track error. It makes at most two delayed retries (100 ms, then 300 ms), preserves the existing subscription dedup key while a retry is pending, and revalidates the exact participant/session/track before retrying or sending `agent-voice-ready`.

Pending retries are cancelled on publication reset/replacement, media-session reconnect, and hook teardown. A stale or replaced publication cannot create a new subscription or ACK. Normal HTTP and track-error handling is unchanged, and an exhausted retry chain deliberately remains unready so a later normal Room reconciliation can recover.

The browser-only scope is limited to `useSfuChatRoom.ts` and its tests. It does not change the Agent Runtime, Room/DO authorization, voice grants, cleanup, provider claims, versioning, or bootstrap/release behavior.

Validation completed locally:

- `yarn test` — 46 files / 458 tests passed
- `yarn prettier --check .`
- `yarn eslint src`
- `yarn type-check`
- `yarn cf-build`

The focused hook regressions cover no-SDP recovery and one ACK, publication disappearance, P1-to-P2 replacement, resync deduplication, retry exhaustion plus later recovery, and preserve the existing successful-first-subscription and readiness re-ACK paths.
