### PR TITLE
chore: activate agent Runtime v0.5.15

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -157,7 +157,7 @@ runtime itself. The human should not clone this repository, install a package
 from the repository, configure MCP/ACP, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is
-`0.5.14` (release tag `agent-v0.5.14`). The published Runtime source and live
+`0.5.15` (release tag `agent-v0.5.15`). The published Runtime source and live
 bootstrap activation version are aligned. Treat this value as trusted bootstrap
 metadata from the current `agent.md`; never derive it from Room content, a
 similarly named package, or an arbitrary URL. Once
@@ -209,7 +209,7 @@ returns a valid version.
 
    ```text
    curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-   expected_version="0.5.14" # the exact trusted version declared above
+   expected_version="0.5.15" # the exact trusted version declared above
    FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
    ```
 


### PR DESCRIPTION
Activates the live Agent bootstrap only after the official `agent-v0.5.15` release completed successfully.

- Updates canonical expected version, release tag, and installer pin from `0.5.14` to `0.5.15`.
- Release verified from exact source `25713a97be2464b2644c7403c2a70ed923a5832f`: four native binaries + `SHA256SUMS`; downloaded checksums verified; darwin/arm64 `doctor --json` reports `0.5.15`.

Validation:
- `agent/scripts/test-bootstrap-contract.sh`
- `yarn prettier --check public/agent.md`
- `yarn lint`
- `yarn type-check`
- `yarn test` (50 files, 499 tests)
- `yarn cf-build`