### PR TITLE
feat(agent): add developer-friendly Room CLI

### DIFF
--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -25,6 +25,10 @@ const mcpEndpointDefault = "https://www.free4.chat/mcp"
 
 func usageText() string {
 	return `Usage:
+  free4chat-agent room create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
+  free4chat-agent room create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
+  free4chat-agent room join <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
+  free4chat-agent room join <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
   free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
   free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
   free4chat-agent connect --room <room-id> --provider-claim <opaque-secret>
@@ -138,29 +142,15 @@ func run(args []string) error {
 	case "daemon":
 		return daemon.New().Run()
 
+	case "room":
+		return runRoom(rest)
+
 	case "join":
-		room := option(rest, "--room")
-		name := option(rest, "--name")
-		agent := option(rest, "--agent")
-		agentCommand := option(rest, "--agent-command")
-		providerClaim := option(rest, "--provider-claim")
-		if providerClaim != "" && !types.ValidRuntimeProviderCredential(providerClaim) {
-			return errors.New("invalid runtime provider claim")
+		request, err := joinRequest(rest)
+		if err != nil {
+			return err
 		}
-		if room == "" || name == "" || (agent == "" && agentCommand == "") ||
-			(agent != "" && agentCommand != "") {
-			return errUsage()
-		}
-		return runViaDaemon(&daemon.IpcRequest{
-			Op:            "join",
-			Room:          room,
-			Name:          name,
-			Agent:         agent,
-			AgentCommand:  agentCommand,
-			AgentArgs:     repeatedOption(rest, "--agent-arg"),
-			Capabilities:  repeatedOption(rest, "--capability"),
-			ProviderClaim: providerClaim,
-		})
+		return runViaDaemon(request)
 
 	case "connect":
 		room := option(rest, "--room")
@@ -175,23 +165,11 @@ func run(args []string) error {
 		})
 
 	case "create":
-		name := option(rest, "--name")
-		agent := option(rest, "--agent")
-		agentCommand := option(rest, "--agent-command")
-		// Create-only command shape: no --room exists here by design — the
-		// room id is generated server-side and returned inside the invite.
-		if hasFlag(rest, "--room") || name == "" ||
-			(agent == "" && agentCommand == "") || (agent != "" && agentCommand != "") {
-			return errUsage()
+		request, err := createRequest(rest)
+		if err != nil {
+			return err
 		}
-		return runViaDaemon(&daemon.IpcRequest{
-			Op:           "create",
-			Name:         name,
-			Agent:        agent,
-			AgentCommand: agentCommand,
-			AgentArgs:    repeatedOption(rest, "--agent-arg"),
-			Capabilities: repeatedOption(rest, "--capability"),
-		})
+		return runViaDaemon(request)
 
 	case "capabilities":
 		request := &daemon.IpcRequest{Op: "update-capabilities", InstanceID: option(rest, "--instance")}
@@ -426,6 +404,137 @@ func run(args []string) error {
 	}
 }
 
+// joinRequest keeps the low-level join parsing shared with the developer
+// convenience command, so both paths always submit the same daemon operation.
+func joinRequest(rest []string) (*daemon.IpcRequest, error) {
+	room := option(rest, "--room")
+	name := option(rest, "--name")
+	agent := option(rest, "--agent")
+	agentCommand := option(rest, "--agent-command")
+	providerClaim := option(rest, "--provider-claim")
+	if providerClaim != "" && !types.ValidRuntimeProviderCredential(providerClaim) {
+		return nil, errors.New("invalid runtime provider claim")
+	}
+	if room == "" || name == "" || (agent == "" && agentCommand == "") ||
+		(agent != "" && agentCommand != "") {
+		return nil, errUsage()
+	}
+	return &daemon.IpcRequest{
+		Op:            "join",
+		Room:          room,
+		Name:          name,
+		Agent:         agent,
+		AgentCommand:  agentCommand,
+		AgentArgs:     repeatedOption(rest, "--agent-arg"),
+		Capabilities:  repeatedOption(rest, "--capability"),
+		ProviderClaim: providerClaim,
+	}, nil
+}
+
+// createRequest keeps the low-level create parsing shared with the developer
+// convenience command. Create has no --room because the server generates the
+// Room and returns its public invite descriptor.
+func createRequest(rest []string) (*daemon.IpcRequest, error) {
+	name := option(rest, "--name")
+	agent := option(rest, "--agent")
+	agentCommand := option(rest, "--agent-command")
+	if hasFlag(rest, "--room") || name == "" ||
+		(agent == "" && agentCommand == "") || (agent != "" && agentCommand != "") {
+		return nil, errUsage()
+	}
+	return &daemon.IpcRequest{
+		Op:           "create",
+		Name:         name,
+		Agent:        agent,
+		AgentCommand: agentCommand,
+		AgentArgs:    repeatedOption(rest, "--agent-arg"),
+		Capabilities: repeatedOption(rest, "--capability"),
+	}, nil
+}
+
+// runRoom is the developer-facing composition layer for the existing create
+// and join lifecycle. It deliberately sends only the legacy daemon operations
+// and prints a small safe projection instead of the low-level JSON response.
+func runRoom(args []string) error {
+	if len(args) == 0 {
+		return errUsage()
+	}
+
+	subcommand, rest := args[0], args[1:]
+	switch subcommand {
+	case "create":
+		request, err := createRequest(rest)
+		if err != nil {
+			return err
+		}
+		result, err := executeDaemonRequest(request)
+		if err != nil {
+			return err
+		}
+		return printRoomCreate(result, request.Name)
+
+	case "join":
+		if len(rest) == 0 || rest[0] == "" || strings.HasPrefix(rest[0], "--") ||
+			hasFlag(rest[1:], "--room") {
+			return errUsage()
+		}
+		request, err := joinRequest(append([]string{"--room", rest[0]}, rest[1:]...))
+		if err != nil {
+			return err
+		}
+		result, err := executeDaemonRequest(request)
+		if err != nil {
+			return err
+		}
+		return printRoomJoin(result, request.Room, request.Name)
+
+	default:
+		return errUsage()
+	}
+}
+
+type roomCreateResponse struct {
+	Invite *types.RoomInviteDescriptorV1 `json:"invite"`
+}
+
+type roomJoinResponse struct {
+	RoomID string `json:"roomId"`
+}
+
+// printRoomCreate exposes only the public invite the server returned. It must
+// never print the daemon's raw response because that contract may grow private
+// resident fields over time.
+func printRoomCreate(raw json.RawMessage, name string) error {
+	var response roomCreateResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return errors.New("daemon create response was invalid")
+	}
+	if response.Invite == nil || strings.TrimSpace(response.Invite.RoomID) == "" ||
+		strings.TrimSpace(response.Invite.RoomURL) == "" {
+		return errors.New("daemon create response omitted the public Room invite")
+	}
+	fmt.Printf("✓ Created temporary Room\n✓ %s joined\n\nRoom: %s\nHuman UI: %s\n",
+		name, response.Invite.RoomID, response.Invite.RoomURL)
+	return nil
+}
+
+// printRoomJoin confirms that the existing daemon join lifecycle returned the
+// requested Room, without exposing participant or Runtime-private metadata.
+func printRoomJoin(raw json.RawMessage, requestedRoom, name string) error {
+	var response roomJoinResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return errors.New("daemon join response was invalid")
+	}
+	if response.RoomID == "" {
+		return errors.New("daemon join response omitted the Room id")
+	}
+	if response.RoomID != requestedRoom {
+		return errors.New("daemon join response did not match the requested Room")
+	}
+	fmt.Printf("✓ %s joined\nRoom: %s\n", name, response.RoomID)
+	return nil
+}
+
 // runVersion reports the build version without contacting the daemon or any
 // network service. The JSON form is the stable local bootstrap contract.
 func runVersion(args []string) error {
@@ -443,21 +552,31 @@ func runVersion(args []string) error {
 	return nil
 }
 
-// runViaDaemon performs the version-checked daemon handshake for join, then
-// sends the IPC request and pretty-prints the result.
+// runViaDaemon preserves the stable low-level CLI contract: it performs the
+// version-checked daemon handshake, then emits the daemon result as JSON.
 func runViaDaemon(request *daemon.IpcRequest) error {
-	if request.Op == "join" || request.Op == "connect" {
-		if err := daemon.EnsureDaemonVersion(doctor.Version); err != nil {
-			return err
-		}
-	} else if err := daemon.EnsureDaemon(); err != nil {
-		return err
-	}
-	result, err := daemon.SendIPC(request)
+	result, err := executeDaemonRequest(request)
 	if err != nil {
 		return err
 	}
 	return printJSONRaw(result)
+}
+
+// executeDaemonRequest is the shared daemon lifecycle boundary for the raw
+// automation commands and the human-friendly room namespace.
+func executeDaemonRequest(request *daemon.IpcRequest) (json.RawMessage, error) {
+	if request.Op == "join" || request.Op == "connect" {
+		if err := daemon.EnsureDaemonVersion(doctor.Version); err != nil {
+			return nil, err
+		}
+	} else if err := daemon.EnsureDaemon(); err != nil {
+		return nil, err
+	}
+	result, err := daemon.SendIPC(request)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // runPeers queries room_info directly — read-only discovery works with or

--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -514,7 +514,7 @@ func printRoomCreate(raw json.RawMessage, name string) error {
 		return errors.New("daemon create response omitted the public Room invite")
 	}
 	fmt.Printf("✓ Created temporary Room\n✓ %s joined\n\nRoom: %s\nHuman UI: %s\n",
-		name, response.Invite.RoomID, response.Invite.RoomURL)
+		terminalSafe(name), terminalSafe(response.Invite.RoomID), terminalSafe(response.Invite.RoomURL))
 	return nil
 }
 
@@ -531,8 +531,33 @@ func printRoomJoin(raw json.RawMessage, requestedRoom, name string) error {
 	if response.RoomID != requestedRoom {
 		return errors.New("daemon join response did not match the requested Room")
 	}
-	fmt.Printf("✓ %s joined\nRoom: %s\n", name, response.RoomID)
+	fmt.Printf("✓ %s joined\nRoom: %s\n", terminalSafe(name), terminalSafe(response.RoomID))
 	return nil
+}
+
+// terminalSafe renders terminal-control runes visibly rather than sending them
+// to the terminal. The Room remains opaque and unchanged for requests or JSON
+// automation; this applies only at the new human-facing display boundary.
+func terminalSafe(value string) string {
+	var output strings.Builder
+	for _, runeValue := range value {
+		switch runeValue {
+		case '\n':
+			output.WriteString(`\n`)
+		case '\r':
+			output.WriteString(`\r`)
+		case '\t':
+			output.WriteString(`\t`)
+		default:
+			if (runeValue >= 0 && runeValue <= 0x1f) || runeValue == 0x7f ||
+				(runeValue >= 0x80 && runeValue <= 0x9f) {
+				fmt.Fprintf(&output, `\x%02x`, runeValue)
+				continue
+			}
+			output.WriteRune(runeValue)
+		}
+	}
+	return output.String()
 }
 
 // runVersion reports the build version without contacting the daemon or any

--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/i365dev/free4chat/agent/internal/daemon"
 	"github.com/i365dev/free4chat/agent/internal/doctor"
@@ -509,6 +510,61 @@ func TestRoomHumanOutputExcludesDaemonPrivateFields(t *testing.T) {
 				t.Fatalf("human-facing room output leaked %q: %q", private, output)
 			}
 		}
+	}
+}
+
+func TestTerminalSafeEscapesTerminalControls(t *testing.T) {
+	input := "safe\n\r\t\x00\x1b\x7f\u009b"
+	if got, want := terminalSafe(input), `safe\n\r\t\x00\x1b\x7f\x9b`; got != want {
+		t.Fatalf("terminal-safe output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+	for _, runeValue := range terminalSafe(input) {
+		if unicode.IsControl(runeValue) {
+			t.Fatalf("terminal-safe output retained control rune %U", runeValue)
+		}
+	}
+}
+
+func TestRoomHumanOutputEscapesTerminalControls(t *testing.T) {
+	roomID := "safe\nFORGED\rROW\u009b2J"
+	name := "\x1b[31mPi\t"
+	createResult := json.RawMessage(`{
+  "invite":{"kind":"free4chat.room-invite","version":1,"roomId":"safe\nFORGED\rROW\u009b2J","roomUrl":"https://www.free4.chat/room?id=safe%0A\u001b]8;;https://attacker.example\u0007"}
+}`)
+	joinResult := json.RawMessage(`{"state":"waiting","roomId":"safe\nFORGED\rROW\u009b2J"}`)
+	fixture := roomFixture(t, createResult, joinResult)
+
+	createOutput, createCode := runCliWithFakeDaemon(t, fixture,
+		"room", "create", "--agent", "pi", "--name", name)
+	if createCode != 0 {
+		t.Fatalf("room create failed: %d %q", createCode, createOutput)
+	}
+	joinOutput, joinCode := runCliWithFakeDaemon(t, fixture,
+		"room", "join", roomID, "--agent", "codex", "--name", name)
+	if joinCode != 0 {
+		t.Fatalf("room join failed: %d %q", joinCode, joinOutput)
+	}
+
+	for _, output := range []string{createOutput, joinOutput} {
+		for _, runeValue := range []rune{'\x00', '\r', '\t', '\x1b', '\x7f', '\u009b'} {
+			if strings.ContainsRune(output, runeValue) {
+				t.Fatalf("human-facing room output retained control rune %U: %q", runeValue, output)
+			}
+		}
+		if strings.Contains(output, "safe\nFORGED") {
+			t.Fatalf("human-facing room output allowed a forged line: %q", output)
+		}
+	}
+	for _, expected := range []string{
+		"✓ \\x1b[31mPi\\t joined",
+		"Room: safe\\nFORGED\\rROW\\x9b2J",
+	} {
+		if !strings.Contains(createOutput, expected) || !strings.Contains(joinOutput, expected) {
+			t.Fatalf("room output omitted escaped public value %q:\ncreate: %q\njoin: %q", expected, createOutput, joinOutput)
+		}
+	}
+	if !strings.Contains(createOutput, "Human UI: https://www.free4.chat/room?id=safe%0A\\x1b]8;;https://attacker.example\\x07") {
+		t.Fatalf("room create did not escape the public Room URL: %q", createOutput)
 	}
 }
 

--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"syscall"
@@ -185,6 +186,118 @@ func runCli(t *testing.T, args ...string) (string, int) {
 	return out, -1
 }
 
+// fakeDaemon is a small IPC-only fixture for CLI composition tests. It speaks
+// the existing daemon envelope and records operations, so these tests prove
+// the room namespace does not invent a second daemon protocol.
+type fakeDaemon struct {
+	dir      string
+	listener net.Listener
+	requests chan daemon.IpcRequest
+	response func(daemon.IpcRequest) daemon.IpcResponse
+}
+
+func newFakeDaemon(t *testing.T, response func(daemon.IpcRequest) daemon.IpcResponse) *fakeDaemon {
+	t.Helper()
+	// Unix socket paths on macOS have a small fixed maximum. t.TempDir()
+	// includes the full test name, which can exceed it; use the same short
+	// temporary-directory pattern as the subprocess helper above.
+	dir, err := os.MkdirTemp("", "fcagent-fake-")
+	if err != nil {
+		t.Fatalf("fake daemon temp directory failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	listener, err := net.Listen("unix", filepath.Join(dir, "daemon.sock"))
+	if err != nil {
+		t.Fatalf("fake daemon listen failed: %v", err)
+	}
+	fixture := &fakeDaemon{
+		dir:      dir,
+		listener: listener,
+		requests: make(chan daemon.IpcRequest, 16),
+		response: response,
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go fixture.serve()
+	return fixture
+}
+
+func (d *fakeDaemon) serve() {
+	for {
+		conn, err := d.listener.Accept()
+		if err != nil {
+			return
+		}
+		go d.serveOne(conn)
+	}
+}
+
+func (d *fakeDaemon) serveOne(conn net.Conn) {
+	defer conn.Close()
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return
+	}
+	request, err := daemon.DecodeRequest([]byte(strings.TrimSpace(line)))
+	if err != nil {
+		return
+	}
+	d.requests <- *request
+	response, err := json.Marshal(d.response(*request))
+	if err == nil {
+		_, _ = conn.Write(append(response, '\n'))
+	}
+}
+
+func runCliWithFakeDaemon(t *testing.T, fixture *fakeDaemon, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Env = append(os.Environ(),
+		"FREE4CHAT_AGENT_DIR="+fixture.dir,
+		"FREE4CHAT_TEST_DISABLE_NATIVE_CREDENTIAL_STORE=1",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	output := string(stdout) + stderr.String()
+	if err == nil {
+		return output, 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return output, exitErr.ExitCode()
+	}
+	t.Fatalf("CLI run against fake daemon failed: %v", err)
+	return output, -1
+}
+
+func nextFakeRequest(t *testing.T, fixture *fakeDaemon) daemon.IpcRequest {
+	t.Helper()
+	select {
+	case request := <-fixture.requests:
+		return request
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for fake daemon request")
+		return daemon.IpcRequest{}
+	}
+}
+
+func roomFixture(t *testing.T, createResult, joinResult json.RawMessage) *fakeDaemon {
+	t.Helper()
+	return newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		switch request.Op {
+		case "status":
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		case "daemon-info":
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		case "create":
+			return daemon.IpcResponse{OK: true, Result: createResult}
+		case "join":
+			return daemon.IpcResponse{OK: true, Result: joinResult}
+		default:
+			return daemon.IpcResponse{OK: false, Error: "unexpected fake daemon operation"}
+		}
+	})
+}
+
 // TestTestDaemonStopIsScopedAndDeterministic pins the reclaim contract the
 // whole suite relies on: the daemon's own stop op tears down the socket and
 // then the process, without any signal or pattern kill, and nothing else is
@@ -267,6 +380,191 @@ func TestCreateRejectsRoomFlagAndMissingLauncher(t *testing.T) {
 		if !strings.Contains(output, "free4chat-agent create") {
 			t.Fatalf("usage text must mention the command: %q", output)
 		}
+	}
+}
+
+func TestRoomCommandsReuseCreateAndJoinDaemonOperations(t *testing.T) {
+	createResult := json.RawMessage(`{
+  "state":"waiting",
+  "roomId":"room-created",
+  "name":"Pi",
+  "invite":{"kind":"free4chat.room-invite","version":1,"roomId":"room-created","roomUrl":"https://www.free4.chat/room?id=room-created"}
+}`)
+	joinResult := json.RawMessage(`{
+  "state":"waiting",
+  "roomId":"room-created",
+  "name":"Codex"
+}`)
+	fixture := roomFixture(t, createResult, joinResult)
+
+	createOutput, createCode := runCliWithFakeDaemon(t, fixture,
+		"room", "create", "--agent", "pi", "--name", "Pi", "--capability", "code.edit")
+	if createCode != 0 {
+		t.Fatalf("room create failed: %d %q", createCode, createOutput)
+	}
+	if !strings.Contains(createOutput, "Created temporary Room") ||
+		!strings.Contains(createOutput, "Pi joined") ||
+		!strings.Contains(createOutput, "Room: room-created") ||
+		!strings.Contains(createOutput, "Human UI: https://www.free4.chat/room?id=room-created") {
+		t.Fatalf("room create human output mismatch: %q", createOutput)
+	}
+	if request := nextFakeRequest(t, fixture); request.Op != "status" {
+		t.Fatalf("room create must retain normal daemon readiness check, got %+v", request)
+	}
+	createRequest := nextFakeRequest(t, fixture)
+	if createRequest.Op != "create" || createRequest.Room != "" ||
+		createRequest.Agent != "pi" || createRequest.Name != "Pi" ||
+		!reflect.DeepEqual(createRequest.Capabilities, []string{"code.edit"}) {
+		t.Fatalf("room create must submit the legacy create request, got %+v", createRequest)
+	}
+
+	joinOutput, joinCode := runCliWithFakeDaemon(t, fixture,
+		"room", "join", "room-created", "--agent", "codex", "--name", "Codex", "--capability", "shell")
+	if joinCode != 0 {
+		t.Fatalf("room join failed: %d %q", joinCode, joinOutput)
+	}
+	if !strings.Contains(joinOutput, "Codex joined") ||
+		!strings.Contains(joinOutput, "Room: room-created") {
+		t.Fatalf("room join human output mismatch: %q", joinOutput)
+	}
+	if request := nextFakeRequest(t, fixture); request.Op != "daemon-info" {
+		t.Fatalf("room join must retain daemon version handshake, got %+v", request)
+	}
+	joinRequest := nextFakeRequest(t, fixture)
+	if joinRequest.Op != "join" || joinRequest.Room != "room-created" ||
+		joinRequest.Agent != "codex" || joinRequest.Name != "Codex" ||
+		!reflect.DeepEqual(joinRequest.Capabilities, []string{"shell"}) {
+		t.Fatalf("room join must submit the legacy join request, got %+v", joinRequest)
+	}
+}
+
+func TestRoomJoinPreservesCustomLauncherAndAllowsMultipleLocalResidents(t *testing.T) {
+	joinResult := json.RawMessage(`{"state":"waiting","roomId":"shared-room"}`)
+	fixture := roomFixture(t, json.RawMessage(`{}`), joinResult)
+
+	for _, command := range [][]string{
+		{"room", "join", "shared-room", "--agent-command", "custom-acp", "--agent-arg", "--stdio", "--agent-arg", "json", "--name", "Custom"},
+		{"room", "join", "shared-room", "--agent", "hermes", "--name", "Hermes"},
+	} {
+		output, code := runCliWithFakeDaemon(t, fixture, command...)
+		if code != 0 {
+			t.Fatalf("%v failed: %d %q", command, code, output)
+		}
+		if request := nextFakeRequest(t, fixture); request.Op != "daemon-info" {
+			t.Fatalf("room join must use the existing daemon handshake, got %+v", request)
+		}
+		request := nextFakeRequest(t, fixture)
+		if request.Op != "join" || request.Room != "shared-room" {
+			t.Fatalf("room join must not impose a team/group restriction, got %+v", request)
+		}
+		if request.AgentCommand == "custom-acp" && !reflect.DeepEqual(request.AgentArgs, []string{"--stdio", "json"}) {
+			t.Fatalf("custom launcher arguments changed: %+v", request)
+		}
+	}
+}
+
+func TestRoomHumanOutputExcludesDaemonPrivateFields(t *testing.T) {
+	createResult := json.RawMessage(`{
+  "roomId":"safe-room",
+  "participantId":"participant-visible-but-unneeded",
+  "participantHandle":"participant-handle-private",
+  "participantToken":"participant-token-private",
+  "runtimeProviderHandle":"provider-handle-private",
+  "providerClaim":"provider-claim-private",
+  "runtimeProviderProof":"provider-proof-private",
+  "sfuSessionId":"sfu-session-private",
+  "internalSecret":"internal-secret-private",
+  "invite":{"kind":"free4chat.room-invite","version":1,"roomId":"safe-room","roomUrl":"https://www.free4.chat/room?id=safe-room"}
+}`)
+	joinResult := json.RawMessage(`{
+  "roomId":"safe-room",
+  "participantId":"participant-visible-but-unneeded",
+  "participantHandle":"participant-handle-private",
+  "participantToken":"participant-token-private",
+  "runtimeProviderHandle":"provider-handle-private",
+  "providerClaim":"provider-claim-private",
+  "runtimeProviderProof":"provider-proof-private",
+  "sfuSessionId":"sfu-session-private",
+  "internalSecret":"internal-secret-private"
+}`)
+	fixture := roomFixture(t, createResult, joinResult)
+
+	createOutput, createCode := runCliWithFakeDaemon(t, fixture,
+		"room", "create", "--agent", "pi", "--name", "Pi")
+	if createCode != 0 {
+		t.Fatalf("room create failed: %d %q", createCode, createOutput)
+	}
+	joinOutput, joinCode := runCliWithFakeDaemon(t, fixture,
+		"room", "join", "safe-room", "--agent", "codex", "--name", "Codex")
+	if joinCode != 0 {
+		t.Fatalf("room join failed: %d %q", joinCode, joinOutput)
+	}
+	for _, output := range []string{createOutput, joinOutput} {
+		for _, private := range []string{
+			"participant-handle-private", "participant-token-private", "provider-handle-private",
+			"provider-claim-private", "provider-proof-private", "sfu-session-private", "internal-secret-private",
+			"participant-visible-but-unneeded", "{\"roomId\"",
+		} {
+			if strings.Contains(output, private) {
+				t.Fatalf("human-facing room output leaked %q: %q", private, output)
+			}
+		}
+	}
+}
+
+func TestRoomCommandsKeepLegacyMachineReadableOutput(t *testing.T) {
+	createResult := json.RawMessage(`{"state":"waiting","roomId":"legacy-room","name":"Pi","instanceId":"instance-a","participantId":"participant-a","invite":{"kind":"free4chat.room-invite","version":1,"roomId":"legacy-room","roomUrl":"https://www.free4.chat/room?id=legacy-room"}}`)
+	joinResult := json.RawMessage(`{"state":"waiting","roomId":"legacy-room","name":"Codex","instanceId":"instance-b","participantId":"participant-b"}`)
+	fixture := roomFixture(t, createResult, joinResult)
+
+	for _, test := range []struct {
+		args     []string
+		expected json.RawMessage
+	}{
+		{[]string{"create", "--agent", "pi", "--name", "Pi"}, createResult},
+		{[]string{"join", "--room", "legacy-room", "--agent", "codex", "--name", "Codex"}, joinResult},
+	} {
+		output, code := runCliWithFakeDaemon(t, fixture, test.args...)
+		if code != 0 {
+			t.Fatalf("legacy %v failed: %d %q", test.args, code, output)
+		}
+		var got, want any
+		if err := json.Unmarshal([]byte(output), &got); err != nil {
+			t.Fatalf("legacy %v stopped returning JSON: %v (%q)", test.args, err, output)
+		}
+		if err := json.Unmarshal(test.expected, &want); err != nil {
+			t.Fatalf("bad expected fixture: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("legacy %v response changed:\n got: %#v\nwant: %#v", test.args, got, want)
+		}
+	}
+}
+
+func TestRoomRejectsInvalidCommandShapesAndMalformedDaemonOutput(t *testing.T) {
+	for _, args := range [][]string{
+		{"room"},
+		{"room", "create", "--room", "not-allowed", "--agent", "pi", "--name", "Pi"},
+		{"room", "join", "--room", "not-allowed", "--agent", "pi", "--name", "Pi"},
+		{"room", "join", "safe-room", "--room", "not-allowed", "--agent", "pi", "--name", "Pi"},
+		{"room", "join", "safe-room", "--name", "Pi"},
+		{"room", "unknown"},
+	} {
+		output, code := runCli(t, args...)
+		if code != 2 || !strings.Contains(output, "free4chat-agent room") {
+			t.Fatalf("room %v must usage-exit without a daemon request: code=%d output=%q", args, code, output)
+		}
+	}
+
+	fixture := roomFixture(t,
+		json.RawMessage(`{"participantHandle":"malformed-response-private"}`),
+		json.RawMessage(`{"participantHandle":"malformed-response-private"}`),
+	)
+	output, code := runCliWithFakeDaemon(t, fixture,
+		"room", "create", "--agent", "pi", "--name", "Pi")
+	if code != 1 || !strings.Contains(output, "omitted the public Room invite") ||
+		strings.Contains(output, "malformed-response-private") {
+		t.Fatalf("malformed create response must fail closed without echoing private fields: code=%d output=%q", code, output)
 	}
 }
 

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.12"
+var Version = "0.5.13"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
Part of #208

## Phase A: browser-optional Agent setup

Adds a thin, developer-friendly namespace over the existing resident-Agent lifecycle:

```text
free4chat-agent room create --agent pi --name Pi
free4chat-agent room join <room-id> --agent codex --name Codex
```

`room join` uses a positional Room id for terminal ergonomics. Built-in Harnesses, custom `--agent-command` / repeated `--agent-arg`, capabilities, and the existing join-only provider claim option retain their current parsing semantics.

## Lifecycle and compatibility

The new commands reuse the exact existing daemon IPC operations:
- `room create` sends `create`
- `room join` sends `join`

No daemon operation, Room API, Room type, Runtime lifecycle, MCP behavior, collaboration protocol, or authorization boundary changed.

Legacy automation remains intact:
- `free4chat-agent create ...`
- `free4chat-agent join --room <room-id> ...`

Both still emit their existing machine-readable JSON response unchanged.

## Human-facing output

The new path projects only the useful safe fields:

```text
✓ Created temporary Room
✓ Pi joined

Room: q7xm2
Human UI: https://www.free4.chat/room?id=q7xm2

✓ Codex joined
Room: q7xm2
```

Create uses the existing server-returned public invite descriptor as the sole source for the Human URL; it does not reconstruct a URL.

The formatter deliberately excludes raw IPC JSON, participant ids/handles/tokens, Runtime provider claims/handles/proofs, SFU session data, instance ids, and any future private daemon fields. Malformed daemon responses fail closed without echoing their contents.

## Files changed

- `agent/internal/cli/cli.go`
- `agent/internal/cli/cli_test.go`
- `agent/internal/doctor/doctor.go`

## Validation

- `gofmt -w internal/cli/cli.go internal/cli/cli_test.go internal/doctor/doctor.go`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `agent/scripts/check-cleanup.sh`
- `agent/scripts/test-bootstrap-contract.sh`
- `bash agent/scripts/test-install-agent.sh`
- native `darwin/arm64` release build plus `version --json` and `doctor --json` smoke

Focused CLI coverage includes built-in/custom parsing, create/join operation reuse, multiple same-Room joins, safe output projection, private-field exclusion, malformed response fail-closed behavior, invalid command shapes, and legacy JSON equivalence.

## Runtime staging

- Source Runtime version: `0.5.13`
- Live `app/public/agent.md` bootstrap: released `0.5.12`

This PR deliberately does not activate the unpublished version, create a tag, or publish a release.

After merge: publish `agent-v0.5.13`, verify the four native assets plus `SHA256SUMS` and version contract, then activate the bootstrap from `0.5.12` to `0.5.13`.

## Production dogfood after release + bootstrap activation

1. On Machine A, run `free4chat-agent room create --agent <A> --name "Agent A"` and record the safe Room id.
2. Share only that Room id with Machine B.
3. On Machine B, run `free4chat-agent room join <room-id> --agent <B> --name "Agent B"`.
4. Verify both Agents are visible in the ordinary Room; no browser was required for setup.
5. Use `peers` to discover participant ids, then exercise the existing structured request → local work → artifact/result → consuming-Agent path without a shared filesystem.
6. Optionally open the same Room in the browser to confirm it remains an ordinary compatible Human surface.

## Explicit non-goals

- Phase B Human terminal participant, stdin chat loop, message stream, or TUI
- Phase C multi-Agent `--with` sugar, teams, groups, templates, workspaces, or orchestration
- Harness session attach, takeover, resume, or co-driving
- Any Room, MCP, transcript, Voice, artifact, or provider-authorization redesign