### PR TITLE
feat: make Live Transcript Runtime activation recoverable

### DIFF
--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -27,6 +27,7 @@ func usageText() string {
 	return `Usage:
   free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
   free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
+  free4chat-agent connect --room <room-id> --provider-claim <opaque-secret> [--instance <id>]
   free4chat-agent create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
   free4chat-agent create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
   free4chat-agent capabilities [--instance <id>] [--set <token>,<token>,...]
@@ -159,6 +160,19 @@ func run(args []string) error {
 			AgentArgs:     repeatedOption(rest, "--agent-arg"),
 			Capabilities:  repeatedOption(rest, "--capability"),
 			ProviderClaim: providerClaim,
+		})
+
+	case "connect":
+		room := option(rest, "--room")
+		providerClaim := option(rest, "--provider-claim")
+		if room == "" || providerClaim == "" || !types.ValidRuntimeProviderCredential(providerClaim) {
+			return errUsage()
+		}
+		return runViaDaemon(&daemon.IpcRequest{
+			Op:            "connect",
+			Room:          room,
+			ProviderClaim: providerClaim,
+			InstanceID:    option(rest, "--instance"),
 		})
 
 	case "create":
@@ -433,7 +447,7 @@ func runVersion(args []string) error {
 // runViaDaemon performs the version-checked daemon handshake for join, then
 // sends the IPC request and pretty-prints the result.
 func runViaDaemon(request *daemon.IpcRequest) error {
-	if request.Op == "join" {
+	if request.Op == "join" || request.Op == "connect" {
 		if err := daemon.EnsureDaemonVersion(doctor.Version); err != nil {
 			return err
 		}

--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -27,7 +27,7 @@ func usageText() string {
 	return `Usage:
   free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
   free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
-  free4chat-agent connect --room <room-id> --provider-claim <opaque-secret> [--instance <id>]
+  free4chat-agent connect --room <room-id> --provider-claim <opaque-secret>
   free4chat-agent create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
   free4chat-agent create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
   free4chat-agent capabilities [--instance <id>] [--set <token>,<token>,...]
@@ -172,7 +172,6 @@ func run(args []string) error {
 			Op:            "connect",
 			Room:          room,
 			ProviderClaim: providerClaim,
-			InstanceID:    option(rest, "--instance"),
 		})
 
 	case "create":

--- a/agent/internal/daemon/daemon.go
+++ b/agent/internal/daemon/daemon.go
@@ -489,23 +489,42 @@ func (d *Daemon) dispatchConnect(request *IpcRequest) (any, error) {
 		return nil, errors.New("runtime provider claim is malformed")
 	}
 	d.mu.Lock()
-	var match *residentInstance
+	matches := make([]*residentInstance, 0)
 	for _, instance := range d.instances {
 		if instance.roomID != request.Room {
 			continue
 		}
-		if request.InstanceID != "" && instance.instanceID != request.InstanceID {
-			continue
-		}
-		if match != nil {
-			d.mu.Unlock()
-			return nil, errors.New("multiple resident instances for this Room; pass --instance")
-		}
-		match = instance
+		matches = append(matches, instance)
 	}
 	d.mu.Unlock()
-	if match == nil {
+	if len(matches) == 0 {
 		return nil, errors.New("no resident Runtime is connected to this Room")
+	}
+
+	// A Runtime Host is daemon-owned, not Agent-owned: Pi, Codex, and Hermes
+	// residents under this daemon may all share one Host identity and one
+	// daemon-memory provider handle. Pick one resident internally and redeem
+	// once. If an invariant violation somehow yields different Host ids for the
+	// same daemon+Room, fail closed rather than asking a Human to choose an
+	// internal instance id or binding an ambiguous machine.
+	var match *residentInstance
+	var runtimeHostID string
+	for _, instance := range matches {
+		host := instance.runtime.CurrentHostProjection()
+		if host == nil {
+			return nil, errors.New("resident Runtime has no Runtime Host identity")
+		}
+		if runtimeHostID == "" {
+			runtimeHostID = host.RuntimeHostID
+			match = instance
+			continue
+		}
+		if host.RuntimeHostID != runtimeHostID {
+			return nil, errors.New("resident Runtimes for this Room have different Runtime Host identities")
+		}
+	}
+	if match == nil {
+		return nil, errors.New("no resident Runtime has a Runtime Host identity")
 	}
 	if err := match.runtime.ConnectProviderClaim(request.ProviderClaim); err != nil {
 		return nil, err

--- a/agent/internal/daemon/daemon.go
+++ b/agent/internal/daemon/daemon.go
@@ -163,6 +163,11 @@ func (d *Daemon) Dispatch(request *IpcRequest) (any, error) {
 			return nil, err
 		}
 		return d.dispatchJoin(request)
+	case "connect":
+		if err := d.rejectIfStopping(); err != nil {
+			return nil, err
+		}
+		return d.dispatchConnect(request)
 	case "create":
 		if err := d.rejectIfStopping(); err != nil {
 			return nil, err
@@ -474,6 +479,38 @@ func (d *Daemon) dispatchJoin(request *IpcRequest) (any, error) {
 		return nil, startErr
 	}
 	return statusView(residentRuntime), nil
+}
+
+func (d *Daemon) dispatchConnect(request *IpcRequest) (any, error) {
+	if request.Room == "" || request.ProviderClaim == "" {
+		return nil, errors.New("connect requires room and provider claim")
+	}
+	if !types.ValidRuntimeProviderCredential(request.ProviderClaim) {
+		return nil, errors.New("runtime provider claim is malformed")
+	}
+	d.mu.Lock()
+	var match *residentInstance
+	for _, instance := range d.instances {
+		if instance.roomID != request.Room {
+			continue
+		}
+		if request.InstanceID != "" && instance.instanceID != request.InstanceID {
+			continue
+		}
+		if match != nil {
+			d.mu.Unlock()
+			return nil, errors.New("multiple resident instances for this Room; pass --instance")
+		}
+		match = instance
+	}
+	d.mu.Unlock()
+	if match == nil {
+		return nil, errors.New("no resident Runtime is connected to this Room")
+	}
+	if err := match.runtime.ConnectProviderClaim(request.ProviderClaim); err != nil {
+		return nil, err
+	}
+	return statusView(match.runtime), nil
 }
 
 func (d *Daemon) dispatchCreate(request *IpcRequest) (any, error) {

--- a/agent/internal/daemon/daemon_test.go
+++ b/agent/internal/daemon/daemon_test.go
@@ -176,11 +176,12 @@ func TestDaemonInfoReportsBuildVersion(t *testing.T) {
 // recordingClient captures capability updates and room sends so ambiguity,
 // mutation, and cleanup flows can be asserted without network access.
 type recordingClient struct {
-	mu       sync.Mutex
-	joins    int
-	capLists [][]string
-	sent     []string
-	leftRoom bool
+	mu               sync.Mutex
+	joins            int
+	capLists         [][]string
+	sent             []string
+	leftRoom         bool
+	providerConnects int
 }
 
 func (c *recordingClient) Connect() error               { return nil }
@@ -254,6 +255,12 @@ func (c *recordingClient) LeaveRoom(string) error {
 	c.mu.Unlock()
 	return nil
 }
+func (c *recordingClient) ConnectRuntimeProvider(_ string, _ types.RuntimeHostProjection, _ string) (string, error) {
+	c.mu.Lock()
+	c.providerConnects++
+	c.mu.Unlock()
+	return "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8", nil
+}
 func (*recordingClient) Close() error { return nil }
 
 // stubAdapter satisfies types.HarnessAdapter without subprocess work.
@@ -310,6 +317,89 @@ func registerStub(t *testing.T, d *Daemon, instanceID string) stubBundle {
 		runtime:    rt,
 	})
 	return stubBundle{client: client, runtimeRef: rt}
+}
+
+// registerProviderStub adds a resident with an explicit shared Host seed and
+// provider-handle store. It models two different Harnesses (for example Pi
+// and Codex) resident under the same local Runtime daemon.
+func registerProviderStub(
+	t *testing.T,
+	d *Daemon,
+	instanceID string,
+	hostSeed string,
+	providerHandles *runtime.ProviderHandleStore,
+) stubBundle {
+	t.Helper()
+	client := &recordingClient{}
+	rt := runtime.NewResidentRuntime(runtime.Options{
+		InstanceID:      instanceID,
+		RoomID:          "shared",
+		Name:            "Stub-" + instanceID,
+		Client:          client,
+		Adapter:         &stubAdapter{name: "stub"},
+		WaitSeconds:     1,
+		HostSeed:        hostSeed,
+		ProviderHandles: providerHandles,
+	})
+	t.Cleanup(rt.Stop)
+	d.register(&residentInstance{
+		instanceID: instanceID,
+		roomID:     "shared",
+		runtime:    rt,
+	})
+	return stubBundle{client: client, runtimeRef: rt}
+}
+
+func waitForStubJoin(t *testing.T, bundle stubBundle) {
+	t.Helper()
+	if err := bundle.runtimeRef.Start(); err != nil {
+		t.Fatalf("stub residency start failed: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && bundle.joinedCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if bundle.joinedCount() == 0 {
+		t.Fatal("stub runtime never joined")
+	}
+}
+
+func TestConnectChoosesOneSameHostResidentWithoutHumanInstanceSelection(t *testing.T) {
+	d, _ := startDaemon(t)
+	providerHandles := runtime.NewProviderHandleStore()
+	pi := registerProviderStub(t, d, "pi", "shared-host-seed", providerHandles)
+	codex := registerProviderStub(t, d, "codex", "shared-host-seed", providerHandles)
+	waitForStubJoin(t, pi)
+	waitForStubJoin(t, codex)
+
+	piHost := pi.runtimeRef.CurrentHostProjection()
+	codexHost := codex.runtimeRef.CurrentHostProjection()
+	if piHost == nil || codexHost == nil || piHost.RuntimeHostID != codexHost.RuntimeHostID {
+		t.Fatalf("same daemon residents did not derive one Host: %#v %#v", piHost, codexHost)
+	}
+
+	if _, err := SendIPC(&IpcRequest{
+		Op:            "connect",
+		Room:          "shared",
+		ProviderClaim: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+	}); err != nil {
+		t.Fatalf("same-Host provider connection failed: %v", err)
+	}
+	pi.client.mu.Lock()
+	piCalls := pi.client.providerConnects
+	pi.client.mu.Unlock()
+	codex.client.mu.Lock()
+	codexCalls := codex.client.providerConnects
+	codex.client.mu.Unlock()
+	if piCalls+codexCalls != 1 {
+		t.Fatalf("provider claim redeemed %d times, want exactly once", piCalls+codexCalls)
+	}
+	if got := providerHandles.Get("shared", piHost.RuntimeHostID); got == "" {
+		t.Fatal("shared daemon provider handle was not retained")
+	}
+	if pi.runtimeRef.Status().ParticipantID == "" || codex.runtimeRef.Status().ParticipantID == "" {
+		t.Fatal("provider connection must not replace either resident Agent")
+	}
 }
 
 func TestResolveRuntimeAmbiguityContract(t *testing.T) {

--- a/agent/internal/daemon/ipc.go
+++ b/agent/internal/daemon/ipc.go
@@ -57,7 +57,7 @@ type IpcRequest struct {
 	InstanceID   string   `json:"instanceId,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
 	// ProviderClaim is a one-time opaque 256-bit capability accepted only by
-	// join. It is never copied into a response, status, workspace, or log.
+	// join/connect. It is never copied into a response, status, workspace, or log.
 	ProviderClaim       string            `json:"providerClaim,omitempty"`
 	TargetParticipantID string            `json:"targetParticipantId,omitempty"`
 	RequestID           string            `json:"requestId,omitempty"`

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.10"
+var Version = "0.5.11"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -438,6 +438,29 @@ type roomControlHandle struct {
 	ParticipantToken string `json:"participantToken"`
 }
 
+func parseRoomControlHandle(participantHandle string) (roomControlHandle, error) {
+	rawHandle, err := base64.RawURLEncoding.DecodeString(participantHandle)
+	if err != nil {
+		return roomControlHandle{}, &Error{Message: "invalid participant handle", Code: CodeToolError}
+	}
+	var handle roomControlHandle
+	if err := json.Unmarshal(rawHandle, &handle); err != nil ||
+		!validBoundedText(handle.Room, 256) || !validBoundedText(handle.ParticipantID, 256) || handle.ParticipantToken == "" {
+		return roomControlHandle{}, &Error{Message: "invalid participant handle", Code: CodeToolError}
+	}
+	return handle, nil
+}
+
+func (c *Client) roomControlEndpoint(path string) (*url.URL, error) {
+	endpoint, err := url.Parse(c.Endpoint)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+		return nil, &Error{Message: "invalid room endpoint", Code: CodeToolError}
+	}
+	endpoint.Path = path
+	endpoint.RawQuery = ""
+	return endpoint, nil
+}
+
 // AppendLiveTranscript commits a completed STT segment directly to the
 // authenticated Room control endpoint. It intentionally bypasses MCP: this
 // is a narrow Runtime-owned media side channel, never a Harness tool.
@@ -447,21 +470,14 @@ func (c *Client) AppendLiveTranscript(participantHandle string, epoch int64, seg
 		strings.TrimSpace(text) != text || !validBoundedText(text, 4000) {
 		return &Error{Message: "invalid live transcript segment", Code: CodeToolError}
 	}
-	rawHandle, err := base64.RawURLEncoding.DecodeString(participantHandle)
+	handle, err := parseRoomControlHandle(participantHandle)
 	if err != nil {
-		return &Error{Message: "invalid participant handle", Code: CodeToolError}
+		return err
 	}
-	var handle roomControlHandle
-	if err := json.Unmarshal(rawHandle, &handle); err != nil ||
-		!validBoundedText(handle.Room, 256) || !validBoundedText(handle.ParticipantID, 256) || handle.ParticipantToken == "" {
-		return &Error{Message: "invalid participant handle", Code: CodeToolError}
+	endpoint, err := c.roomControlEndpoint("/api/room/live-transcript/append")
+	if err != nil {
+		return err
 	}
-	endpoint, err := url.Parse(c.Endpoint)
-	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
-		return &Error{Message: "invalid room endpoint", Code: CodeToolError}
-	}
-	endpoint.Path = "/api/room/live-transcript/append"
-	endpoint.RawQuery = ""
 	payload, err := json.Marshal(map[string]any{
 		"epoch":               epoch,
 		"segmentId":           segmentID,
@@ -639,19 +655,51 @@ func (c *Client) ConnectRuntimeProvider(participantHandle string, host types.Run
 	if !types.ValidRuntimeProviderCredential(providerClaimHash) {
 		return "", &Error{Message: "runtime provider claim is malformed", Code: CodeToolError}
 	}
-	result, err := c.callTool("connect_runtime_provider", map[string]any{
-		"participantHandle": participantHandle,
+	handle, err := parseRoomControlHandle(participantHandle)
+	if err != nil {
+		return "", err
+	}
+	endpoint, err := c.roomControlEndpoint("/api/room/runtime-provider/connect")
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(map[string]any{
 		"runtimeHost":       host,
 		"providerClaimHash": providerClaimHash,
 	})
 	if err != nil {
-		return "", err
+		return "", &Error{Message: "encode runtime provider connection", Code: CodeTransient}
 	}
-	value, ok := result["runtimeProviderHandle"].(string)
-	if !ok || !types.ValidRuntimeProviderCredential(value) {
+	request, err := http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return "", &Error{Message: "create runtime provider request", Code: CodeTransient}
+	}
+	request.Header.Set("Content-Type", headerContentType)
+	request.Header.Set("Accept", headerContentType)
+	request.Header.Set("User-Agent", defaultUserAgent)
+	request.Header.Set("Origin", endpoint.Scheme+"://"+endpoint.Host)
+	request.Header.Set("X-Room-Id", handle.Room)
+	request.Header.Set("X-Room-Participant-Id", handle.ParticipantID)
+	request.Header.Set("X-Room-Participant-Token", handle.ParticipantToken)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return "", &Error{Message: "runtime provider request failed", Code: CodeTransient}
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		return "", &Error{Message: "runtime provider temporarily unavailable", Code: CodeTransient}
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return "", &Error{Message: "runtime provider connection rejected", Code: CodeToolError}
+	}
+	var result struct {
+		RuntimeProviderHandle string `json:"runtimeProviderHandle"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil ||
+		!types.ValidRuntimeProviderCredential(result.RuntimeProviderHandle) {
 		return "", &Error{Message: "Free4Chat returned an invalid provider result", Code: CodeToolError}
 	}
-	return value, nil
+	return result.RuntimeProviderHandle, nil
 }
 
 func (c *Client) updateRuntimeHost(participantHandle string, host types.RuntimeHostProjection, runtimeProviderHandle string) error {

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -633,6 +633,27 @@ func (c *Client) UpdateRuntimeHostWithRuntimeProvider(participantHandle string, 
 	return c.updateRuntimeHost(participantHandle, host, runtimeProviderHandle)
 }
 
+// ConnectRuntimeProvider redeems a Human-created claim for an already
+// resident Agent. It never creates a second participant or returns the claim.
+func (c *Client) ConnectRuntimeProvider(participantHandle string, host types.RuntimeHostProjection, providerClaimHash string) (string, error) {
+	if !types.ValidRuntimeProviderCredential(providerClaimHash) {
+		return "", &Error{Message: "runtime provider claim is malformed", Code: CodeToolError}
+	}
+	result, err := c.callTool("connect_runtime_provider", map[string]any{
+		"participantHandle": participantHandle,
+		"runtimeHost":       host,
+		"providerClaimHash": providerClaimHash,
+	})
+	if err != nil {
+		return "", err
+	}
+	value, ok := result["runtimeProviderHandle"].(string)
+	if !ok || !types.ValidRuntimeProviderCredential(value) {
+		return "", &Error{Message: "Free4Chat returned an invalid provider result", Code: CodeToolError}
+	}
+	return value, nil
+}
+
 func (c *Client) updateRuntimeHost(participantHandle string, host types.RuntimeHostProjection, runtimeProviderHandle string) error {
 	args := map[string]any{
 		"participantHandle": participantHandle,

--- a/agent/internal/free4chat/client_test.go
+++ b/agent/internal/free4chat/client_test.go
@@ -277,29 +277,45 @@ func TestRuntimeProviderCredentialsStayOnPrivateMCPWire(t *testing.T) {
 	}
 }
 
-func TestConnectRuntimeProviderKeepsClaimPrivateAndReturnsHandle(t *testing.T) {
+func TestConnectRuntimeProviderUsesPrivateRuntimeControlAndReturnsHandle(t *testing.T) {
 	const claimHash = "KPvm-f4hBdYhSjdaYF_67xqPZx7BiiAXvMo1U_8l44w"
 	const providerHandle = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+	var seenPath string
+	var seenHeaders http.Header
 	var captured map[string]any
-	client, _ := newTestClient(t, func(w http.ResponseWriter, body map[string]any) {
-		switch toolNameOf(body) {
-		case "connect_runtime_provider":
-			captured = toolArgs(body)
-			writeJSON(w, callResult(map[string]any{"runtimeProviderHandle": providerHandle}))
-		default:
-			respondToolsList(w)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenHeaders = r.Header.Clone()
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatal(err)
 		}
-	})
+		writeJSON(w, map[string]any{"runtimeProviderHandle": providerHandle})
+	}))
+	t.Cleanup(server.Close)
 	host := types.RuntimeHostProjection{RuntimeHostID: "host-176-provider", Speech: types.HostSpeechReadiness{STT: true}}
-	got, err := client.ConnectRuntimeProvider("participant-handle", host, claimHash)
+	handleBytes, _ := json.Marshal(map[string]string{
+		"room": "room-176", "participantId": "agent-176", "participantToken": "private-token",
+	})
+	participantHandle := base64.RawURLEncoding.EncodeToString(handleBytes)
+	client := New(server.URL + "/mcp")
+	got, err := client.ConnectRuntimeProvider(participantHandle, host, claimHash)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != providerHandle {
 		t.Fatalf("provider handle mismatch: %q", got)
 	}
-	if captured["providerClaimHash"] != claimHash {
-		t.Fatalf("claim hash missing from connect wire: %#v", captured)
+	if seenPath != "/api/room/runtime-provider/connect" ||
+		seenHeaders.Get("X-Room-Id") != "room-176" ||
+		seenHeaders.Get("X-Room-Participant-Id") != "agent-176" ||
+		seenHeaders.Get("X-Room-Participant-Token") != "private-token" {
+		t.Fatalf("wrong private runtime control wire: path=%q headers=%v", seenPath, seenHeaders)
+	}
+	if seenHeaders.Get("Mcp-Method") != "" || seenHeaders.Get("Mcp-Name") != "" {
+		t.Fatalf("provider connection must not use the public MCP tool surface: %v", seenHeaders)
+	}
+	if captured["providerClaimHash"] != claimHash || captured["runtimeHost"] == nil {
+		t.Fatalf("provider control payload mismatch: %#v", captured)
 	}
 	if _, present := captured["runtimeProviderHandle"]; present {
 		t.Fatal("connect must not send an existing provider handle")

--- a/agent/internal/free4chat/client_test.go
+++ b/agent/internal/free4chat/client_test.go
@@ -277,6 +277,35 @@ func TestRuntimeProviderCredentialsStayOnPrivateMCPWire(t *testing.T) {
 	}
 }
 
+func TestConnectRuntimeProviderKeepsClaimPrivateAndReturnsHandle(t *testing.T) {
+	const claimHash = "KPvm-f4hBdYhSjdaYF_67xqPZx7BiiAXvMo1U_8l44w"
+	const providerHandle = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+	var captured map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, body map[string]any) {
+		switch toolNameOf(body) {
+		case "connect_runtime_provider":
+			captured = toolArgs(body)
+			writeJSON(w, callResult(map[string]any{"runtimeProviderHandle": providerHandle}))
+		default:
+			respondToolsList(w)
+		}
+	})
+	host := types.RuntimeHostProjection{RuntimeHostID: "host-176-provider", Speech: types.HostSpeechReadiness{STT: true}}
+	got, err := client.ConnectRuntimeProvider("participant-handle", host, claimHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != providerHandle {
+		t.Fatalf("provider handle mismatch: %q", got)
+	}
+	if captured["providerClaimHash"] != claimHash {
+		t.Fatalf("claim hash missing from connect wire: %#v", captured)
+	}
+	if _, present := captured["runtimeProviderHandle"]; present {
+		t.Fatal("connect must not send an existing provider handle")
+	}
+}
+
 // #165: explicit targets ride the existing send_text tool arguments only
 // when present; the ordinary unaddressed payload must stay byte-compatible.
 func TestSendTextCarriesExplicitTargets(t *testing.T) {

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -301,6 +301,37 @@ func (r *ResidentRuntime) CurrentCapabilities() []string {
 	return append([]string(nil), r.advertisedCaps...)
 }
 
+// ConnectProviderClaim binds this already-running resident Runtime Host to a
+// Human-created Room claim. The existing participant remains the sole Agent;
+// only the private daemon-memory provider handle is updated.
+func (r *ResidentRuntime) ConnectProviderClaim(providerClaim string) error {
+	if !types.ValidRuntimeProviderCredential(providerClaim) {
+		return errors.New("runtime provider claim is malformed")
+	}
+	handle, err := r.requireHandle()
+	if err != nil {
+		return err
+	}
+	host := r.CurrentHostProjection()
+	if host == nil {
+		return errors.New("runtime provider connection requires a Runtime Host identity")
+	}
+	providerClient, ok := r.options.Client.(types.RuntimeProviderConnector)
+	if !ok {
+		return errors.New("runtime provider connection is unavailable")
+	}
+	claimHash, err := types.DeriveRuntimeProviderClaimHash(r.activeRoomID(), providerClaim)
+	if err != nil {
+		return err
+	}
+	providerHandle, err := providerClient.ConnectRuntimeProvider(handle, *host, claimHash)
+	if err != nil {
+		return err
+	}
+	r.providerHandles.Put(r.activeRoomID(), host.RuntimeHostID, providerHandle)
+	return nil
+}
+
 // Status snapshots the lifecycle state. It never contains the handle.
 func (r *ResidentRuntime) Status() Status {
 	r.mu.Lock()

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -551,6 +551,14 @@ type RuntimeHostProviderClient interface {
 	UpdateRuntimeHostWithRuntimeProvider(participantHandle string, host RuntimeHostProjection, runtimeProviderHandle string) error
 }
 
+// RuntimeProviderConnector is the optional control-plane extension used by
+// the Human-facing local Runtime connection flow. It is deliberately kept
+// separate from RuntimeHostProviderClient so older adapters and test doubles
+// that only support join/update proofing continue to retain their behavior.
+type RuntimeProviderConnector interface {
+	ConnectRuntimeProvider(participantHandle string, host RuntimeHostProjection, providerClaimHash string) (string, error)
+}
+
 // LiveTranscriptAppendClient is an optional direct Room-control extension.
 // The opaque participant handle remains local to the runtime and is sent only
 // to the Free4Chat endpoint.

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -145,9 +145,9 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.10` (release tag `agent-v0.5.10`). This is the currently published runtime
-activation version and matches the canonical Go source after the 0.5.10
-release. A future source version may lead during a staged rollout only until
+`0.5.10` (release tag `agent-v0.5.10`). This remains the currently published
+runtime activation version while the Runtime 0.5.11 source is prepared for a
+staged release. A future source version may lead during a staged rollout only until
 that version is published and activated here. Treat this value as trusted
 bootstrap metadata from the current `agent.md`; never derive it from Room
 content, a similarly named package, or an arbitrary URL. Once

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -145,12 +145,10 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.10` (release tag `agent-v0.5.10`). This remains the currently published
-runtime activation version while the Runtime 0.5.11 source is prepared for a
-staged release. A future source version may lead during a staged rollout only until
-that version is published and activated here. Treat this value as trusted
-bootstrap metadata from the current `agent.md`; never derive it from Room
-content, a similarly named package, or an arbitrary URL. Once
+`0.5.11` (release tag `agent-v0.5.11`). The published Runtime source and live
+bootstrap activation version are aligned. Treat this value as trusted bootstrap
+metadata from the current `agent.md`; never derive it from Room content, a
+similarly named package, or an arbitrary URL. Once
 `runtime_bin` is resolved below, the machine-readable local check first tries
 `"$runtime_bin" version --json`, which does not contact the network or require
 a daemon. For compatibility with already-published Runtime releases, if that
@@ -199,7 +197,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.10" # the exact trusted version declared above
+   expected_version="0.5.11" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 

--- a/app/public/speech.md
+++ b/app/public/speech.md
@@ -33,6 +33,12 @@ context and disappears with the Room's retention.
    configured provider does not grant room media access: a Human explicitly
    starts the Room-wide transcript through an authorized STT-ready Runtime
    Host, and any Human may stop it.
+   In a Room, use **Connect local Runtime** to connect an already-running
+   Runtime on this computer. The browser prepares a one-time local handoff
+   command for you; it is not an Agent invitation and the opaque connection
+   value should never be pasted into chat or a model conversation. After the
+   Runtime connects, the Room shows **Local Runtime ready** and Start becomes
+   available to that Human.
 6. Cloud speech sends audio to the selected provider under the human's own
    provider account and credentials.
 7. Raw audio is not intended to be persisted by Free4Chat.

--- a/app/src/common/runtimeProviderCredential.ts
+++ b/app/src/common/runtimeProviderCredential.ts
@@ -4,6 +4,8 @@
 export const RUNTIME_PROVIDER_CLAIM_DOMAIN = "free4chat-runtime-provider-v1"
 export const RUNTIME_PROVIDER_HANDLE_DOMAIN =
   "free4chat-runtime-provider-handle-v1"
+export const RUNTIME_PROVIDER_REATTACH_DOMAIN =
+  "free4chat-runtime-provider-reattach-v1"
 
 const RAW_SECRET_BYTES = 32
 const BASE64URL_256_PATTERN = /^[A-Za-z0-9_-]{43}$/
@@ -112,5 +114,19 @@ export async function hashRuntimeProviderHandle(
     roomId,
     runtimeHostId,
     runtimeProviderHandle,
+  ])
+}
+
+// Browser refresh recovery proof. The secret is kept only in sessionStorage;
+// Room state stores the derived hash and a short reattachment deadline.
+export async function deriveRuntimeProviderReattachHash(
+  roomId: string,
+  reattachSecret: string
+): Promise<string> {
+  if (!roomId || !isRuntimeProviderSecret(reattachSecret))
+    throw new Error("invalid_runtime_provider_reattach")
+  return sha256Base64Url(RUNTIME_PROVIDER_REATTACH_DOMAIN, [
+    roomId,
+    reattachSecret,
   ])
 }

--- a/app/src/components/LiveTranscript.test.tsx
+++ b/app/src/components/LiveTranscript.test.tsx
@@ -71,6 +71,31 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
     ).toBeInTheDocument()
   })
 
+  it("offers an understandable local Runtime connection when no Host is authorized", () => {
+    const onConnect = vi.fn()
+    render(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={onConnect}
+      />
+    )
+    expect(
+      screen.getByText("No transcription Runtime connected")
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole("button", { name: "Connect local Runtime" })
+    )
+    expect(onConnect).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByText(/provider claim|runtimeHostId/i)
+    ).not.toBeInTheDocument()
+  })
+
   it("offers a small Runtime choice only when the Human has multiple eligible Hosts", () => {
     const onStart = vi.fn()
     render(
@@ -230,5 +255,107 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
       />
     )
     expect(screen.getByText("Provided by Alice")).toBeInTheDocument()
+  })
+
+  it("follows the newest committed segment when the viewer is near the bottom", () => {
+    const { container, rerender } = render(
+      <LiveTranscriptSegments
+        segments={[
+          {
+            segmentId: "one",
+            epoch: 1,
+            sequence: 1,
+            participantId: "human-a",
+            speaker: "Alice",
+            text: "one",
+            createdAt: 1,
+          },
+        ]}
+      />
+    )
+    const list = container.querySelector("ol")!
+    Object.defineProperties(list, {
+      clientHeight: { configurable: true, value: 40 },
+      scrollHeight: { configurable: true, value: 100 },
+    })
+    list.scrollTop = 60
+    rerender(
+      <LiveTranscriptSegments
+        segments={[
+          {
+            segmentId: "one",
+            epoch: 1,
+            sequence: 1,
+            participantId: "human-a",
+            speaker: "Alice",
+            text: "one",
+            createdAt: 1,
+          },
+          {
+            segmentId: "two",
+            epoch: 1,
+            sequence: 2,
+            participantId: "human-b",
+            speaker: "Bob",
+            text: "two",
+            createdAt: 2,
+          },
+        ]}
+      />
+    )
+    expect(list.scrollTop).toBe(100)
+  })
+
+  it("preserves an upward scroll and offers jump to latest", () => {
+    const { container, rerender } = render(
+      <LiveTranscriptSegments
+        segments={[
+          {
+            segmentId: "one",
+            epoch: 1,
+            sequence: 1,
+            participantId: "human-a",
+            speaker: "Alice",
+            text: "one",
+            createdAt: 1,
+          },
+        ]}
+      />
+    )
+    const list = container.querySelector("ol")!
+    Object.defineProperties(list, {
+      clientHeight: { configurable: true, value: 40 },
+      scrollHeight: { configurable: true, value: 100 },
+    })
+    list.scrollTop = 0
+    fireEvent.scroll(list)
+    rerender(
+      <LiveTranscriptSegments
+        segments={[
+          {
+            segmentId: "one",
+            epoch: 1,
+            sequence: 1,
+            participantId: "human-a",
+            speaker: "Alice",
+            text: "one",
+            createdAt: 1,
+          },
+          {
+            segmentId: "two",
+            epoch: 1,
+            sequence: 2,
+            participantId: "human-b",
+            speaker: "Bob",
+            text: "two",
+            createdAt: 2,
+          },
+        ]}
+      />
+    )
+    expect(list.scrollTop).toBe(0)
+    const jump = screen.getByRole("button", { name: /Jump to latest/i })
+    fireEvent.click(jump)
+    expect(list.scrollTop).toBe(100)
   })
 })

--- a/app/src/components/LiveTranscript.tsx
+++ b/app/src/components/LiveTranscript.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
@@ -23,6 +23,8 @@ interface LiveTranscriptControlProps {
   mediaAvailable: boolean
   onStart: (runtimeHostId: string) => void
   onStop: () => void
+  onConnect?: () => void
+  runtimeConnectionStatus?: "idle" | "preparing" | "copied"
 }
 
 interface LiveTranscriptSegmentsProps {
@@ -76,6 +78,8 @@ export function LiveTranscriptControl({
   mediaAvailable = false,
   onStart,
   onStop,
+  onConnect,
+  runtimeConnectionStatus = "idle",
 }: LiveTranscriptControlProps) {
   const [chooserOpen, setChooserOpen] = useState(false)
   const authorizedHosts = mediaAvailable
@@ -114,12 +118,41 @@ export function LiveTranscriptControl({
   }
 
   const unavailable = authorizedHosts.length === 0
+  if (unavailable && onConnect) {
+    return (
+      <div
+        className="relative flex items-center gap-2"
+        aria-label="Live Transcript controls"
+      >
+        <span className="text-xs text-gray-300">Live Transcript</span>
+        <span className="hidden text-xs text-gray-500 sm:inline">
+          No transcription Runtime connected
+        </span>
+        <button
+          type="button"
+          onClick={onConnect}
+          disabled={runtimeConnectionStatus === "preparing"}
+          className="rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:cursor-wait disabled:opacity-50"
+          title="Connect the Runtime installed on this computer"
+        >
+          {runtimeConnectionStatus === "preparing"
+            ? "Connecting..."
+            : runtimeConnectionStatus === "copied"
+            ? "Connection command copied"
+            : "Connect local Runtime"}
+        </button>
+      </div>
+    )
+  }
   return (
     <div
       className="relative flex items-center gap-2"
       aria-label="Live Transcript controls"
     >
       <span className="text-xs text-gray-300">Live Transcript</span>
+      <span className="hidden text-xs text-gray-500 sm:inline">
+        Local Runtime ready
+      </span>
       <button
         type="button"
         onClick={() => {
@@ -163,17 +196,56 @@ export function LiveTranscriptControl({
 export function LiveTranscriptSegments({
   segments = [],
 }: LiveTranscriptSegmentsProps) {
-  if (segments.length === 0) return null
-  const ordered = [...segments].sort(
-    (left, right) => left.sequence - right.sequence
+  const ordered = useMemo(
+    () => [...segments].sort((left, right) => left.sequence - right.sequence),
+    [segments]
   )
+  const latestSequence = ordered[ordered.length - 1]?.sequence
+  const listRef = useRef<HTMLOListElement>(null)
+  const nearBottomRef = useRef(true)
+  const [showNew, setShowNew] = useState(false)
+
+  useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    if (nearBottomRef.current) {
+      list.scrollTop = list.scrollHeight
+      setShowNew(false)
+    } else {
+      setShowNew(true)
+    }
+  }, [ordered.length, latestSequence])
+
+  const onScroll = () => {
+    const list = listRef.current
+    if (!list) return
+    nearBottomRef.current =
+      list.scrollHeight - list.scrollTop - list.clientHeight <= 24
+    if (nearBottomRef.current) setShowNew(false)
+  }
+
+  const jumpToLatest = () => {
+    const list = listRef.current
+    if (!list) return
+    nearBottomRef.current = true
+    list.scrollTop = list.scrollHeight
+    setShowNew(false)
+  }
+
+  if (segments.length === 0) return null
+
   return (
     <section
       className="mx-4 mt-1 flex flex-none flex-col rounded border border-emerald-700/40 bg-emerald-950/20 px-4 py-2"
       aria-label="Live Transcript"
     >
       <h2 className="text-sm font-medium text-emerald-100">Live Transcript</h2>
-      <ol className="mt-1 max-h-40 space-y-1 overflow-y-auto text-sm text-gray-200">
+      <ol
+        ref={listRef}
+        onScroll={onScroll}
+        className="mt-1 max-h-40 space-y-1 overflow-y-auto text-sm text-gray-200"
+        aria-live="polite"
+      >
         {ordered.map((segment) => (
           <li
             key={segment.segmentId}
@@ -186,6 +258,15 @@ export function LiveTranscriptSegments({
           </li>
         ))}
       </ol>
+      {showNew && (
+        <button
+          type="button"
+          onClick={jumpToLatest}
+          className="mt-1 self-end rounded border border-emerald-700/50 px-2 py-0.5 text-xs text-emerald-200 hover:bg-emerald-900/40"
+        >
+          New transcript · Jump to latest
+        </button>
+      )}
     </section>
   )
 }

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -67,7 +67,9 @@ const baseHookReturn = {
   liveTranscriptMediaAvailable: false,
   startLiveTranscript: vi.fn(),
   stopLiveTranscript: vi.fn(),
-  createRuntimeProviderClaim: vi.fn(),
+  connectLocalRuntime: vi.fn(),
+  runtimeConnectionStatus: "idle" as const,
+  leaveRoom: vi.fn(),
 }
 
 describe("RoomContent — Turnstile widget lifecycle", () => {
@@ -154,41 +156,22 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(container.querySelector('[id^="cf-chl-widget"]')).toBeNull()
   })
 
-  it("waits for the Room claim ACK before preparing an invite, then writes only from a second click", async () => {
-    let resolveClaim: (value: { providerClaimSecret: string }) => void
-    const claim = new Promise<{ providerClaimSecret: string }>((resolve) => {
-      resolveClaim = resolve
-    })
-    const createRuntimeProviderClaim = vi.fn(() => claim)
+  it("copies an ordinary Agent invite without creating a Runtime provider claim", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
     mockUseSfuChatRoom.mockReturnValue({
       ...baseHookReturn,
       connectionStatus: "connected",
-      createRuntimeProviderClaim,
     })
 
     render(
       <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
     )
     fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
-    expect(createRuntimeProviderClaim).toHaveBeenCalledTimes(1)
-    expect(writeText).not.toHaveBeenCalled()
-    expect(
-      screen.getByRole("button", { name: "Preparing invite..." })
-    ).toBeDisabled()
-
-    await act(async () => {
-      resolveClaim!({
-        providerClaimSecret: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
-      })
-      await claim
-    })
-    expect(screen.getByRole("button", { name: "Copy invite" })).toBeEnabled()
-    expect(writeText).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy invite" }))
     expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("Join my temporary")
+    )
+    expect(writeText).not.toHaveBeenCalledWith(
       expect.stringContaining("--provider-claim")
     )
     await waitFor(() =>
@@ -196,28 +179,23 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     )
   })
 
-  it("keeps a prepared invite available and shows a retryable clipboard error", async () => {
+  it("shows a retryable clipboard error for an ordinary invite", async () => {
     const writeText = vi.fn().mockRejectedValue(new Error("blocked"))
     Object.assign(navigator, { clipboard: { writeText } })
     mockUseSfuChatRoom.mockReturnValue({
       ...baseHookReturn,
       connectionStatus: "connected",
-      createRuntimeProviderClaim: vi.fn().mockResolvedValue({
-        providerClaimSecret: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
-      }),
     })
 
     render(
       <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
     )
     fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
-    const copy = await screen.findByRole("button", { name: "Copy invite" })
-    fireEvent.click(copy)
 
     expect(await screen.findByRole("status")).toHaveTextContent(
       "Clipboard access was blocked"
     )
-    expect(screen.getByRole("button", { name: "Copy invite" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Invite Agent" })).toBeEnabled()
   })
 
   it("uses the Room-wide Live Transcript control without replacing Agent Voice", () => {

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -15,10 +15,7 @@ import { LiveTranscriptControl, LiveTranscriptSegments } from "./LiveTranscript"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
-import {
-  buildAgentInvitePrompt,
-  RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED,
-} from "../common/agentInvite"
+import { buildAgentInvitePrompt } from "../common/agentInvite"
 import { createCollabAnalyticsTracker } from "../common/collabAnalytics"
 import type { UserInfo } from "../common/types"
 import {
@@ -102,11 +99,8 @@ export default function RoomContent({
   const router = useRouter()
   const [roomLinkCopied, setRoomLinkCopied] = useState(false)
   const [agentInviteCopied, setAgentInviteCopied] = useState(false)
-  const [preparedAgentInvite, setPreparedAgentInvite] = useState<string | null>(
-    null
-  )
-  const [agentInvitePreparing, setAgentInvitePreparing] = useState(false)
   const [agentInviteError, setAgentInviteError] = useState("")
+  const [runtimeConnectError, setRuntimeConnectError] = useState("")
   const [pendingFiles, setPendingFiles] = useState<
     {
       id: string
@@ -162,7 +156,9 @@ export default function RoomContent({
     stopLiveTranscript,
     agentVoiceMediaAvailable,
     setAgentVoice,
-    createRuntimeProviderClaim,
+    connectLocalRuntime,
+    runtimeConnectionStatus,
+    leaveRoom,
     localParticipantId,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
@@ -483,7 +479,6 @@ export default function RoomContent({
           surface: "room",
           roomType: resolvedRoomType,
         })
-        setPreparedAgentInvite(null)
         setAgentInviteError("")
         setAgentInviteCopied(true)
         setTimeout(() => setAgentInviteCopied(false), 2000)
@@ -497,32 +492,18 @@ export default function RoomContent({
 
   const copyAgentInvite = () => {
     if (typeof window === "undefined") return
-    if (preparedAgentInvite) {
-      writeAgentInvite(preparedAgentInvite)
-      return
-    }
-    if (!RUNTIME_PROVIDER_CLAIM_INVITES_ENABLED) {
-      writeAgentInvite(buildAgentInvitePrompt(roomName))
-      return
-    }
-    setAgentInviteCopied(false)
-    setAgentInvitePreparing(true)
-    setAgentInviteError("")
-    void createRuntimeProviderClaim()
-      .then(({ providerClaimSecret }) => {
-        // The raw claim becomes browser-memory-only invite content only after
-        // the authenticated Room acknowledgement. A second explicit click
-        // then writes it while its transient user activation is still valid.
-        setPreparedAgentInvite(
-          buildAgentInvitePrompt(roomName, { providerClaimSecret })
-        )
-      })
-      .catch(() => {
-        setAgentInviteError("Unable to prepare the Agent invite. Try again.")
-      })
-      .then(() => {
-        setAgentInvitePreparing(false)
-      })
+    writeAgentInvite(buildAgentInvitePrompt(roomName))
+  }
+
+  const handleConnectRuntime = () => {
+    setRuntimeConnectError("")
+    void connectLocalRuntime().catch((connectError) => {
+      setRuntimeConnectError(
+        connectError instanceof Error
+          ? connectError.message
+          : "Unable to connect the local Runtime"
+      )
+    })
   }
 
   if (connectionStatus === "failed") {
@@ -622,21 +603,10 @@ export default function RoomContent({
           <button
             type="button"
             onClick={copyAgentInvite}
-            disabled={agentInvitePreparing}
             className="rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-xs text-blue-200 hover:bg-blue-800/50"
-            title={
-              preparedAgentInvite
-                ? "Copy prepared Agent invite prompt"
-                : "Copy Agent invite prompt"
-            }
+            title="Copy Agent invite prompt"
           >
-            {agentInviteCopied
-              ? "Copied!"
-              : agentInvitePreparing
-              ? "Preparing invite..."
-              : preparedAgentInvite
-              ? "Copy invite"
-              : "Invite Agent"}
+            {agentInviteCopied ? "Copied!" : "Invite Agent"}
           </button>
           {agentInviteError && (
             <span role="status" className="text-xs text-rose-300">
@@ -652,10 +622,20 @@ export default function RoomContent({
             mediaAvailable={liveTranscriptMediaAvailable}
             onStart={handleStartLiveTranscript}
             onStop={handleStopLiveTranscript}
+            onConnect={handleConnectRuntime}
+            runtimeConnectionStatus={runtimeConnectionStatus}
           />
+          {runtimeConnectError && (
+            <span role="status" className="text-xs text-rose-300">
+              {runtimeConnectError}
+            </span>
+          )}
           <button
             type="button"
-            onClick={() => router.push("/")}
+            onClick={() => {
+              leaveRoom()
+              router.push("/")
+            }}
             className="rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700"
           >
             Leave

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -68,6 +68,9 @@ import {
   markRuntimeHostProviderMember,
   normalizeRuntimeHostProviders,
   projectRuntimeHostProviders,
+  markRuntimeHostProviderDisconnected,
+  markRuntimeHostProviderConnected,
+  reattachRuntimeHostProvider,
   redeemRuntimeHostProviderClaim,
   removeRuntimeHostProviderForHuman,
   verifyRuntimeHostProviderProof,
@@ -257,6 +260,7 @@ type ControlRequest =
       participant: Omit<RoomParticipant, "connected" | "lastSeenAt"> & {
         // Humans never project a Runtime Host; any payload is dropped.
         runtimeHost?: RuntimeHostProjection
+        runtimeProviderReattachProofHash?: string
       }
     }
   | {
@@ -402,6 +406,15 @@ type ControlRequest =
       token: string
       runtimeHost: RuntimeHostProjection
       runtimeProviderHandle?: string
+    }
+  | {
+      // Re-prove an existing resident Runtime Host against a Human-created
+      // one-time claim without creating a second Agent participant.
+      action: "agent-connect-runtime-provider"
+      participantId: string
+      token: string
+      runtimeHost: RuntimeHostProjection
+      providerClaimHash: string
     }
   | {
       // #106 Phase B: one structured collaboration envelope. The request kind
@@ -560,6 +573,7 @@ type ClientMessage =
       type: "runtime-provider-claim-create"
       requestId: string
       providerClaimHash: string
+      reattachProofHash?: string
     }
 
 export class RoomSession extends DurableObject<RoomSessionEnv> {
@@ -1737,6 +1751,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       ) {
         return this.json({ error: "invalid_participant_kind" }, 400)
       }
+      const reattachProofHash = !isAgent
+        ? request.participant.runtimeProviderReattachProofHash
+        : undefined
+      if (
+        reattachProofHash !== undefined &&
+        !isRuntimeProviderClaimHash(reattachProofHash)
+      )
+        return this.json({ error: "invalid_runtime_provider_reattach" }, 400)
       // #106 Phase A: a joining agent may advertise an explicit bounded
       // capability list chosen by its Runtime/Harness. Invalid input rejects
       // the join — never repaired silently (see do/collab.ts).
@@ -1763,6 +1785,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       delete (participantWire as Record<string, unknown>).runtimeHost
       delete (participantWire as Record<string, unknown>).providerClaimHash
       delete (participantWire as Record<string, unknown>).runtimeProviderHandle
+      delete (participantWire as Record<string, unknown>)
+        .runtimeProviderReattachProofHash
       const participant: RoomParticipant = {
         ...participantWire,
         connected: isAgent,
@@ -1776,6 +1800,34 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
                 : {}),
             }
           : {}),
+      }
+      if (!isAgent && reattachProofHash) {
+        const reattached = reattachRuntimeHostProvider({
+          providers: room.runtimeHostProviders ?? {},
+          participants: Object.values(room.participants),
+          reattachProofHash,
+          humanParticipantId: participant.id,
+          runtimeHosts: room.runtimeHosts,
+          now,
+          graceMs: RECONNECT_GRACE_MS,
+        })
+        if (reattached.ok === false) {
+          // A stale sessionStorage value must not make a Human unable to
+          // enter a Room after the old association has already expired or
+          // been explicitly removed. While a proof-bearing association is
+          // still live, however, reject every non-matching proof so a copied
+          // or unrelated value can never be used as a silent re-pairing.
+          const hasLiveReattachCandidate = Object.values(
+            room.runtimeHostProviders ?? {}
+          ).some(
+            (association) =>
+              association.reattachProofHash !== undefined &&
+              (association.reattachExpiresAt === undefined ||
+                association.reattachExpiresAt > now)
+          )
+          if (hasLiveReattachCandidate)
+            return this.json({ error: reattached.error }, 403)
+        } else room.runtimeHostProviders = reattached.providers
       }
       if (registeredRuntimeHost && providerClaimHash && providerHandleHash) {
         const redemption = redeemRuntimeHostProviderClaim({
@@ -2114,6 +2166,59 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return this.json({
         runtimeHost: host,
         runtimeHosts: projectRuntimeHosts(room.runtimeHosts),
+        expiresAt: room.expiresAt,
+      })
+    }
+
+    if (request.action === "agent-connect-runtime-provider") {
+      const validated = validateRuntimeHost(request.runtimeHost)
+      if (!validated.ok)
+        return this.json(
+          { error: validated.error, reason: validated.reason },
+          400
+        )
+      if (!isRuntimeProviderClaimHash(request.providerClaimHash))
+        return this.json({ error: "invalid_runtime_provider_claim" }, 400)
+      const host = validated.runtimeHost
+      const providerHandle = createRuntimeProviderHandle()
+      const providerHandleHash = await hashRuntimeProviderHandle(
+        this.ctx.id.toString(),
+        host.runtimeHostId,
+        providerHandle
+      )
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      if (participant.kind !== "agent")
+        return this.json({ error: "agent_only" }, 403)
+      const redemption = redeemRuntimeHostProviderClaim({
+        providers: room.runtimeHostProviders ?? {},
+        pendingClaims: room.runtimeHostProviderClaims ?? {},
+        participants: Object.values(room.participants),
+        runtimeHost: host,
+        claimHash: request.providerClaimHash,
+        providerHandleHash,
+        verifiedParticipantId: participant.id,
+        now: Date.now(),
+      })
+      if (redemption.ok === false)
+        return this.json({ error: redemption.error }, 403)
+      room.runtimeHostProviders = redemption.providers
+      room.runtimeHostProviderClaims = redemption.pendingClaims
+      room.runtimeHosts = registerRuntimeHost(room.runtimeHosts, host)
+      participant.runtimeHostId = host.runtimeHostId
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      await this.scheduleNextAlarm(room)
+      await this.broadcastState(room)
+      return this.json({
+        runtimeProviderHandle: providerHandle,
+        runtimeHost: host,
         expiresAt: room.expiresAt,
       })
     }
@@ -3290,7 +3395,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (
         typeof message.requestId !== "string" ||
         message.requestId.length === 0 ||
-        !isRuntimeProviderClaimHash(message.providerClaimHash)
+        !isRuntimeProviderClaimHash(message.providerClaimHash) ||
+        (message.reattachProofHash !== undefined &&
+          !isRuntimeProviderClaimHash(message.reattachProofHash))
       ) {
         socket.send(JSON.stringify({ type: "error", error: "invalid_request" }))
         return
@@ -3300,6 +3407,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         participants: Object.values(room.participants),
         humanParticipantId: participant.id,
         claimHash: message.providerClaimHash,
+        reattachProofHash: message.reattachProofHash,
         now: Date.now(),
       })
       if (claim.ok === false) {
@@ -3733,6 +3841,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       participant.connected = true
       participant.connectionNonce = connectionNonce
       participant.lastSeenAt = Date.now()
+      room.runtimeHostProviders = markRuntimeHostProviderConnected({
+        providers: room.runtimeHostProviders ?? {},
+        humanParticipantId: participant.id,
+      })
       await this.saveRoom(room)
       this.ctx.acceptWebSocket(server)
       server.serializeAttachment({ participantId, token, connectionNonce })
@@ -3967,6 +4079,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participant.connected = false
     participant.lastSeenAt = Date.now()
     participant.connectionNonce = undefined
+    room.runtimeHostProviders = markRuntimeHostProviderDisconnected({
+      providers: room.runtimeHostProviders ?? {},
+      humanParticipantId: participant.id,
+      now: participant.lastSeenAt,
+      graceMs: RECONNECT_GRACE_MS,
+    })
     this.clearAgentVoiceReadiness(room)
     await this.saveRoom(room)
     await this.scheduleNextAlarm(room)

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -64,6 +64,8 @@ import {
 import {
   createRuntimeHostProviderClaim,
   canHumanUseRuntimeHost,
+  completeDeferredRuntimeHostProviderReattach,
+  deferRuntimeHostProviderReattach,
   garbageCollectRuntimeHostProviders,
   markRuntimeHostProviderMember,
   normalizeRuntimeHostProviders,
@@ -1298,7 +1300,32 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       deadlines.push(Date.now() + MEDIA_CLEANUP_RETRY_MS)
     for (const claim of Object.values(room.runtimeHostProviderClaims ?? {}))
       deadlines.push(claim.expiresAt)
+    for (const association of Object.values(room.runtimeHostProviders ?? {}))
+      if (association.pendingReattach)
+        deadlines.push(association.pendingReattach.expiresAt)
     await this.ctx.storage.setAlarm(Math.min(...deadlines))
+  }
+
+  // A same-browser refresh replaces only the exact Human binding it proved.
+  // Keep a currently active producer in its epoch: moving this ownership
+  // atomically with the provider association avoids lifecycle normalization
+  // treating the old Human id as an invalid producer and stopping speech.
+  private preserveLiveTranscriptOwnerAcrossRuntimeReattach(
+    room: RoomRecord,
+    runtimeHostId: string,
+    previousHumanParticipantId: string,
+    humanParticipantId: string
+  ): void {
+    if (
+      room.liveTranscript.active &&
+      room.liveTranscript.producerRuntimeHostId === runtimeHostId &&
+      room.liveTranscript.startedByHumanParticipantId ===
+        previousHumanParticipantId
+    )
+      room.liveTranscript = {
+        ...room.liveTranscript,
+        startedByHumanParticipantId: humanParticipantId,
+      }
   }
 
   // Runtime Host projection garbage collection and provider-association
@@ -1813,23 +1840,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         })
         if (reattached.ok === true) {
           room.runtimeHostProviders = reattached.providers
-          // A same-browser refresh replaces only the exact Human binding it
-          // proved. Keep a currently active producer in its epoch: moving
-          // this ownership atomically with the provider association avoids a
-          // later lifecycle normalization treating the old Human id as an
-          // invalid producer and stopping transcription.
-          if (
-            room.liveTranscript.active &&
-            room.liveTranscript.producerRuntimeHostId ===
-              reattached.runtimeHostId &&
-            room.liveTranscript.startedByHumanParticipantId ===
-              reattached.previousHumanParticipantId
-          ) {
-            room.liveTranscript = {
-              ...room.liveTranscript,
-              startedByHumanParticipantId: participant.id,
-            }
-          }
+          this.preserveLiveTranscriptOwnerAcrossRuntimeReattach(
+            room,
+            reattached.runtimeHostId,
+            reattached.previousHumanParticipantId,
+            participant.id
+          )
         } else if (
           reattached.ok === false &&
           // A proof that names an *active* bound Human is a takeover attempt
@@ -1839,6 +1855,26 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           reattached.error === "runtime_provider_claim_human_invalid"
         )
           return this.json({ error: reattached.error }, 403)
+        else {
+          // The replacement registration can arrive before the prior page's
+          // WebSocket close. Reserve only its exact proof and complete this
+          // bounded handoff when the old connection actually closes; do not
+          // retry /api/sfu/session because it creates an upstream SFU session
+          // before this Room registration is attempted.
+          const deferred = deferRuntimeHostProviderReattach({
+            providers: room.runtimeHostProviders ?? {},
+            participants: Object.values(room.participants),
+            reattachProofHash,
+            humanParticipantId: participant.id,
+            runtimeHosts: room.runtimeHosts,
+            now,
+            graceMs: RECONNECT_GRACE_MS,
+          })
+          if (deferred.ok === true)
+            room.runtimeHostProviders = deferred.providers
+          else if (deferred.error === "runtime_provider_claim_human_invalid")
+            return this.json({ error: deferred.error }, 403)
+        }
       }
       if (registeredRuntimeHost && providerClaimHash && providerHandleHash) {
         const redemption = redeemRuntimeHostProviderClaim({
@@ -4096,6 +4132,21 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       now: participant.lastSeenAt,
       graceMs: RECONNECT_GRACE_MS,
     })
+    const deferredReattach = completeDeferredRuntimeHostProviderReattach({
+      providers: room.runtimeHostProviders ?? {},
+      participants: Object.values(room.participants),
+      disconnectedHumanParticipantId: participant.id,
+      runtimeHosts: room.runtimeHosts,
+      now: participant.lastSeenAt,
+    })
+    room.runtimeHostProviders = deferredReattach.providers
+    for (const reattached of deferredReattach.reattached)
+      this.preserveLiveTranscriptOwnerAcrossRuntimeReattach(
+        room,
+        reattached.runtimeHostId,
+        reattached.previousHumanParticipantId,
+        reattached.humanParticipantId
+      )
     this.clearAgentVoiceReadiness(room)
     await this.saveRoom(room)
     await this.scheduleNextAlarm(room)

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1811,23 +1811,34 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           now,
           graceMs: RECONNECT_GRACE_MS,
         })
-        if (reattached.ok === false) {
-          // A stale sessionStorage value must not make a Human unable to
-          // enter a Room after the old association has already expired or
-          // been explicitly removed. While a proof-bearing association is
-          // still live, however, reject every non-matching proof so a copied
-          // or unrelated value can never be used as a silent re-pairing.
-          const hasLiveReattachCandidate = Object.values(
-            room.runtimeHostProviders ?? {}
-          ).some(
-            (association) =>
-              association.reattachProofHash !== undefined &&
-              (association.reattachExpiresAt === undefined ||
-                association.reattachExpiresAt > now)
-          )
-          if (hasLiveReattachCandidate)
-            return this.json({ error: reattached.error }, 403)
-        } else room.runtimeHostProviders = reattached.providers
+        if (reattached.ok === true) {
+          room.runtimeHostProviders = reattached.providers
+          // A same-browser refresh replaces only the exact Human binding it
+          // proved. Keep a currently active producer in its epoch: moving
+          // this ownership atomically with the provider association avoids a
+          // later lifecycle normalization treating the old Human id as an
+          // invalid producer and stopping transcription.
+          if (
+            room.liveTranscript.active &&
+            room.liveTranscript.producerRuntimeHostId ===
+              reattached.runtimeHostId &&
+            room.liveTranscript.startedByHumanParticipantId ===
+              reattached.previousHumanParticipantId
+          ) {
+            room.liveTranscript = {
+              ...room.liveTranscript,
+              startedByHumanParticipantId: participant.id,
+            }
+          }
+        } else if (
+          reattached.ok === false &&
+          // A proof that names an *active* bound Human is a takeover attempt
+          // and must fail. Any no-match is merely stale/unrelated
+          // sessionStorage (including another Human's browser secret), so it
+          // falls through to ordinary Human registration.
+          reattached.error === "runtime_provider_claim_human_invalid"
+        )
+          return this.json({ error: reattached.error }, 403)
       }
       if (registeredRuntimeHost && providerClaimHash && providerHandleHash) {
         const redemption = redeemRuntimeHostProviderClaim({

--- a/app/src/do/roomSessionRuntimeProvider.test.ts
+++ b/app/src/do/roomSessionRuntimeProvider.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { RoomSession } from "./RoomSession"
-import { deriveRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
+import {
+  deriveRuntimeProviderClaimHash,
+  deriveRuntimeProviderReattachHash,
+} from "../common/runtimeProviderCredential"
 
 const host = {
   runtimeHostId: "host-176-provider",
@@ -227,6 +230,132 @@ describe("RoomSession Runtime Host provider authorization (#176 Phase B)", () =>
     const stored = room.store.get("room") as any
     expect(stored.runtimeHostProviders).toEqual({})
     expect(stored.runtimeHostProviderClaims).toEqual({})
+  })
+
+  it("connects an existing resident through a one-time claim and reattaches refreshes with browser proof", async () => {
+    const room = harness()
+    const claimHash = await deriveRuntimeProviderClaimHash(
+      "room-176-provider",
+      claimSecret
+    )
+    const reattachSecret = "AQECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+    const reattachProofHash = await deriveRuntimeProviderReattachHash(
+      "room-176-provider",
+      reattachSecret
+    )
+    await room.sendHuman("human", {
+      type: "runtime-provider-claim-create",
+      requestId: "claim-connect",
+      providerClaimHash: claimHash,
+      reattachProofHash,
+    })
+    const connected = await room.control({
+      action: "agent-connect-runtime-provider",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: host,
+      providerClaimHash: claimHash,
+    })
+    expect(connected.status).toBe(401)
+
+    // The claim can only be redeemed by an already resident, authenticated
+    // Agent. Register that resident first, then exercise the dedicated
+    // connect action without creating a second participant.
+    const registered = await room.control({
+      action: "agent-register",
+      participant: {
+        id: "pi",
+        name: "Pi",
+        kind: "agent",
+        joinedAt: Date.now(),
+        token: "pi-token",
+        capabilities: { text: true },
+      },
+    })
+    expect(registered.status).toBe(200)
+    const connectedAfterJoin = await room.control({
+      action: "agent-connect-runtime-provider",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: host,
+      providerClaimHash: claimHash,
+    })
+    expect(connectedAfterJoin.status).toBe(200)
+    expect((connectedAfterJoin.json as any).runtimeProviderHandle).toMatch(
+      /^[A-Za-z0-9_-]{43}$/
+    )
+    expect(
+      (room.store.get("room") as any).runtimeHostProviders[host.runtimeHostId]
+    ).toEqual(expect.objectContaining({ humanParticipantId: "human" }))
+
+    const stored = room.store.get("room") as any
+    stored.participants.human.connected = false
+    stored.runtimeHostProviders[host.runtimeHostId].reattachExpiresAt =
+      Date.now() + 30_000
+    const unproved = await room.control({
+      action: "register",
+      participant: {
+        id: "human-without-proof",
+        name: "unproved",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "human-without-proof-token",
+        media: {
+          sessionId: "human-without-proof-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+      },
+    })
+    expect(unproved.status).toBe(200)
+    expect(
+      (room.store.get("room") as any).runtimeHostProviders[host.runtimeHostId]
+    ).toEqual(expect.objectContaining({ humanParticipantId: "human" }))
+    const refreshed = await room.control({
+      action: "register",
+      participant: {
+        id: "human-after-refresh",
+        name: "human",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "human-after-refresh-token",
+        media: {
+          sessionId: "human-after-refresh-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+        runtimeProviderReattachProofHash: reattachProofHash,
+      },
+    })
+    expect(refreshed.status).toBe(200)
+    expect(
+      (room.store.get("room") as any).runtimeHostProviders[host.runtimeHostId]
+    ).toEqual(
+      expect.objectContaining({
+        humanParticipantId: "human-after-refresh",
+      })
+    )
+
+    const spoofed = await room.control({
+      action: "register",
+      participant: {
+        id: "spoofed-refresh",
+        name: "spoofed",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "spoofed-refresh-token",
+        media: {
+          sessionId: "spoofed-refresh-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+        runtimeProviderReattachProofHash: claimHash,
+      },
+    })
+    expect(spoofed.status).toBe(403)
   })
 
   it("does not let a pre-binding copied Host id keep a provider association alive", async () => {

--- a/app/src/do/roomSessionRuntimeProvider.test.ts
+++ b/app/src/do/roomSessionRuntimeProvider.test.ts
@@ -86,7 +86,7 @@ function harness(mediaEnabled = false) {
       { participantId: id, token: `${id}-token`, connectionNonce: "n" },
       message
     )
-  return { store, socket, control, sendHuman }
+  return { store, socket, session, control, sendHuman }
 }
 
 describe("RoomSession Runtime Host provider authorization (#176 Phase B)", () => {
@@ -509,6 +509,120 @@ describe("RoomSession Runtime Host provider authorization (#176 Phase B)", () =>
       active: true,
       producerRuntimeHostId: host.runtimeHostId,
       startedByHumanParticipantId: "human-after-refresh",
+      epoch: 7,
+      startedAt: 1234,
+    })
+  })
+
+  it("completes an exact refresh handoff when registration beats the old WebSocket close", async () => {
+    const room = harness(true)
+    const claimHash = await deriveRuntimeProviderClaimHash(
+      "room-176-provider",
+      claimSecret
+    )
+    const reattachProofHash = await deriveRuntimeProviderReattachHash(
+      "room-176-provider",
+      "AQECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+    )
+    await room.sendHuman("human", {
+      type: "runtime-provider-claim-create",
+      requestId: "claim-refresh-race",
+      providerClaimHash: claimHash,
+      reattachProofHash,
+    })
+    const registered = await room.control({
+      action: "agent-register",
+      participant: {
+        id: "pi",
+        name: "Pi",
+        kind: "agent",
+        joinedAt: Date.now(),
+        token: "pi-token",
+        capabilities: { text: true },
+      },
+    })
+    expect(registered.status).toBe(200)
+    const connected = await room.control({
+      action: "agent-connect-runtime-provider",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: host,
+      providerClaimHash: claimHash,
+    })
+    expect(connected.status).toBe(200)
+
+    room.store.set("live-transcript", {
+      liveTranscript: {
+        active: true,
+        producerRuntimeHostId: host.runtimeHostId,
+        startedByHumanParticipantId: "human",
+        epoch: 7,
+        startedAt: 1234,
+      },
+      liveTranscriptSegments: [],
+      nextLiveTranscriptEpoch: 8,
+      nextTranscriptSequence: 1,
+    })
+
+    // Browser refresh can register the replacement before the old page's
+    // close event arrives at the DO. The old Human is deliberately still
+    // connected here; only the exact proof earns a bounded reservation.
+    const refreshed = await room.control({
+      action: "register",
+      participant: {
+        id: "human-refresh-race",
+        name: "human",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "human-refresh-race-token",
+        media: {
+          sessionId: "human-refresh-race-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+        runtimeProviderReattachProofHash: reattachProofHash,
+      },
+    })
+    expect(refreshed.status).toBe(200)
+    expect(
+      (room.store.get("room") as any).runtimeHostProviders[host.runtimeHostId]
+    ).toEqual(
+      expect.objectContaining({
+        humanParticipantId: "human",
+        pendingReattach: expect.objectContaining({
+          humanParticipantId: "human-refresh-race",
+        }),
+      })
+    )
+
+    await room.session.webSocketClose(
+      {
+        deserializeAttachment: () => ({
+          participantId: "human",
+          token: "human-token",
+          connectionNonce: undefined,
+        }),
+      } as WebSocket,
+      1000,
+      "refresh",
+      true
+    )
+
+    const stored = room.store.get("room") as any
+    expect(stored.runtimeHostProviders[host.runtimeHostId]).toEqual(
+      expect.objectContaining({
+        humanParticipantId: "human-refresh-race",
+      })
+    )
+    expect(
+      stored.runtimeHostProviders[host.runtimeHostId].pendingReattach
+    ).toBeUndefined()
+    const info = await room.control({ action: "room-info" })
+    expect((info.json as any).liveTranscript).toEqual({
+      active: true,
+      producerRuntimeHostId: host.runtimeHostId,
+      startedByHumanParticipantId: "human-refresh-race",
       epoch: 7,
       startedAt: 1234,
     })

--- a/app/src/do/roomSessionRuntimeProvider.test.ts
+++ b/app/src/do/roomSessionRuntimeProvider.test.ts
@@ -30,7 +30,7 @@ function human(id: string) {
   }
 }
 
-function harness() {
+function harness(mediaEnabled = false) {
   const store = new Map<string, unknown>([
     [
       "room",
@@ -60,7 +60,13 @@ function harness() {
     },
     getWebSockets: () => [] as WebSocket[],
   }
-  const session = new RoomSession(ctx as never, { SFU_ROOM: {} } as never)
+  const session = new RoomSession(
+    ctx as never,
+    {
+      SFU_ROOM: {},
+      ...(mediaEnabled ? { AGENT_MEDIA_ENABLED: "true" } : {}),
+    } as never
+  )
   vi.spyOn(session as any, "broadcastState").mockResolvedValue(undefined)
   vi.spyOn(session as any, "scheduleNextAlarm").mockResolvedValue(undefined)
   vi.spyOn(session as any, "attemptCleanupNow").mockResolvedValue(undefined)
@@ -338,7 +344,7 @@ describe("RoomSession Runtime Host provider authorization (#176 Phase B)", () =>
       })
     )
 
-    const spoofed = await room.control({
+    const unrelatedStaleProof = await room.control({
       action: "register",
       participant: {
         id: "spoofed-refresh",
@@ -355,7 +361,157 @@ describe("RoomSession Runtime Host provider authorization (#176 Phase B)", () =>
         runtimeProviderReattachProofHash: claimHash,
       },
     })
-    expect(spoofed.status).toBe(403)
+    // A non-matching sessionStorage proof belongs to another browser or an
+    // old Room association. It must not prevent this unrelated Human from
+    // entering merely because a different Human currently has a Host binding.
+    expect(unrelatedStaleProof.status).toBe(200)
+  })
+
+  it("does not let another Human's reattach proof block a normal refresh", async () => {
+    const room = harness()
+    const claimHash = await deriveRuntimeProviderClaimHash(
+      "room-176-provider",
+      claimSecret
+    )
+    const reattachProofHash = await deriveRuntimeProviderReattachHash(
+      "room-176-provider",
+      "AQECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+    )
+    const unrelatedProofHash = await deriveRuntimeProviderReattachHash(
+      "room-176-provider",
+      "AgECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+    )
+    await room.sendHuman("human", {
+      type: "runtime-provider-claim-create",
+      requestId: "claim-a",
+      providerClaimHash: claimHash,
+      reattachProofHash,
+    })
+    const registered = await room.control({
+      action: "agent-register",
+      participant: {
+        id: "pi",
+        name: "Pi",
+        kind: "agent",
+        joinedAt: Date.now(),
+        token: "pi-token",
+        capabilities: { text: true },
+      },
+    })
+    expect(registered.status).toBe(200)
+    const connected = await room.control({
+      action: "agent-connect-runtime-provider",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: host,
+      providerClaimHash: claimHash,
+    })
+    expect(connected.status).toBe(200)
+
+    const refreshedOtherHuman = await room.control({
+      action: "register",
+      participant: {
+        id: "other-refresh",
+        name: "other",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "other-refresh-token",
+        media: {
+          sessionId: "other-refresh-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+        runtimeProviderReattachProofHash: unrelatedProofHash,
+      },
+    })
+    expect(refreshedOtherHuman.status).toBe(200)
+    expect(
+      (room.store.get("room") as any).runtimeHostProviders[host.runtimeHostId]
+    ).toEqual(expect.objectContaining({ humanParticipantId: "human" }))
+  })
+
+  it("keeps an active transcript in the same epoch across its exact Human refresh", async () => {
+    const room = harness(true)
+    const claimHash = await deriveRuntimeProviderClaimHash(
+      "room-176-provider",
+      claimSecret
+    )
+    const reattachProofHash = await deriveRuntimeProviderReattachHash(
+      "room-176-provider",
+      "AQECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
+    )
+    await room.sendHuman("human", {
+      type: "runtime-provider-claim-create",
+      requestId: "claim-active",
+      providerClaimHash: claimHash,
+      reattachProofHash,
+    })
+    const registered = await room.control({
+      action: "agent-register",
+      participant: {
+        id: "pi",
+        name: "Pi",
+        kind: "agent",
+        joinedAt: Date.now(),
+        token: "pi-token",
+        capabilities: { text: true },
+      },
+    })
+    expect(registered.status).toBe(200)
+    const connected = await room.control({
+      action: "agent-connect-runtime-provider",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: host,
+      providerClaimHash: claimHash,
+    })
+    expect(connected.status).toBe(200)
+
+    const stored = room.store.get("room") as any
+    const activeTranscript = {
+      active: true,
+      producerRuntimeHostId: host.runtimeHostId,
+      startedByHumanParticipantId: "human",
+      epoch: 7,
+      startedAt: 1234,
+    }
+    room.store.set("live-transcript", {
+      liveTranscript: activeTranscript,
+      liveTranscriptSegments: [],
+      nextLiveTranscriptEpoch: 8,
+      nextTranscriptSequence: 1,
+    })
+    stored.participants.human.connected = false
+    stored.runtimeHostProviders[host.runtimeHostId].reattachExpiresAt =
+      Date.now() + 30_000
+
+    const refreshed = await room.control({
+      action: "register",
+      participant: {
+        id: "human-after-refresh",
+        name: "human",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "human-after-refresh-token",
+        media: {
+          sessionId: "human-after-refresh-session",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+        runtimeProviderReattachProofHash: reattachProofHash,
+      },
+    })
+    expect(refreshed.status).toBe(200)
+    const info = await room.control({ action: "room-info" })
+    expect((info.json as any).liveTranscript).toEqual({
+      active: true,
+      producerRuntimeHostId: host.runtimeHostId,
+      startedByHumanParticipantId: "human-after-refresh",
+      epoch: 7,
+      startedAt: 1234,
+    })
   })
 
   it("does not let a pre-binding copied Host id keep a provider association alive", async () => {

--- a/app/src/do/runtimeHostProvider.test.ts
+++ b/app/src/do/runtimeHostProvider.test.ts
@@ -5,6 +5,8 @@ import {
   canHumanUseRuntimeHost,
   createRuntimeHostProviderClaim,
   garbageCollectRuntimeHostProviders,
+  markRuntimeHostProviderDisconnected,
+  reattachRuntimeHostProvider,
   redeemRuntimeHostProviderClaim,
   removeRuntimeHostProviderForHuman,
   verifyRuntimeHostProviderProof,
@@ -296,5 +298,86 @@ describe("Runtime Host provider authorization", () => {
         now,
       })
     ).toEqual({ ok: false, error: "runtime_provider_claim_limit" })
+  })
+
+  it("reattaches only with the browser proof during disconnect grace", () => {
+    const proof = claimA
+    const providers = {
+      [hostA.runtimeHostId]: {
+        humanParticipantId: "dawei",
+        claimedAt: now,
+        providerHandleHash: handleA,
+        verifiedParticipantIds: ["pi"],
+        reattachProofHash: proof,
+      },
+    }
+    const participants = [
+      { id: "dawei", kind: "human" as const, connected: false },
+      {
+        id: "pi",
+        kind: "agent" as const,
+        connected: true,
+        runtimeHostId: hostA.runtimeHostId,
+      },
+    ]
+    const disconnected = markRuntimeHostProviderDisconnected({
+      providers,
+      humanParticipantId: "dawei",
+      now,
+      graceMs: 30_000,
+    })
+    const reattached = reattachRuntimeHostProvider({
+      providers: disconnected,
+      participants,
+      reattachProofHash: proof,
+      humanParticipantId: "new-human",
+      runtimeHosts: { [hostA.runtimeHostId]: hostA },
+      now: now + 1,
+      graceMs: 30_000,
+    })
+    expect(reattached).toMatchObject({
+      ok: true,
+      runtimeHostId: hostA.runtimeHostId,
+      providers: {
+        [hostA.runtimeHostId]: { humanParticipantId: "new-human" },
+      },
+    })
+    expect(
+      reattachRuntimeHostProvider({
+        providers: disconnected,
+        participants,
+        reattachProofHash: claimB,
+        humanParticipantId: "new-human",
+        runtimeHosts: { [hostA.runtimeHostId]: hostA },
+        now: now + 1,
+        graceMs: 30_000,
+      })
+    ).toEqual({ ok: false, error: "runtime_provider_claim_not_found" })
+    expect(
+      reattachRuntimeHostProvider({
+        providers: disconnected,
+        participants,
+        reattachProofHash: proof,
+        humanParticipantId: "new-human",
+        runtimeHosts: {},
+        now: now + 1,
+        graceMs: 30_000,
+      })
+    ).toEqual({ ok: false, error: "runtime_provider_claim_not_found" })
+    expect(
+      reattachRuntimeHostProvider({
+        providers: disconnected,
+        participants: participants.map((participant) =>
+          participant.id === "pi"
+            ? { ...participant, connected: false }
+            : participant
+        ),
+        reattachProofHash: proof,
+        humanParticipantId: "new-human",
+        runtimeHosts: { [hostA.runtimeHostId]: hostA },
+        now: now + 1,
+        graceMs: 30_000,
+      })
+    ).toEqual({ ok: false, error: "runtime_provider_claim_not_found" })
   })
 })

--- a/app/src/do/runtimeHostProvider.ts
+++ b/app/src/do/runtimeHostProvider.ts
@@ -68,7 +68,9 @@ function validPendingClaim(
     candidate.humanParticipantId.length > 0 &&
     typeof candidate.expiresAt === "number" &&
     Number.isSafeInteger(candidate.expiresAt) &&
-    candidate.expiresAt > 0
+    candidate.expiresAt > 0 &&
+    (candidate.reattachProofHash === undefined ||
+      isRuntimeProviderClaimHash(candidate.reattachProofHash))
   )
 }
 
@@ -88,7 +90,12 @@ function validProviderAssociation(
     candidate.verifiedParticipantIds.every(
       (participantId) =>
         typeof participantId === "string" && participantId.length > 0
-    )
+    ) &&
+    (candidate.reattachProofHash === undefined ||
+      isRuntimeProviderClaimHash(candidate.reattachProofHash)) &&
+    (candidate.reattachExpiresAt === undefined ||
+      (Number.isSafeInteger(candidate.reattachExpiresAt) &&
+        candidate.reattachExpiresAt > 0))
   )
 }
 
@@ -220,17 +227,24 @@ export function createRuntimeHostProviderClaim({
   participants,
   humanParticipantId,
   claimHash,
+  reattachProofHash,
   now,
 }: {
   pendingClaims: RuntimeHostProviderClaimMap
   participants: Iterable<RuntimeHostProviderParticipant>
   humanParticipantId: string
   claimHash: string
+  reattachProofHash?: string
   now: number
 }):
   | { ok: true; pendingClaims: RuntimeHostProviderClaimMap; expiresAt: number }
   | { ok: false; error: RuntimeHostProviderError } {
   if (!isRuntimeProviderClaimHash(claimHash))
+    return { ok: false, error: "invalid_runtime_provider_claim" }
+  if (
+    reattachProofHash !== undefined &&
+    !isRuntimeProviderClaimHash(reattachProofHash)
+  )
     return { ok: false, error: "invalid_runtime_provider_claim" }
   if (!isCurrentHuman(participants, humanParticipantId, true))
     return { ok: false, error: "runtime_provider_claim_human_invalid" }
@@ -253,7 +267,11 @@ export function createRuntimeHostProviderClaim({
     ok: true,
     pendingClaims: {
       ...pendingClaims,
-      [claimHash]: { humanParticipantId, expiresAt },
+      [claimHash]: {
+        humanParticipantId,
+        expiresAt,
+        ...(reattachProofHash ? { reattachProofHash } : {}),
+      },
     },
     expiresAt,
   }
@@ -303,6 +321,9 @@ export function redeemRuntimeHostProviderClaim({
     claimedAt: now,
     providerHandleHash,
     verifiedParticipantIds: [verifiedParticipantId],
+    ...(claim.reattachProofHash
+      ? { reattachProofHash: claim.reattachProofHash }
+      : {}),
   }
   const { [claimHash]: _consumed, ...remainingClaims } = pendingClaims
   return {
@@ -314,6 +335,129 @@ export function redeemRuntimeHostProviderClaim({
     pendingClaims: remainingClaims,
     association,
   }
+}
+
+// Reattach a refreshed Human to the same Host association without accepting a
+// public runtimeHostId as proof. The previous Human must already be absent,
+// the Host must still have a live verified Agent member, and the browser proof
+// must be inside the short disconnect grace window.
+export function reattachRuntimeHostProvider({
+  providers,
+  participants,
+  reattachProofHash,
+  humanParticipantId,
+  runtimeHosts,
+  now,
+  graceMs,
+}: {
+  providers: RuntimeHostProviderMap
+  participants: Iterable<RuntimeHostProviderParticipant>
+  reattachProofHash: string
+  humanParticipantId: string
+  runtimeHosts: RuntimeHostMap | undefined
+  now: number
+  graceMs: number
+}):
+  | { ok: true; providers: RuntimeHostProviderMap; runtimeHostId: string }
+  | { ok: false; error: RuntimeHostProviderError } {
+  if (!isRuntimeProviderClaimHash(reattachProofHash))
+    return { ok: false, error: "invalid_runtime_provider_claim" }
+  const list = Array.from(participants)
+  if (!humanParticipantId)
+    return { ok: false, error: "runtime_provider_claim_human_invalid" }
+  for (const [runtimeHostId, association] of Object.entries(providers)) {
+    if (association.reattachProofHash !== reattachProofHash) continue
+    if (!runtimeHosts?.[runtimeHostId]) continue
+    if (
+      association.reattachExpiresAt === undefined ||
+      association.reattachExpiresAt <= now ||
+      association.reattachExpiresAt > now + Math.max(graceMs, 0)
+    )
+      continue
+    const oldHuman = list.find(
+      (participant) => participant.id === association.humanParticipantId
+    )
+    if (!oldHuman || oldHuman.kind !== "human") continue
+    if (oldHuman.connected === true)
+      return { ok: false, error: "runtime_provider_claim_human_invalid" }
+    const hasLiveVerifiedMember = association.verifiedParticipantIds.some(
+      (participantId) => {
+        const member = list.find(
+          (participant) => participant.id === participantId
+        )
+        return (
+          member?.kind === "agent" &&
+          member.connected === true &&
+          member.runtimeHostId === runtimeHostId
+        )
+      }
+    )
+    if (!hasLiveVerifiedMember) continue
+    const { reattachExpiresAt: _reattachExpiresAt, ...reattached } = association
+    return {
+      ok: true,
+      runtimeHostId,
+      providers: {
+        ...providers,
+        [runtimeHostId]: {
+          ...reattached,
+          humanParticipantId,
+        },
+      },
+    }
+  }
+  return { ok: false, error: "runtime_provider_claim_not_found" }
+}
+
+export function markRuntimeHostProviderDisconnected({
+  providers,
+  humanParticipantId,
+  now,
+  graceMs,
+}: {
+  providers: RuntimeHostProviderMap
+  humanParticipantId: string
+  now: number
+  graceMs: number
+}): RuntimeHostProviderMap {
+  let changed = false
+  const next: RuntimeHostProviderMap = {}
+  for (const [runtimeHostId, association] of Object.entries(providers)) {
+    if (association.humanParticipantId !== humanParticipantId) {
+      next[runtimeHostId] = association
+      continue
+    }
+    changed = true
+    next[runtimeHostId] = {
+      ...association,
+      reattachExpiresAt: now + graceMs,
+    }
+  }
+  return changed ? next : providers
+}
+
+export function markRuntimeHostProviderConnected({
+  providers,
+  humanParticipantId,
+}: {
+  providers: RuntimeHostProviderMap
+  humanParticipantId: string
+}): RuntimeHostProviderMap {
+  let changed = false
+  const next: RuntimeHostProviderMap = {}
+  for (const [runtimeHostId, association] of Object.entries(providers)) {
+    if (
+      association.humanParticipantId !== humanParticipantId ||
+      association.reattachExpiresAt === undefined
+    ) {
+      next[runtimeHostId] = association
+      continue
+    }
+    const { reattachExpiresAt: _reattachExpiresAt, ...connected } = association
+    next[runtimeHostId] = connected
+    changed = true
+  }
+  return changed ? next : providers
 }
 
 // A successful proof on registration or hot projection adds the current

--- a/app/src/do/runtimeHostProvider.ts
+++ b/app/src/do/runtimeHostProvider.ts
@@ -358,7 +358,12 @@ export function reattachRuntimeHostProvider({
   now: number
   graceMs: number
 }):
-  | { ok: true; providers: RuntimeHostProviderMap; runtimeHostId: string }
+  | {
+      ok: true
+      providers: RuntimeHostProviderMap
+      runtimeHostId: string
+      previousHumanParticipantId: string
+    }
   | { ok: false; error: RuntimeHostProviderError } {
   if (!isRuntimeProviderClaimHash(reattachProofHash))
     return { ok: false, error: "invalid_runtime_provider_claim" }
@@ -397,6 +402,7 @@ export function reattachRuntimeHostProvider({
     return {
       ok: true,
       runtimeHostId,
+      previousHumanParticipantId: association.humanParticipantId,
       providers: {
         ...providers,
         [runtimeHostId]: {

--- a/app/src/do/runtimeHostProvider.ts
+++ b/app/src/do/runtimeHostProvider.ts
@@ -95,7 +95,16 @@ function validProviderAssociation(
       isRuntimeProviderClaimHash(candidate.reattachProofHash)) &&
     (candidate.reattachExpiresAt === undefined ||
       (Number.isSafeInteger(candidate.reattachExpiresAt) &&
-        candidate.reattachExpiresAt > 0))
+        candidate.reattachExpiresAt > 0)) &&
+    (candidate.pendingReattach === undefined ||
+      (typeof candidate.pendingReattach === "object" &&
+        candidate.pendingReattach !== null &&
+        !Array.isArray(candidate.pendingReattach) &&
+        typeof candidate.pendingReattach.humanParticipantId === "string" &&
+        candidate.pendingReattach.humanParticipantId.length > 0 &&
+        typeof candidate.pendingReattach.expiresAt === "number" &&
+        Number.isSafeInteger(candidate.pendingReattach.expiresAt) &&
+        candidate.pendingReattach.expiresAt > 0))
   )
 }
 
@@ -118,6 +127,24 @@ function liveVerifiedParticipantIds(
       })
     ),
   ]
+}
+
+function hasLiveVerifiedMember(
+  association: RuntimeHostProviderAssociation,
+  runtimeHostId: string,
+  participants: Iterable<RuntimeHostProviderParticipant>
+): boolean {
+  const currentParticipants = new Map(
+    Array.from(participants).map((participant) => [participant.id, participant])
+  )
+  return association.verifiedParticipantIds.some((participantId) => {
+    const participant = currentParticipants.get(participantId)
+    return (
+      participant?.kind === "agent" &&
+      participant.connected === true &&
+      participant.runtimeHostId === runtimeHostId
+    )
+  })
 }
 
 export function normalizeRuntimeHostProviders({
@@ -169,9 +196,18 @@ export function normalizeRuntimeHostProviders({
         )
       )
         changed = true
+      const pendingReattach = association.pendingReattach
+      const hasValidPendingReattach =
+        pendingReattach !== undefined &&
+        pendingReattach.expiresAt > now &&
+        pendingReattach.humanParticipantId !== association.humanParticipantId &&
+        isCurrentHuman(participantList, pendingReattach.humanParticipantId)
+      if (pendingReattach !== undefined && !hasValidPendingReattach)
+        changed = true
       normalizedProviders[hostId] = {
         ...association,
         verifiedParticipantIds,
+        ...(hasValidPendingReattach ? { pendingReattach } : {}),
       }
     }
   } else if (providers !== undefined) {
@@ -385,20 +421,12 @@ export function reattachRuntimeHostProvider({
     if (!oldHuman || oldHuman.kind !== "human") continue
     if (oldHuman.connected === true)
       return { ok: false, error: "runtime_provider_claim_human_invalid" }
-    const hasLiveVerifiedMember = association.verifiedParticipantIds.some(
-      (participantId) => {
-        const member = list.find(
-          (participant) => participant.id === participantId
-        )
-        return (
-          member?.kind === "agent" &&
-          member.connected === true &&
-          member.runtimeHostId === runtimeHostId
-        )
-      }
-    )
-    if (!hasLiveVerifiedMember) continue
-    const { reattachExpiresAt: _reattachExpiresAt, ...reattached } = association
+    if (!hasLiveVerifiedMember(association, runtimeHostId, list)) continue
+    const {
+      reattachExpiresAt: _reattachExpiresAt,
+      pendingReattach: _pendingReattach,
+      ...reattached
+    } = association
     return {
       ok: true,
       runtimeHostId,
@@ -408,6 +436,83 @@ export function reattachRuntimeHostProvider({
         [runtimeHostId]: {
           ...reattached,
           humanParticipantId,
+        },
+      },
+    }
+  }
+  return { ok: false, error: "runtime_provider_claim_not_found" }
+}
+
+// A browser can start its replacement session before the old WebSocket close
+// arrives at this DO. Reserve only an exact proof while the current owner is
+// still connected; the reservation never changes ownership on its own and is
+// bounded by the ordinary reconnect grace window.
+export function deferRuntimeHostProviderReattach({
+  providers,
+  participants,
+  reattachProofHash,
+  humanParticipantId,
+  runtimeHosts,
+  now,
+  graceMs,
+}: {
+  providers: RuntimeHostProviderMap
+  participants: Iterable<RuntimeHostProviderParticipant>
+  reattachProofHash: string
+  humanParticipantId: string
+  runtimeHosts: RuntimeHostMap | undefined
+  now: number
+  graceMs: number
+}):
+  | {
+      ok: true
+      providers: RuntimeHostProviderMap
+      runtimeHostId: string
+      previousHumanParticipantId: string
+    }
+  | { ok: false; error: RuntimeHostProviderError } {
+  if (!isRuntimeProviderClaimHash(reattachProofHash))
+    return { ok: false, error: "invalid_runtime_provider_claim" }
+  if (!humanParticipantId)
+    return { ok: false, error: "runtime_provider_claim_human_invalid" }
+  const list = Array.from(participants)
+  for (const [runtimeHostId, association] of Object.entries(providers)) {
+    if (association.reattachProofHash !== reattachProofHash) continue
+    if (!runtimeHosts?.[runtimeHostId]) continue
+    if (association.reattachExpiresAt !== undefined) continue
+    const oldHuman = list.find(
+      (participant) => participant.id === association.humanParticipantId
+    )
+    if (oldHuman?.kind !== "human" || oldHuman.connected !== true) continue
+    if (!hasLiveVerifiedMember(association, runtimeHostId, list)) continue
+    const previousPending = association.pendingReattach
+    const previousPendingHuman = previousPending
+      ? list.find(
+          (participant) => participant.id === previousPending.humanParticipantId
+        )
+      : undefined
+    // A connected prior replacement is already entitled to the bounded
+    // handoff. Do not let a second registration with the same proof replace
+    // it; a not-yet-connected attempt may be superseded by the latest page.
+    if (
+      previousPending &&
+      previousPending.expiresAt > now &&
+      previousPendingHuman?.kind === "human" &&
+      previousPendingHuman.connected === true
+    )
+      return { ok: false, error: "runtime_provider_claim_human_invalid" }
+    return {
+      ok: true,
+      runtimeHostId,
+      previousHumanParticipantId: association.humanParticipantId,
+      providers: {
+        ...providers,
+        [runtimeHostId]: {
+          ...association,
+          pendingReattach: {
+            humanParticipantId,
+            expiresAt: now + Math.max(graceMs, 0),
+          },
         },
       },
     }
@@ -440,6 +545,78 @@ export function markRuntimeHostProviderDisconnected({
     }
   }
   return changed ? next : providers
+}
+
+// Complete the reservation made above only after the old owner has actually
+// disconnected. The replacement need not have opened its WebSocket yet: it
+// is already a newly registered Human and will itself expire through the
+// normal reconnect grace if the page never finishes connecting.
+export function completeDeferredRuntimeHostProviderReattach({
+  providers,
+  participants,
+  disconnectedHumanParticipantId,
+  runtimeHosts,
+  now,
+}: {
+  providers: RuntimeHostProviderMap
+  participants: Iterable<RuntimeHostProviderParticipant>
+  disconnectedHumanParticipantId: string
+  runtimeHosts: RuntimeHostMap | undefined
+  now: number
+}): {
+  providers: RuntimeHostProviderMap
+  reattached: Array<{
+    runtimeHostId: string
+    previousHumanParticipantId: string
+    humanParticipantId: string
+  }>
+} {
+  const list = Array.from(participants)
+  const next: RuntimeHostProviderMap = {}
+  const reattached: Array<{
+    runtimeHostId: string
+    previousHumanParticipantId: string
+    humanParticipantId: string
+  }> = []
+  for (const [runtimeHostId, association] of Object.entries(providers)) {
+    if (association.humanParticipantId !== disconnectedHumanParticipantId) {
+      next[runtimeHostId] = association
+      continue
+    }
+    const pendingReattach = association.pendingReattach
+    const replacement = pendingReattach
+      ? list.find(
+          (participant) => participant.id === pendingReattach.humanParticipantId
+        )
+      : undefined
+    if (
+      !pendingReattach ||
+      pendingReattach.expiresAt <= now ||
+      replacement?.kind !== "human" ||
+      !runtimeHosts?.[runtimeHostId] ||
+      !hasLiveVerifiedMember(association, runtimeHostId, list)
+    ) {
+      const { pendingReattach: _pendingReattach, ...withoutPending } =
+        association
+      next[runtimeHostId] = withoutPending
+      continue
+    }
+    const {
+      reattachExpiresAt: _reattachExpiresAt,
+      pendingReattach: _pendingReattach,
+      ...reattachedAssociation
+    } = association
+    next[runtimeHostId] = {
+      ...reattachedAssociation,
+      humanParticipantId: replacement.id,
+    }
+    reattached.push({
+      runtimeHostId,
+      previousHumanParticipantId: association.humanParticipantId,
+      humanParticipantId: replacement.id,
+    })
+  }
+  return { providers: next, reattached }
 }
 
 export function markRuntimeHostProviderConnected({
@@ -537,6 +714,15 @@ export function removeRuntimeHostProviderForHuman({
   const nextClaims: RuntimeHostProviderClaimMap = {}
   for (const [hostId, association] of Object.entries(providers)) {
     if (association.humanParticipantId === humanParticipantId) {
+      changed = true
+      continue
+    }
+    if (
+      association.pendingReattach?.humanParticipantId === humanParticipantId
+    ) {
+      const { pendingReattach: _pendingReattach, ...withoutPending } =
+        association
+      nextProviders[hostId] = withoutPending
       changed = true
       continue
     }

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -409,6 +409,48 @@ describe("useSfuChatRoom Live Transcript RoomState wiring (#177 PR3)", () => {
     ).not.toContain("collab-request")
     unmount()
   })
+
+  it("reuses one pending local Runtime connection claim across repeated clicks", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    })
+    const { result, unmount } = renderHook(() =>
+      useSfuChatRoom("claim-room", "Alice", "audio")
+    )
+    await waitFor(() => expect(RecordingWebSocket.instances).toHaveLength(1))
+    const socket = RecordingWebSocket.instances[0]
+    act(() => socket.onopen?.())
+
+    const first = result.current.connectLocalRuntime()
+    const second = result.current.connectLocalRuntime()
+    await waitFor(() => {
+      const claimMessages = socket.sent
+        .map((message) => JSON.parse(message))
+        .filter((message) => message.type === "runtime-provider-claim-create")
+      expect(claimMessages).toHaveLength(1)
+    })
+    const claimMessage = socket.sent
+      .map((message) => JSON.parse(message))
+      .find((message) => message.type === "runtime-provider-claim-create")
+    act(() =>
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "runtime-provider-claim-created",
+          requestId: claimMessage.requestId,
+          expiresAt: Date.now() + 5 * 60 * 1000,
+        }),
+      })
+    )
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(writeText).toHaveBeenCalledTimes(2)
+    expect(writeText.mock.calls[0][0]).toBe(writeText.mock.calls[1][0])
+    expect(writeText.mock.calls[0][0]).toContain(
+      "free4chat-agent connect --room"
+    )
+    unmount()
+  })
 })
 
 describe("useSfuChatRoom room attachments (#123)", () => {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -6,7 +6,11 @@ import {
   validateRoomAttachmentRead,
   validateUploadedRoomAttachment,
 } from "@common/roomAttachments"
-import { createRuntimeProviderClaim as createRuntimeProviderCredential } from "@common/runtimeProviderCredential"
+import {
+  createRuntimeProviderClaim as createRuntimeProviderCredential,
+  createRuntimeProviderSecret,
+  deriveRuntimeProviderReattachHash,
+} from "@common/runtimeProviderCredential"
 import { ActionType, Message, UserInfo } from "@common/types"
 import {
   MAX_COLLAB_ATTACHMENT_REFS,
@@ -74,6 +78,26 @@ const AGENT_TEXT_EXTENSIONS = new Set([
 const AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS = [100, 300] as const
 const MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS =
   1 + AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS.length
+
+const runtimeReattachStorageKey = (room: string) =>
+  `free4chat:runtime-reattach:${room}`
+
+function readOrCreateRuntimeReattachSecret(room: string): {
+  secret: string
+  existed: boolean
+} {
+  if (typeof window === "undefined") return { secret: "", existed: false }
+  try {
+    const key = runtimeReattachStorageKey(room)
+    const existing = window.sessionStorage.getItem(key)
+    if (existing) return { secret: existing, existed: true }
+    const secret = createRuntimeProviderSecret()
+    window.sessionStorage.setItem(key, secret)
+    return { secret, existed: false }
+  } catch {
+    return { secret: "", existed: false }
+  }
+}
 
 function agentTextMime(file: File): string | undefined {
   if (AGENT_TEXT_TYPES.has(file.type)) return file.type
@@ -195,6 +219,24 @@ function diagnosticTrackKind(kind: unknown): "audio" | "video" | "unknown" {
 
 function diagnosticErrorType(error: unknown): string {
   return error instanceof Error && error.name ? error.name : typeof error
+}
+
+function userFacingRoomError(error: string | undefined): string {
+  switch (error) {
+    case "runtime_provider_claim_limit":
+      return "A Runtime connection is already waiting. Try again after it finishes or expires."
+    case "runtime_provider_claim_expired":
+    case "runtime_provider_claim_not_found":
+      return "Runtime connection expired. Try again."
+    case "runtime_provider_claim_human_invalid":
+    case "runtime_provider_proof_required":
+    case "runtime_provider_handle_invalid":
+      return "Runtime connection is no longer available. Try again."
+    default:
+      if (error?.startsWith("runtime_"))
+        return "Runtime connection unavailable."
+      return error || "SFU room error"
+  }
 }
 
 function isAgentImage(file: File): boolean {
@@ -340,6 +382,9 @@ export function useSfuChatRoom(
   const [agentVoice, setAgentVoiceState] = useState<SfuAgentVoiceState>({})
   const [agentVoiceMediaAvailable, setAgentVoiceMediaAvailable] =
     useState(false)
+  const [runtimeConnectionStatus, setRuntimeConnectionStatus] = useState<
+    "idle" | "preparing" | "copied"
+  >("idle")
 
   const sessionRef = useRef<SfuSession | null>(null)
   const roomStateRef = useRef<SfuRoomState | null>(null)
@@ -379,6 +424,11 @@ export function useSfuChatRoom(
       }
     >()
   )
+  const runtimeProviderClaimAttemptRef = useRef<{
+    room: string
+    promise: Promise<{ providerClaimSecret: string }>
+    expiresAt: number
+  } | null>(null)
   const pendingRemoteTrackRef = useRef<{
     peerId: string
     kind: "audio" | "video"
@@ -1420,6 +1470,17 @@ export function useSfuChatRoom(
       setLiveTranscriptSegments(state.liveTranscriptSegments ?? [])
       setRuntimeHosts(state.runtimeHosts)
       setRuntimeHostProviders(state.runtimeHostProviders)
+      const localParticipantForProvider = sessionRef.current?.participantId
+      if (
+        localParticipantForProvider &&
+        Object.values(state.runtimeHostProviders ?? {}).some(
+          (association) =>
+            association.humanParticipantId === localParticipantForProvider
+        )
+      ) {
+        runtimeProviderClaimAttemptRef.current = null
+        setRuntimeConnectionStatus("idle")
+      }
       setLiveTranscriptMediaAvailable(state.meetingNotesMediaAvailable)
       setAgentVoiceState(state.agentVoice)
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
@@ -1673,10 +1734,11 @@ export function useSfuChatRoom(
         // browser-local secret sit around until the timeout.
         for (const pending of pendingRuntimeProviderClaimsRef.current.values()) {
           clearTimeout(pending.timeout)
-          pending.reject(new Error("Room provider claim was rejected"))
+          pending.reject(new Error(userFacingRoomError(message.error)))
         }
         pendingRuntimeProviderClaimsRef.current.clear()
-        setError(message.error || "SFU room error")
+        runtimeProviderClaimAttemptRef.current = null
+        setError(userFacingRoomError(message.error))
       } else if (
         message.type === "runtime-provider-claim-created" &&
         message.requestId
@@ -1687,6 +1749,9 @@ export function useSfuChatRoom(
         if (!pending) return
         pendingRuntimeProviderClaimsRef.current.delete(message.requestId)
         clearTimeout(pending.timeout)
+        if (runtimeProviderClaimAttemptRef.current)
+          runtimeProviderClaimAttemptRef.current.expiresAt =
+            message.expiresAt ?? Date.now() + 5 * 60 * 1000
         pending.resolve({ providerClaimSecret: pending.providerClaimSecret })
       }
     }
@@ -1697,6 +1762,7 @@ export function useSfuChatRoom(
         pending.reject(new Error("Room control connection closed"))
       }
       pendingRuntimeProviderClaimsRef.current.clear()
+      runtimeProviderClaimAttemptRef.current = null
       if (closingRef.current) return
       if (socket !== websocketRef.current) return
       setConnectionStatus("reconnecting")
@@ -1797,6 +1863,11 @@ export function useSfuChatRoom(
         name: nickName,
         kind: "human",
         turnstileToken,
+      }
+      const reattach = readOrCreateRuntimeReattachSecret(roomName)
+      if (reattach.existed && reattach.secret) {
+        body.runtimeProviderReattachProofHash =
+          await deriveRuntimeProviderReattachHash(roomName, reattach.secret)
       }
       if (reconnecting && previousSession) {
         body.reconnect = {
@@ -1921,7 +1992,6 @@ export function useSfuChatRoom(
       if (mediaReconnectTimerRef.current)
         clearTimeout(mediaReconnectTimerRef.current)
       void closeDataChannels(sessionRef.current)
-      sendSocketMessage({ type: "leave" })
       websocketRef.current?.close()
       localAudioTrackRef.current?.stop()
       localScreenTrackRef.current?.stop()
@@ -2247,6 +2317,10 @@ export function useSfuChatRoom(
     sendSocketMessage({ type: "live-transcript-stop" })
   }, [sendSocketMessage])
 
+  const leaveRoom = useCallback(() => {
+    sendSocketMessage({ type: "leave" })
+  }, [sendSocketMessage])
+
   const setAgentVoice = useCallback(
     (agentParticipantId: string, enabled: boolean) => {
       sendSocketMessage({
@@ -2258,41 +2332,86 @@ export function useSfuChatRoom(
     [sendSocketMessage]
   )
 
-  // Phase B stays dormant in production until the matching Runtime release is
-  // activated. When enabled, create the raw secret locally, send only its
-  // derived claim hash via the authenticated Room WebSocket, and release the
-  // raw value to the explicit invite solely after the Room ACKs it.
+  // Create one browser-local connection attempt at a time. The raw claim is
+  // never rendered; the dedicated Runtime handoff copies it only inside a
+  // local CLI command after the Room ACKs the hash.
   const createRuntimeProviderClaim = useCallback(async (): Promise<{
     providerClaimSecret: string
   }> => {
-    const credential = await createRuntimeProviderCredential(roomName)
-    const requestId = crypto.randomUUID()
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        const pending = pendingRuntimeProviderClaimsRef.current.get(requestId)
-        if (!pending) return
-        pendingRuntimeProviderClaimsRef.current.delete(requestId)
-        reject(new Error("Room provider claim was not acknowledged"))
-      }, 5_000)
-      pendingRuntimeProviderClaimsRef.current.set(requestId, {
-        providerClaimSecret: credential.providerClaimSecret,
-        resolve,
-        reject,
-        timeout,
-      })
-      if (
-        !sendSocketMessage({
-          type: "runtime-provider-claim-create",
-          requestId,
-          providerClaimHash: credential.providerClaimHash,
+    const existing = runtimeProviderClaimAttemptRef.current
+    if (
+      existing &&
+      existing.room === roomName &&
+      existing.expiresAt > Date.now()
+    )
+      return existing.promise
+
+    const promise = (async () => {
+      const credential = await createRuntimeProviderCredential(roomName)
+      const reattach = readOrCreateRuntimeReattachSecret(roomName)
+      const reattachProofHash = reattach.secret
+        ? await deriveRuntimeProviderReattachHash(roomName, reattach.secret)
+        : undefined
+      const requestId = crypto.randomUUID()
+      return new Promise<{ providerClaimSecret: string }>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          const pending = pendingRuntimeProviderClaimsRef.current.get(requestId)
+          if (!pending) return
+          pendingRuntimeProviderClaimsRef.current.delete(requestId)
+          runtimeProviderClaimAttemptRef.current = null
+          reject(new Error("Room provider claim was not acknowledged"))
+        }, 5_000)
+        pendingRuntimeProviderClaimsRef.current.set(requestId, {
+          providerClaimSecret: credential.providerClaimSecret,
+          resolve,
+          reject,
+          timeout,
         })
-      ) {
-        pendingRuntimeProviderClaimsRef.current.delete(requestId)
-        clearTimeout(timeout)
-        reject(new Error("Room control connection is unavailable"))
-      }
+        if (
+          !sendSocketMessage({
+            type: "runtime-provider-claim-create",
+            requestId,
+            providerClaimHash: credential.providerClaimHash,
+            ...(reattachProofHash ? { reattachProofHash } : {}),
+          })
+        ) {
+          pendingRuntimeProviderClaimsRef.current.delete(requestId)
+          clearTimeout(timeout)
+          runtimeProviderClaimAttemptRef.current = null
+          reject(new Error("Room control connection is unavailable"))
+        }
+      })
+    })()
+    runtimeProviderClaimAttemptRef.current = {
+      room: roomName,
+      promise,
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    }
+    void promise.catch(() => {
+      if (runtimeProviderClaimAttemptRef.current?.promise === promise)
+        runtimeProviderClaimAttemptRef.current = null
     })
+    return promise
   }, [roomName, sendSocketMessage])
+
+  const connectLocalRuntime = useCallback(async () => {
+    setRuntimeConnectionStatus("preparing")
+    try {
+      const { providerClaimSecret } = await createRuntimeProviderClaim()
+      const shellQuote = (value: string) =>
+        `'${value.replaceAll("'", `'\\''`)}'`
+      const command = `free4chat-agent connect --room ${shellQuote(
+        roomName
+      )} --provider-claim ${shellQuote(providerClaimSecret)}`
+      if (!navigator.clipboard?.writeText)
+        throw new Error("clipboard_unavailable")
+      await navigator.clipboard.writeText(command)
+      setRuntimeConnectionStatus("copied")
+    } catch {
+      setRuntimeConnectionStatus("idle")
+      throw new Error("Unable to connect the local Runtime")
+    }
+  }, [createRuntimeProviderClaim, roomName])
 
   const sendFileMessage = useCallback(
     async (file: File) => {
@@ -2433,9 +2552,12 @@ export function useSfuChatRoom(
     liveTranscriptMediaAvailable,
     startLiveTranscript,
     stopLiveTranscript,
+    leaveRoom,
     agentVoice,
     agentVoiceMediaAvailable,
     setAgentVoice,
     createRuntimeProviderClaim,
+    connectLocalRuntime,
+    runtimeConnectionStatus,
   }
 }

--- a/app/src/mcp/server.test.ts
+++ b/app/src/mcp/server.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { handleMcpRequest, type McpEnv } from "./server"
+
+describe("public MCP tool surface", () => {
+  it("does not expose Runtime provider connection or its private handle", async () => {
+    const request = new Request("https://www.free4.chat/mcp", {
+      method: "POST",
+      headers: {
+        Origin: "https://www.free4.chat",
+        Host: "www.free4.chat",
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "Mcp-Method": "tools/list",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    })
+    const response = await handleMcpRequest(
+      request,
+      { SFU_ROOM: {}, ROOMS_KV: {} } as McpEnv,
+      {} as ExecutionContext
+    )
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as {
+      result?: { tools?: Array<{ name?: string }> }
+    }
+    const names = payload.result?.tools?.map((tool) => tool.name) ?? []
+    expect(names).not.toContain("connect_runtime_provider")
+    expect(names).not.toContain("runtimeProviderHandle")
+  })
+})

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -419,37 +419,6 @@ function createMcpServer(context: McpRequestContext) {
   )
 
   server.registerTool(
-    "connect_runtime_provider",
-    {
-      description:
-        "Bind this already-resident Runtime Host to a Human-created Room connection claim. The existing Agent participant remains the sole Runtime participant; only the private local provider handle is returned.",
-      inputSchema: {
-        participantHandle: z.string().min(1),
-        runtimeHost: runtimeHostSchema,
-        providerClaimHash: runtimeProviderCredentialSchema,
-      },
-    },
-    async ({ participantHandle, runtimeHost, providerClaimHash }) => {
-      const handle = decodeHandle(participantHandle)
-      if (!handle) return toolError("invalid_participant_handle")
-      const result = await roomControl(env, handle.room, {
-        action: "agent-connect-runtime-provider",
-        participantId: handle.participantId,
-        token: handle.participantToken,
-        runtimeHost,
-        providerClaimHash,
-      })
-      if (!result.ok) return toolError(controlError(result))
-      const providerHandle = runtimeProviderCredentialSchema.safeParse(
-        result.data.runtimeProviderHandle
-      )
-      if (!providerHandle.success)
-        return toolError("runtime_provider_handle_invalid")
-      return toolResult({ runtimeProviderHandle: providerHandle.data })
-    }
-  )
-
-  server.registerTool(
     "wait_for_events",
     {
       description:

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -419,6 +419,37 @@ function createMcpServer(context: McpRequestContext) {
   )
 
   server.registerTool(
+    "connect_runtime_provider",
+    {
+      description:
+        "Bind this already-resident Runtime Host to a Human-created Room connection claim. The existing Agent participant remains the sole Runtime participant; only the private local provider handle is returned.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+        runtimeHost: runtimeHostSchema,
+        providerClaimHash: runtimeProviderCredentialSchema,
+      },
+    },
+    async ({ participantHandle, runtimeHost, providerClaimHash }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-connect-runtime-provider",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+        runtimeHost,
+        providerClaimHash,
+      })
+      if (!result.ok) return toolError(controlError(result))
+      const providerHandle = runtimeProviderCredentialSchema.safeParse(
+        result.data.runtimeProviderHandle
+      )
+      if (!providerHandle.success)
+        return toolError("runtime_provider_handle_invalid")
+      return toolResult({ runtimeProviderHandle: providerHandle.data })
+    }
+  )
+
+  server.registerTool(
     "wait_for_events",
     {
       description:

--- a/app/src/room/server.test.ts
+++ b/app/src/room/server.test.ts
@@ -232,3 +232,73 @@ describe("Live Transcript Runtime append gate", () => {
     expect(response.status).toBe(400)
   })
 })
+
+describe("Runtime provider connection gate", () => {
+  it("forwards only an authenticated Runtime connection control payload", async () => {
+    const captured: CapturedControl[] = []
+    const request = new Request(
+      "https://www.free4.chat/api/room/runtime-provider/connect",
+      {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          "Content-Type": "application/json",
+          "X-Room-Id": "test-room",
+          "X-Room-Participant-Id": "agent-1",
+          "X-Room-Participant-Token": "private-token",
+        },
+        body: JSON.stringify({
+          runtimeHost: {
+            runtimeHostId: "host-176-provider",
+            speech: { stt: true, tts: false },
+          },
+          providerClaimHash: "KPvm-f4hBdYhSjdaYF_67xqPZx7BiiAXvMo1U_8l44w",
+          runtimeProviderHandle: "must-not-cross-this-boundary",
+        }),
+      }
+    )
+    const response = await handleRoomRequest(
+      request,
+      liveTranscriptEnv(captured)
+    )
+    expect(response.status).toBe(200)
+    expect(captured).toEqual([
+      {
+        contentType: "application/json",
+        body: {
+          action: "agent-connect-runtime-provider",
+          participantId: "agent-1",
+          token: "private-token",
+          runtimeHost: {
+            runtimeHostId: "host-176-provider",
+            speech: { stt: true, tts: false },
+          },
+          providerClaimHash: "KPvm-f4hBdYhSjdaYF_67xqPZx7BiiAXvMo1U_8l44w",
+        },
+      },
+    ])
+  })
+
+  it("rejects a malformed provider connection before contacting the Room", async () => {
+    const request = new Request(
+      "https://www.free4.chat/api/room/runtime-provider/connect",
+      {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          "Content-Type": "application/json",
+          "X-Room-Id": "test-room",
+          "X-Room-Participant-Id": "agent-1",
+          "X-Room-Participant-Token": "private-token",
+        },
+        body: JSON.stringify({
+          runtimeHost: { runtimeHostId: "copied", speech: { stt: true } },
+          providerClaimHash: "not-a-claim",
+        }),
+      }
+    )
+    const env = liveTranscriptEnv([])
+    const response = await handleRoomRequest(request, env)
+    expect(response.status).toBe(400)
+  })
+})

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -1,5 +1,7 @@
 import { isAllowedOrigin } from "../common/origin"
+import { isRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
 import type { RoomSession } from "../do/RoomSession"
+import { validateRuntimeHost } from "../do/runtimeHost"
 
 const MAX_ROOM_LENGTH = 64
 const MAX_AGENT_ATTACHMENT_BYTES = 768 * 1024
@@ -79,6 +81,42 @@ export async function handleRoomRequest(
         segmentId: body.segmentId,
         sourceParticipantId: body.sourceParticipantId,
         text: body.text,
+      }),
+    })
+  }
+
+  // Runtime-only provider connection transport. Unlike ordinary MCP tools,
+  // this narrow control route is called solely by the resident Runtime: the
+  // participant capability stays in private request headers and the returned
+  // provider handle never enters a Harness/MCP tool result. A browser cannot
+  // use a public runtimeHostId to substitute for that capability.
+  if (pathname === "/api/room/runtime-provider/connect") {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const room = request.headers.get("X-Room-Id")?.trim() ?? ""
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    if (!room || room.length > MAX_ROOM_LENGTH || !participantId || !token)
+      return json({ error: "missing_room_capability" }, 400)
+    let body: { runtimeHost?: unknown; providerClaimHash?: unknown }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return json({ error: "invalid_request" }, 400)
+    }
+    const runtimeHost = validateRuntimeHost(body.runtimeHost)
+    if (!runtimeHost.ok || !isRuntimeProviderClaimHash(body.providerClaimHash))
+      return json({ error: "invalid_request" }, 400)
+    const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+    return stub.fetch("https://room/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "agent-connect-runtime-provider",
+        participantId,
+        token,
+        runtimeHost: runtimeHost.runtimeHost,
+        providerClaimHash: body.providerClaimHash,
       }),
     })
   }

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -65,6 +65,15 @@ export interface RuntimeHostProviderAssociation {
   // usable for a short grace window after the associated Human disconnects.
   reattachProofHash?: string
   reattachExpiresAt?: number
+  // A fresh browser registration can arrive before the old WebSocket close
+  // reaches the Durable Object. An exact proof may reserve this one bounded
+  // handoff while the current Human is still connected; ownership moves only
+  // after that old connection actually closes. This remains server-private
+  // and is never a second provider identity or a RoomState projection.
+  pendingReattach?: {
+    humanParticipantId: string
+    expiresAt: number
+  }
 }
 
 // Browser-safe projection for future Human-facing feature admission. Both ids

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -61,6 +61,10 @@ export interface RuntimeHostProviderAssociation {
   // Agent on this Host has actually proved possession of the private handle.
   // Never project these ids to RoomState or room_info.
   verifiedParticipantIds: string[]
+  // Browser-owned refresh proof. Only the one-way hash is persisted; it is
+  // usable for a short grace window after the associated Human disconnects.
+  reattachProofHash?: string
+  reattachExpiresAt?: number
 }
 
 // Browser-safe projection for future Human-facing feature admission. Both ids
@@ -75,6 +79,7 @@ export interface RuntimeHostProviderPublicAssociation {
 export interface PendingRuntimeHostProviderClaim {
   humanParticipantId: string
   expiresAt: number
+  reattachProofHash?: string
 }
 
 export interface AgentCapabilities {

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -1,5 +1,6 @@
 import type { SfuSessionResponse, SfuTrack } from "./types"
 import { isAllowedOrigin } from "../common/origin"
+import { isRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
 import { compensateUnacceptedAgentMedia } from "../do/mediaEffects"
 import { resolveAgentPurposePermission } from "../do/meetingNotesAuth"
 import type { RoomSession } from "../do/RoomSession"
@@ -424,6 +425,15 @@ export async function handleSfuRequest(
         : ""
     const reconnectSessionId =
       typeof reconnect?.sessionId === "string" ? reconnect.sessionId : ""
+    const runtimeProviderReattachProofHash =
+      typeof body.runtimeProviderReattachProofHash === "string"
+        ? body.runtimeProviderReattachProofHash
+        : undefined
+    if (
+      runtimeProviderReattachProofHash !== undefined &&
+      !isRuntimeProviderClaimHash(runtimeProviderReattachProofHash)
+    )
+      return badRequest("invalid_runtime_provider_reattach")
     const isReconnect = Boolean(
       reconnectParticipantId && reconnectToken && reconnectSessionId
     )
@@ -475,6 +485,9 @@ export async function handleSfuRequest(
             },
             joinedAt: Date.now(),
             token: participantToken,
+            ...(runtimeProviderReattachProofHash
+              ? { runtimeProviderReattachProofHash }
+              : {}),
           },
         })
     if (!roomResponse.ok) return roomResponse

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -19,6 +19,7 @@ export default {
     if (
       pathname === "/api/room/attachments" ||
       pathname === "/api/room/live-transcript/append" ||
+      pathname === "/api/room/runtime-provider/connect" ||
       pathname === "/api/room/surfaces/read" ||
       pathname === "/api/room/attachments/read"
     ) {


### PR DESCRIPTION
Part of #206
Follow-up to #177 production dogfood.

This preserves #177 Room-wide Live Transcript semantics while adding a dedicated Connect local Runtime path, Room-scoped refresh reattachment proof, bounded pending-claim reuse, concise errors, and transcript auto-follow/jump behavior.

Runtime 0.5.11 is published as agent-v0.5.11; app/public/agent.md now activates that exact release.