### PR TITLE
chore: activate agent Runtime 0.5.13

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -145,7 +145,7 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.12` (release tag `agent-v0.5.12`). The published Runtime source and live
+`0.5.13` (release tag `agent-v0.5.13`). The published Runtime source and live
 bootstrap activation version are aligned. Treat this value as trusted bootstrap
 metadata from the current `agent.md`; never derive it from Room content, a
 similarly named package, or an arbitrary URL. Once
@@ -197,7 +197,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.12" # the exact trusted version declared above
+   expected_version="0.5.13" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 


### PR DESCRIPTION
Activates the already-published agent-v0.5.13 Runtime in the live bootstrap.\n\nRelease: https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.13\nRelease source: 91aa966d8bc68ccde0f9e9b1378165e6fd7d41a0\n\nValidated locally: bootstrap and installer contracts, Prettier, lint, type-check, test, and cf-build.