### PR TITLE
fix(ui): make normal Human and Agent participant cards equal height

### DIFF
--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -1,17 +1,13 @@
-import { readFileSync } from "node:fs"
-
 import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 /**
- * #228 production follow-up: the previous uniform min-height contract did not
- * make Human and Agent cards equal because Agent-only controls could still
- * grow the card. Normal RoomContent cards now share one fixed outer height;
- * compact/screen-share cards remain content-sized.
- *
- * jsdom cannot measure real layout, so this test pins both halves of the
- * implementation contract: the unique normal-card wrapper shape and the CSS
- * rule that fixes its direct UserCard child to 16rem. Production visual smoke
- * remains the final check.
+ * #228 participant-card visual consistency: in the NORMAL participant grid,
+ * every UserCard root carries the SAME uniform min-height contract, so
+ * Agent-only controls (Request work + Voice) live inside a shared reserved
+ * card height instead of stretching Agent cards taller than Human cards.
+ * jsdom cannot measure layout; this pins the class contract that produces
+ * equal heights (uniform min-height on every normal card root). Visual
+ * confirmation happens in the production regression pass.
  */
 
 vi.mock("next/router", () => ({
@@ -75,52 +71,34 @@ describe("participant card equal-height contract (#228)", () => {
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it(
-    "normal-grid participant cards share one fixed outer-height contract regardless of kind",
-    () => {
-      mockUseSfuChatRoom.mockReturnValue(
-        hookReturn([
-          { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
-          { peerId: "agent-pi", name: "Pi", kind: "agent", room: "test-room" },
-          {
-            peerId: "human-r",
-            name: "Remote",
-            kind: "human",
-            room: "test-room",
-          },
-        ])
-      )
-      render(
-        <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
-      )
+  it("normal-grid participant cards share the stretch/height contract regardless of kind", () => {
+    mockUseSfuChatRoom.mockReturnValue(
+      hookReturn([
+        { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
+        { peerId: "agent-pi", name: "Pi", kind: "agent", room: "test-room" },
+        {
+          peerId: "human-r",
+          name: "Remote",
+          kind: "human",
+          room: "test-room",
+        },
+      ])
+    )
+    render(
+      <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
+    )
 
-      // RoomContent gives exactly this wrapper to every NORMAL UserCard.
-      const normalCardWrappers = Array.from(
-        document.querySelectorAll("div.w-40.flex-none")
-      )
-      expect(normalCardWrappers.length).toBe(3)
+    // Every normal-grid participant card root carries the SAME uniform
+    // min-height — Human self, Agents with controls, remote Humans.
+    const cards = Array.from(
+      document.querySelectorAll("div.rounded-xl.border-gray-700")
+    ).filter((el) => el.className.includes("min-h-[196px]"))
+    expect(cards.length).toBe(3)
 
-      // UserCard still carries its old minimum as a harmless fallback, but the
-      // stylesheet now pins the normal wrapper's direct card child to one real
-      // fixed height so Agent-only controls cannot grow the outer card.
-      const cards = Array.from(
-        document.querySelectorAll("div.rounded-xl.border-gray-700")
-      ).filter((el) => el.className.includes("min-h-[196px]"))
-      expect(cards.length).toBe(3)
-
-      const css = readFileSync(
-        new URL("../styles/tailwind.css", import.meta.url),
-        "utf8"
-      )
-      expect(css).toContain(".w-40.flex-none > div.rounded-xl.border-gray-700 {")
-      expect(css).toContain("height: 16rem;")
-      expect(css).toContain("min-height: 16rem;")
-
-      // The grid stays top-aligned; no full-panel-height stretching returns.
-      const grid = document.querySelector(".flex-wrap.items-start")
-      expect(grid).toBeTruthy()
-      expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
-      expect(document.querySelectorAll("[data-peer]").length).toBe(0)
-    }
-  )
+    // The grid top-aligns rows; no full-panel-height stretching remains.
+    const grid = document.querySelector(".flex-wrap.items-start")
+    expect(grid).toBeTruthy()
+    expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
+    expect(document.querySelectorAll("[data-peer]").length).toBe(0)
+  })
 })

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -75,51 +75,52 @@ describe("participant card equal-height contract (#228)", () => {
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it("normal-grid participant cards share one fixed outer-height contract regardless of kind", () => {
-    mockUseSfuChatRoom.mockReturnValue(
-      hookReturn([
-        { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
-        { peerId: "agent-pi", name: "Pi", kind: "agent", room: "test-room" },
-        {
-          peerId: "human-r",
-          name: "Remote",
-          kind: "human",
-          room: "test-room",
-        },
-      ])
-    )
-    render(
-      <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
-    )
+  it(
+    "normal-grid participant cards share one fixed outer-height contract regardless of kind",
+    () => {
+      mockUseSfuChatRoom.mockReturnValue(
+        hookReturn([
+          { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
+          { peerId: "agent-pi", name: "Pi", kind: "agent", room: "test-room" },
+          {
+            peerId: "human-r",
+            name: "Remote",
+            kind: "human",
+            room: "test-room",
+          },
+        ])
+      )
+      render(
+        <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
+      )
 
-    // RoomContent gives exactly this wrapper to every NORMAL UserCard.
-    const normalCardWrappers = Array.from(
-      document.querySelectorAll("div.w-40.flex-none")
-    )
-    expect(normalCardWrappers.length).toBe(3)
+      // RoomContent gives exactly this wrapper to every NORMAL UserCard.
+      const normalCardWrappers = Array.from(
+        document.querySelectorAll("div.w-40.flex-none")
+      )
+      expect(normalCardWrappers.length).toBe(3)
 
-    // UserCard still carries its old minimum as a harmless fallback, but the
-    // stylesheet now pins the normal wrapper's direct card child to one real
-    // fixed height so Agent-only controls cannot grow the outer card.
-    const cards = Array.from(
-      document.querySelectorAll("div.rounded-xl.border-gray-700")
-    ).filter((el) => el.className.includes("min-h-[196px]"))
-    expect(cards.length).toBe(3)
+      // UserCard still carries its old minimum as a harmless fallback, but the
+      // stylesheet now pins the normal wrapper's direct card child to one real
+      // fixed height so Agent-only controls cannot grow the outer card.
+      const cards = Array.from(
+        document.querySelectorAll("div.rounded-xl.border-gray-700")
+      ).filter((el) => el.className.includes("min-h-[196px]"))
+      expect(cards.length).toBe(3)
 
-    const css = readFileSync(
-      new URL("../styles/tailwind.css", import.meta.url),
-      "utf8"
-    )
-    expect(css).toContain(
-      ".w-40.flex-none > div.rounded-xl.border-gray-700 {"
-    )
-    expect(css).toContain("height: 16rem;")
-    expect(css).toContain("min-height: 16rem;")
+      const css = readFileSync(
+        new URL("../styles/tailwind.css", import.meta.url),
+        "utf8"
+      )
+      expect(css).toContain(".w-40.flex-none > div.rounded-xl.border-gray-700 {")
+      expect(css).toContain("height: 16rem;")
+      expect(css).toContain("min-height: 16rem;")
 
-    // The grid stays top-aligned; no full-panel-height stretching returns.
-    const grid = document.querySelector(".flex-wrap.items-start")
-    expect(grid).toBeTruthy()
-    expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
-    expect(document.querySelectorAll("[data-peer]").length).toBe(0)
-  })
+      // The grid stays top-aligned; no full-panel-height stretching returns.
+      const grid = document.querySelector(".flex-wrap.items-start")
+      expect(grid).toBeTruthy()
+      expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
+      expect(document.querySelectorAll("[data-peer]").length).toBe(0)
+    }
+  )
 })

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -1,13 +1,17 @@
+import { readFileSync } from "node:fs"
+
 import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 /**
- * #228 participant-card visual consistency: in the NORMAL participant grid,
- * every UserCard root carries the SAME uniform min-height contract, so
- * Agent-only controls (Request work + Voice) live inside a shared reserved
- * card height instead of stretching Agent cards taller than Human cards.
- * jsdom cannot measure layout; this pins the class contract that produces
- * equal heights (uniform min-height on every normal card root). Visual
- * confirmation happens in the production regression pass.
+ * #228 production follow-up: the previous uniform min-height contract did not
+ * make Human and Agent cards equal because Agent-only controls could still
+ * grow the card. Normal RoomContent cards now share one fixed outer height;
+ * compact/screen-share cards remain content-sized.
+ *
+ * jsdom cannot measure real layout, so this test pins both halves of the
+ * implementation contract: the unique normal-card wrapper shape and the CSS
+ * rule that fixes its direct UserCard child to 16rem. Production visual smoke
+ * remains the final check.
  */
 
 vi.mock("next/router", () => ({
@@ -71,7 +75,7 @@ describe("participant card equal-height contract (#228)", () => {
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it("normal-grid participant cards share the stretch/height contract regardless of kind", () => {
+  it("normal-grid participant cards share one fixed outer-height contract regardless of kind", () => {
     mockUseSfuChatRoom.mockReturnValue(
       hookReturn([
         { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
@@ -88,14 +92,31 @@ describe("participant card equal-height contract (#228)", () => {
       <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
     )
 
-    // Every normal-grid participant card root carries the SAME uniform
-    // min-height — Human self, Agents with controls, remote Humans.
+    // RoomContent gives exactly this wrapper to every NORMAL UserCard.
+    const normalCardWrappers = Array.from(
+      document.querySelectorAll("div.w-40.flex-none")
+    )
+    expect(normalCardWrappers.length).toBe(3)
+
+    // UserCard still carries its old minimum as a harmless fallback, but the
+    // stylesheet now pins the normal wrapper's direct card child to one real
+    // fixed height so Agent-only controls cannot grow the outer card.
     const cards = Array.from(
       document.querySelectorAll("div.rounded-xl.border-gray-700")
     ).filter((el) => el.className.includes("min-h-[196px]"))
     expect(cards.length).toBe(3)
 
-    // The grid top-aligns rows; no full-panel-height stretching remains.
+    const css = readFileSync(
+      new URL("../styles/tailwind.css", import.meta.url),
+      "utf8"
+    )
+    expect(css).toContain(
+      ".w-40.flex-none > div.rounded-xl.border-gray-700 {"
+    )
+    expect(css).toContain("height: 16rem;")
+    expect(css).toContain("min-height: 16rem;")
+
+    // The grid stays top-aligned; no full-panel-height stretching returns.
     const grid = document.querySelector(".flex-wrap.items-start")
     expect(grid).toBeTruthy()
     expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -6,6 +6,15 @@ html {
   @apply antialiased;
 }
 
+/* Normal participant cards are the one UserCard shape RoomContent wraps with
+   `w-40 flex-none`. Keep their OUTER card height fixed so Agent-only actions
+   (Request work + Voice) consume reserved space instead of making Agent cards
+   taller than Human cards. Compact/screen-share cards use different wrappers. */
+.w-40.flex-none > div.rounded-xl.border-gray-700 {
+  height: 16rem;
+  min-height: 16rem;
+}
+
 /* --- Retro terminal scope (homepage only) --- */
 
 .retro-scope {


### PR DESCRIPTION
Production regression follow-up to #228 / #229.

Dogfood confirmed the underlying visual asymmetry, but this fixed-height approach is intentionally NOT being shipped.

Why closed:
- Human and Agent card height differences are cosmetic and acceptable for now;
- the proposed `16rem` fixed height is a magic number tied to today's content;
- the selector depends on incidental Tailwind/layout classes rather than a semantic component contract;
- equal height is not important enough to justify that brittleness.

The broader participant-card polish work has been folded into #200, together with Room-visible Runtime Host version metadata. Future work should use a semantic card structure / natural grid or flex layout rather than a hard-coded height.

No code from this PR should be merged.