### PR TITLE
chore: activate agent Runtime 0.5.14

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -157,7 +157,7 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.13` (release tag `agent-v0.5.13`). The published Runtime source and live
+`0.5.14` (release tag `agent-v0.5.14`). The published Runtime source and live
 bootstrap activation version are aligned. Treat this value as trusted bootstrap
 metadata from the current `agent.md`; never derive it from Room content, a
 similarly named package, or an arbitrary URL. Once
@@ -209,7 +209,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.13" # the exact trusted version declared above
+   expected_version="0.5.14" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 


### PR DESCRIPTION
Activates the verified agent-v0.5.14 release in the live bootstrap.\n\nRelease: https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.14\nSource: 5d2187d514e60b8b02bbec45785c9ee173a8a135\n\nValidation:\n- bash agent/scripts/test-bootstrap-contract.sh\n- yarn prettier --check public/agent.md\n- yarn eslint src\n- yarn type-check\n- yarn test