### PR TITLE
feat(web): advertise llms.txt discovery

### DIFF
--- a/README.tmp
+++ b/README.tmp
@@ -1,0 +1,1 @@
+placeholder

--- a/README.tmp
+++ b/README.tmp
@@ -1,1 +1,0 @@
-placeholder

--- a/app/src/__tests__/discovery/crawl-surface.test.ts
+++ b/app/src/__tests__/discovery/crawl-surface.test.ts
@@ -103,9 +103,15 @@ describe("sitemap.xml", () => {
 })
 
 describe("_document.tsx", () => {
+  const source = readFileSync(join(ROOT, "src/pages/_document.tsx"), "utf-8")
+
   it("does not set a description meta tag (next/document renders unconditionally on every page and next/head does not dedupe plain <meta> tags, so a fallback here would duplicate each page's own description)", () => {
-    const source = readFileSync(join(ROOT, "src/pages/_document.tsx"), "utf-8")
     expect(source).not.toMatch(/name="description"/)
+  })
+
+  it("advertises the site-wide llms.txt through the standard describedby link relation", () => {
+    expect(source).toContain('rel="describedby"')
+    expect(source).toContain('href="https://www.free4.chat/llms.txt"')
   })
 })
 

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -22,6 +22,10 @@ class MyDocument extends Document {
               every page unconditionally and next/head does not dedupe plain
               <meta> tags, so a "fallback" here would just duplicate the
               page-specific one each route sets itself (see Header/SeoHead). */}
+          <link
+            rel="describedby"
+            href="https://www.free4.chat/llms.txt"
+          />
           <link rel="icon" href="/favicon.ico" />
           <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -22,10 +22,7 @@ class MyDocument extends Document {
               every page unconditionally and next/head does not dedupe plain
               <meta> tags, so a "fallback" here would just duplicate the
               page-specific one each route sets itself (see Header/SeoHead). */}
-          <link
-            rel="describedby"
-            href="https://www.free4.chat/llms.txt"
-          />
+          <link rel="describedby" href="https://www.free4.chat/llms.txt" />
           <link rel="icon" href="/favicon.ico" />
           <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"


### PR DESCRIPTION
## Summary

Advertise the existing root `llms.txt` from every HTML page using the llms.txt v2 discovery relation:

```html
<link rel="describedby" href="https://www.free4.chat/llms.txt" />
```

This lets compatible Agents discover the site-wide LLM index from any public HTML page without guessing `/llms.txt`.

## Scope

- add the global `rel="describedby"` link in `_document.tsx`
- extend the existing crawl-surface test to lock the discovery contract
- no changes to `llms.txt`, `llms-full.txt`, sitemap, robots, docs content, Room behavior, Runtime, MCP, or media

## Rationale

The root `llms.txt` already provides the curated Agent index and points to `/llms-full.txt`, `/agent.md`, `/speech.md`, and the Markdown docs. This change only makes that existing entry point discoverable through the standard link relation recommended by llms.txt v2.