### PR TITLE
ux(room): simplify Live Transcript header control

### DIFF
--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -648,11 +648,12 @@ and provisioning contract is [/speech.md](/speech.md).
 
 A configured provider alone grants nothing: a Human explicitly starts the
 Room-wide transcript through an authorized STT-ready Runtime Host, and any
-Human may stop it. In the browser, use **Connect local Runtime** to connect
-an already-running Runtime on your computer first. The browser prepares a
-one-time local handoff command for you; it is not an Agent invitation, and
-the connection value must never be pasted into Room chat or a model
-conversation.
+Human may stop it. In the browser, open **Live Transcript** in the Room.
+If transcription setup is needed, use **Copy setup command** and run the
+copied command on the computer where the Free4Chat Runtime is running. The
+browser prepares a one-time local handoff command for you; it is not an
+Agent invitation, and the connection value must never be pasted into Room
+chat or a model conversation.
 
 After the Runtime connects, the Live Transcript control shows
 **Ready to start** and the transcript Start control becomes available.
@@ -886,9 +887,9 @@ free4chat-agent room join ... --provider-claim <opaque-secret>
 ```
 
 `--provider-claim` carries the one-time opaque connection value produced by
-the browser's **Connect local Runtime** flow (used for speech features such
-as Live Transcript). It is not an Agent invitation; never paste such a
-handoff value into Room chat or a model conversation. See
+the setup command copied from the Room's **Live Transcript** control (used
+for speech features such as Live Transcript). It is not an Agent invitation;
+never paste such a handoff value into Room chat or a model conversation. See
 [Live Transcript](../guides/live-transcript).
 
 ---

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -118,8 +118,9 @@ container - not from the browser. Two paths exist:
   Runtime itself and joins your Room. See
   [Agent Room quick start](agent-room).
 - Connect your own already-running local Runtime through the Room's
-  **Connect local Runtime** control for speech features such as Live
-  Transcript. See [Live Transcript](/docs/guides/live-transcript).
+  **Live Transcript** control (it offers a setup command when no
+  transcription Runtime is connected). See
+  [Live Transcript](/docs/guides/live-transcript).
 
 There is no centralized Agent hosting on the Free4Chat side: Agents run on
 your machines with your tools and credentials.
@@ -653,8 +654,8 @@ one-time local handoff command for you; it is not an Agent invitation, and
 the connection value must never be pasted into Room chat or a model
 conversation.
 
-After the Runtime connects, the Room shows **Local Runtime ready** and the
-transcript Start control becomes available.
+After the Runtime connects, the Live Transcript control shows
+**Ready to start** and the transcript Start control becomes available.
 
 ## Transcript visibility never wakes an Agent
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1728,10 +1728,11 @@ A configured provider does not grant media access. A Human explicitly starts
 Live Transcript through an authorized STT-ready Runtime Host, and any Human may
 stop it.
 
-In the browser, **Connect local Runtime** connects an already-running Runtime
-on the same computer. The browser prepares a one-time local handoff command.
-That handoff value is not an Agent invitation and must not be pasted into Room
-chat or a model conversation.
+In the browser, open **Live Transcript**. If transcription setup is needed,
+use **Copy setup command** and run the copied command on the computer where
+Free4Chat Runtime is running. The browser prepares a one-time local handoff
+command. That handoff value is not an Agent invitation and must not be pasted
+into Room chat or a model conversation.
 
 Seeing committed transcript context does not itself wake an Agent. Explicit
 addressing controls Harness activation.

--- a/app/public/speech.md
+++ b/app/public/speech.md
@@ -102,10 +102,11 @@ A configured provider does not grant media access. A Human explicitly starts
 Live Transcript through an authorized STT-ready Runtime Host, and any Human may
 stop it.
 
-In the browser, **Connect local Runtime** connects an already-running Runtime
-on the same computer. The browser prepares a one-time local handoff command.
-That handoff value is not an Agent invitation and must not be pasted into Room
-chat or a model conversation.
+In the browser, open **Live Transcript**. If transcription setup is needed,
+use **Copy setup command** and run the copied command on the computer where
+Free4Chat Runtime is running. The browser prepares a one-time local handoff
+command. That handoff value is not an Agent invitation and must not be pasted
+into Room chat or a model conversation.
 
 Seeing committed transcript context does not itself wake an Agent. Explicit
 addressing controls Harness activation.

--- a/app/src/components/LiveTranscript.test.tsx
+++ b/app/src/components/LiveTranscript.test.tsx
@@ -18,7 +18,11 @@ const readyHost = {
   "host-a": { runtimeHostId: "host-a", speech: { stt: true, tts: true } },
 }
 
-describe("Room-wide Live Transcript UI (#177 PR3)", () => {
+function openControl() {
+  fireEvent.click(screen.getByRole("button", { name: "Live Transcript" }))
+}
+
+describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)", () => {
   it("starts directly through the one server-associated STT-ready Runtime Host", () => {
     const onStart = vi.fn()
     render(
@@ -36,8 +40,13 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
       />
     )
 
+    // #236: the single header control opens the feature popover; Start lives
+    // inside it and must not render the opaque host id.
+    openControl()
+    expect(screen.getByText("Ready to start.")).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Start" }))
     expect(onStart).toHaveBeenCalledWith("host-a")
+    expect(screen.queryByText("host-a")).not.toBeInTheDocument()
   })
 
   it("does not mistake a copied public Runtime Host id for authorization", () => {
@@ -65,13 +74,17 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
         onStop={vi.fn()}
       />
     )
-    expect(screen.getByRole("button", { name: "Start" })).toBeDisabled()
+    openControl()
+    // No authorized Host: the feature popover explains transcription is
+    // unavailable; no Start is offered and no id leaks.
+    expect(screen.queryByRole("button", { name: "Start" })).toBeNull()
     expect(
-      screen.getByTitle("No authorized transcription Runtime is available")
+      screen.getByText("Transcription is unavailable in this room right now.")
     ).toBeInTheDocument()
+    expect(screen.queryByText("host-a")).not.toBeInTheDocument()
   })
 
-  it("offers an understandable local Runtime connection when no Host is authorized", () => {
+  it("keeps a single compact header control with setup inside the popover when no Host is authorized", () => {
     const onConnect = vi.fn()
     render(
       <LiveTranscriptControl
@@ -84,19 +97,95 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
         onConnect={onConnect}
       />
     )
+
+    // The header exposes ONLY the feature name — no plumbing labels.
+    expect(screen.getByRole("button", { name: "Live Transcript" })).toBeTruthy()
     expect(
-      screen.getByText("No transcription Runtime connected")
+      screen.queryByText("No transcription Runtime connected")
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Connection command copied")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
+
+    openControl()
+    expect(
+      screen.getByText("Turn room audio into shared text.")
     ).toBeInTheDocument()
-    fireEvent.click(
-      screen.getByRole("button", { name: "Connect local Runtime" })
-    )
+    expect(
+      screen.getByText(
+        "A local Free4Chat Runtime with transcription is needed to start."
+      )
+    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Copy setup command" }))
     expect(onConnect).toHaveBeenCalledTimes(1)
     expect(
       screen.queryByText(/provider claim|runtimeHostId/i)
     ).not.toBeInTheDocument()
   })
 
-  it("offers a small Runtime choice only when the Human has multiple eligible Hosts", () => {
+  it("keeps the primary setup action stable and shows transient copy feedback instead", () => {
+    const onConnect = vi.fn()
+    const { rerender } = render(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={onConnect}
+        runtimeConnectionStatus="idle"
+      />
+    )
+    openControl()
+    fireEvent.click(screen.getByRole("button", { name: "Copy setup command" }))
+
+    rerender(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={onConnect}
+        runtimeConnectionStatus="copied"
+      />
+    )
+    // The header control and the primary action never mutate into
+    // "Connection command copied"; success is a separate status line.
+    expect(screen.getByRole("button", { name: "Live Transcript" })).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "Copy setup command" })
+    ).toBeTruthy()
+    expect(
+      screen.queryByText("Connection command copied")
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/Setup command copied/i)).toBeInTheDocument()
+  })
+
+  it("disables the setup action truthfully while the claim is preparing", () => {
+    const onConnect = vi.fn()
+    render(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={onConnect}
+        runtimeConnectionStatus="preparing"
+      />
+    )
+    openControl()
+    fireEvent.click(screen.getByRole("button", { name: "Preparing…" }))
+    expect(onConnect).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "Preparing…" })).toBeDisabled()
+  })
+
+  it("offers a small Runtime choice inside the feature UI when multiple eligible Hosts exist", () => {
     const onStart = vi.fn()
     render(
       <LiveTranscriptControl
@@ -120,8 +209,10 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
       />
     )
 
-    fireEvent.click(screen.getByRole("button", { name: "Start" }))
-    expect(screen.getByText("Choose a Runtime")).toBeInTheDocument()
+    openControl()
+    expect(
+      screen.getByText("Choose a transcription Runtime")
+    ).toBeInTheDocument()
     fireEvent.click(
       screen.getByRole("button", { name: "Your STT-ready Runtime 2" })
     )
@@ -129,7 +220,7 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
     expect(screen.queryByText("host-b")).not.toBeInTheDocument()
   })
 
-  it("keeps the global active state visible to another Human, who may Stop it", () => {
+  it("shows a compact active header and keeps Stop available to any Human inside the popover", () => {
     const onStop = vi.fn()
     render(
       <LiveTranscriptControl
@@ -149,6 +240,10 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
     )
 
     expect(screen.getByText("● Live Transcript")).toBeInTheDocument()
+    // #236: active details live in the popover; Stop is NOT hidden behind
+    // provider ownership — any current Human sees it.
+    openControl()
+    expect(screen.getByText("Live Transcript is on")).toBeInTheDocument()
     expect(screen.getByText("Provided by Alice")).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Stop" }))
     expect(onStop).toHaveBeenCalledTimes(1)
@@ -171,7 +266,9 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
         onStop={vi.fn()}
       />
     )
+    openControl()
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: "Escape" })
 
     rerender(
       <LiveTranscriptControl
@@ -183,7 +280,9 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
         onStop={vi.fn()}
       />
     )
-    expect(screen.getByRole("button", { name: "Start" })).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Live Transcript" })
+    ).toBeInTheDocument()
 
     rerender(
       <LiveTranscriptControl
@@ -201,7 +300,83 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
         onStop={vi.fn()}
       />
     )
+    openControl()
     expect(screen.getByText("Provided by Bob")).toBeInTheDocument()
+  })
+
+  it("surfaces setup errors inside the popover without leaking claims or ids", () => {
+    render(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={vi.fn()}
+        runtimeConnectError="Could not prepare the setup command. Try again."
+      />
+    )
+    // The error is NOT part of the Room header.
+    expect(
+      screen.queryByText("Could not prepare the setup command. Try again.")
+    ).not.toBeInTheDocument()
+    openControl()
+    expect(
+      screen.getByText("Could not prepare the setup command. Try again.")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(/provider claim|runtimeHostId/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it("closes the popover on outside click and Escape", () => {
+    render(
+      <LiveTranscriptControl
+        liveTranscript={{ active: false }}
+        localParticipantId="human-a"
+        participants={participants}
+        mediaAvailable={false}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+        onConnect={vi.fn()}
+      />
+    )
+    openControl()
+    expect(
+      screen.getByText(/A local Free4Chat Runtime with transcription/)
+    ).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(
+      screen.queryByText(/A local Free4Chat Runtime with transcription/)
+    ).not.toBeInTheDocument()
+
+    openControl()
+    fireEvent.mouseDown(document.body)
+    expect(
+      screen.queryByText(/A local Free4Chat Runtime with transcription/)
+    ).not.toBeInTheDocument()
+  })
+
+  it("resolves the local provider through the authenticated participant id", () => {
+    render(
+      <LiveTranscriptControl
+        liveTranscript={{
+          active: true,
+          producerRuntimeHostId: "host-a",
+          startedByHumanParticipantId: "human-a",
+          epoch: 7,
+          startedAt: 1,
+        }}
+        localParticipantId="human-a"
+        participants={[{ peerId: LOCAL_PEER_ID, name: "Alice" }]}
+        mediaAvailable={false}
+        onStart={vi.fn()}
+        onStop={vi.fn()}
+      />
+    )
+    openControl()
+    expect(screen.getByText("Provided by Alice")).toBeInTheDocument()
   })
 
   it("renders only committed segments in Room sequence order", () => {
@@ -235,26 +410,6 @@ describe("Room-wide Live Transcript UI (#177 PR3)", () => {
       "Alice: First decision",
       "Bob: Second decision",
     ])
-  })
-
-  it("resolves the local provider through the authenticated participant id", () => {
-    render(
-      <LiveTranscriptControl
-        liveTranscript={{
-          active: true,
-          producerRuntimeHostId: "host-a",
-          startedByHumanParticipantId: "human-a",
-          epoch: 7,
-          startedAt: 1,
-        }}
-        localParticipantId="human-a"
-        participants={[{ peerId: LOCAL_PEER_ID, name: "Alice" }]}
-        mediaAvailable={false}
-        onStart={vi.fn()}
-        onStop={vi.fn()}
-      />
-    )
-    expect(screen.getByText("Provided by Alice")).toBeInTheDocument()
   })
 
   it("follows the newest committed segment when the viewer is near the bottom", () => {

--- a/app/src/components/LiveTranscript.tsx
+++ b/app/src/components/LiveTranscript.tsx
@@ -25,6 +25,9 @@ interface LiveTranscriptControlProps {
   onStop: () => void
   onConnect?: () => void
   runtimeConnectionStatus?: "idle" | "preparing" | "copied"
+  /** #236: feature-specific setup error shown INSIDE the Live Transcript
+   * popover; it never expands the Room header. */
+  runtimeConnectError?: string
 }
 
 interface LiveTranscriptSegmentsProps {
@@ -69,6 +72,11 @@ function providerName({
   return provider?.name ?? "a Room participant"
 }
 
+// #236: the Room header exposes exactly ONE Live Transcript control. All
+// setup/readiness/provider detail lives inside the anchored feature popover
+// so the toolbar never turns into a Runtime diagnostics strip. The
+// interaction, authorization, claim security, epoch/start/stop semantics and
+// #206 refresh recovery are unchanged — this is presentation only.
 export function LiveTranscriptControl({
   liveTranscript = { active: false },
   runtimeHosts,
@@ -80,8 +88,10 @@ export function LiveTranscriptControl({
   onStop,
   onConnect,
   runtimeConnectionStatus = "idle",
+  runtimeConnectError = "",
 }: LiveTranscriptControlProps) {
-  const [chooserOpen, setChooserOpen] = useState(false)
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   const authorizedHosts = mediaAvailable
     ? authorizedLiveTranscriptHosts({
         runtimeHosts,
@@ -90,103 +100,148 @@ export function LiveTranscriptControl({
       })
     : []
 
-  if (liveTranscript.active) {
-    return (
-      <div
-        className="flex items-center gap-2"
-        aria-label="Live Transcript controls"
-      >
-        <span className="text-xs text-emerald-200">● Live Transcript</span>
-        <span className="text-xs text-gray-400">
-          Provided by{" "}
-          {providerName({
-            liveTranscript,
-            participants,
-            localParticipantId,
-          })}
-        </span>
-        <button
-          type="button"
-          onClick={onStop}
-          className="rounded-md border border-rose-700/60 bg-rose-900/30 px-3 py-1 text-xs text-rose-200 hover:bg-rose-800/50"
-          title="Stop Live Transcript for everyone in this room"
-        >
-          Stop
-        </button>
-      </div>
-    )
-  }
+  // Popover lifetime: click-outside and Escape close it, matching the
+  // existing room UI conventions; the underlying control semantics never
+  // depend on popover state.
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false)
+    }
+    document.addEventListener("mousedown", onPointerDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open])
 
   const unavailable = authorizedHosts.length === 0
-  if (unavailable && onConnect) {
-    return (
-      <div
-        className="relative flex items-center gap-2"
-        aria-label="Live Transcript controls"
-      >
-        <span className="text-xs text-gray-300">Live Transcript</span>
-        <span className="hidden text-xs text-gray-500 sm:inline">
-          No transcription Runtime connected
-        </span>
-        <button
-          type="button"
-          onClick={onConnect}
-          disabled={runtimeConnectionStatus === "preparing"}
-          className="rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:cursor-wait disabled:opacity-50"
-          title="Connect the Runtime installed on this computer"
-        >
-          {runtimeConnectionStatus === "preparing"
-            ? "Connecting..."
-            : runtimeConnectionStatus === "copied"
-            ? "Connection command copied"
-            : "Connect local Runtime"}
-        </button>
-      </div>
-    )
-  }
+  const connecting = runtimeConnectionStatus === "preparing"
+  const copied = runtimeConnectionStatus === "copied"
+  const active = liveTranscript.active
+
   return (
     <div
-      className="relative flex items-center gap-2"
+      ref={containerRef}
+      className="relative"
       aria-label="Live Transcript controls"
     >
-      <span className="text-xs text-gray-300">Live Transcript</span>
-      <span className="hidden text-xs text-gray-500 sm:inline">
-        Local Runtime ready
-      </span>
       <button
         type="button"
-        onClick={() => {
-          if (authorizedHosts.length === 1) onStart(authorizedHosts[0][0])
-          else if (authorizedHosts.length > 1) setChooserOpen((open) => !open)
-        }}
-        disabled={unavailable}
-        className="rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
-        title={
-          unavailable
-            ? "No authorized transcription Runtime is available"
-            : "Start Live Transcript"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+        aria-label="Live Transcript"
+        className={
+          active
+            ? "flex items-center gap-1 rounded-md border border-emerald-700/60 bg-emerald-900/30 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-800/50"
+            : "rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700"
         }
       >
-        Start
+        {active ? "● Live Transcript" : "Live Transcript"}
       </button>
-      {chooserOpen && authorizedHosts.length > 1 && (
-        <div className="absolute right-0 top-full z-20 mt-1 w-56 rounded-md border border-gray-700 bg-gray-800 py-1 shadow-lg">
-          <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
-            Choose a Runtime
-          </p>
-          {authorizedHosts.map(([runtimeHostId], index) => (
-            <button
-              key={runtimeHostId}
-              type="button"
-              onClick={() => {
-                onStart(runtimeHostId)
-                setChooserOpen(false)
-              }}
-              className="block w-full px-3 py-1.5 text-left text-xs text-gray-200 hover:bg-gray-700"
-            >
-              Your STT-ready Runtime {index + 1}
-            </button>
-          ))}
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Live Transcript"
+          className="absolute right-0 top-full z-20 mt-1 w-72 rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg"
+        >
+          {active ? (
+            <>
+              <p className="font-medium text-emerald-200">
+                Live Transcript is on
+              </p>
+              <p className="mt-1 text-gray-400">
+                Provided by{" "}
+                {providerName({
+                  liveTranscript,
+                  participants,
+                  localParticipantId,
+                })}
+              </p>
+              <button
+                type="button"
+                onClick={onStop}
+                className="mt-2 rounded-md border border-rose-700/60 bg-rose-900/30 px-3 py-1 text-xs text-rose-200 hover:bg-rose-800/50"
+                title="Stop Live Transcript for everyone in this room"
+              >
+                Stop
+              </button>
+            </>
+          ) : unavailable && onConnect ? (
+            <>
+              <p className="font-medium text-gray-100">Live Transcript</p>
+              <p className="mt-1 text-gray-400">
+                Turn room audio into shared text.
+              </p>
+              <p className="mt-1 text-gray-400">
+                A local Free4Chat Runtime with transcription is needed to start.
+              </p>
+              <button
+                type="button"
+                onClick={onConnect}
+                disabled={connecting}
+                className="mt-2 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-gray-200 hover:bg-gray-700 disabled:cursor-wait disabled:opacity-50"
+                title="Copy the command for the computer where Free4Chat Runtime is running"
+              >
+                {connecting ? "Preparing…" : "Copy setup command"}
+              </button>
+              {copied && (
+                <p role="status" className="mt-2 text-emerald-300">
+                  ✓ Setup command copied. Run it in your terminal.
+                </p>
+              )}
+              {runtimeConnectError && (
+                <p role="status" className="mt-2 text-rose-300">
+                  {runtimeConnectError}
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <p className="font-medium text-gray-100">Live Transcript</p>
+              {authorizedHosts.length === 0 ? (
+                <p className="mt-1 text-gray-400">
+                  Transcription is unavailable in this room right now.
+                </p>
+              ) : authorizedHosts.length === 1 ? (
+                <>
+                  <p className="mt-1 text-emerald-200">Ready to start.</p>
+                  <button
+                    type="button"
+                    onClick={() => onStart(authorizedHosts[0][0])}
+                    className="mt-2 rounded-md border border-emerald-700/60 bg-emerald-900/30 px-3 py-1 text-emerald-200 hover:bg-emerald-800/50"
+                  >
+                    Start
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="mt-1 text-gray-400">
+                    Choose a transcription Runtime
+                  </p>
+                  <div className="mt-1.5 flex flex-col gap-1">
+                    {authorizedHosts.map(([runtimeHostId], index) => (
+                      <button
+                        key={runtimeHostId}
+                        type="button"
+                        onClick={() => onStart(runtimeHostId)}
+                        className="w-full rounded-md bg-gray-700/60 px-2 py-1.5 text-left text-gray-200 hover:bg-gray-700"
+                      >
+                        Your STT-ready Runtime {index + 1}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -237,6 +237,8 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
     )
 
+    // #236: one feature-first header control; Start lives inside its popover.
+    fireEvent.click(screen.getByRole("button", { name: "Live Transcript" }))
     fireEvent.click(screen.getByRole("button", { name: "Start" }))
     expect(startLiveTranscript).toHaveBeenCalledWith("host-a")
     expect(screen.queryByText(/Meeting Notes/i)).not.toBeInTheDocument()
@@ -244,5 +246,43 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(
       screen.getByRole("button", { name: "Enable voice for Codex" })
     ).toBeEnabled()
+  })
+
+  it("keeps the Room header to user goals — no Runtime plumbing labels (#236)", () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      liveTranscriptMediaAvailable: false,
+      agentVoiceMediaAvailable: false,
+      runtimeHosts: {},
+      runtimeHostProviders: {},
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    // The toolbar exposes exactly the primary controls, and Live Transcript
+    // appears once as a feature button — never as a status strip.
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Invite Agent" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Leave" })).toBeTruthy()
+    expect(screen.getAllByText("Live Transcript").length).toBeGreaterThan(0)
+    expect(
+      screen.queryByText("No transcription Runtime connected")
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Connection command copied")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
   })
 })

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -564,12 +564,8 @@ export default function RoomContent({
             onStop={handleStopLiveTranscript}
             onConnect={handleConnectRuntime}
             runtimeConnectionStatus={runtimeConnectionStatus}
+            runtimeConnectError={runtimeConnectError}
           />
-          {runtimeConnectError && (
-            <span role="status" className="text-xs text-rose-300">
-              {runtimeConnectError}
-            </span>
-          )}
           <button
             type="button"
             onClick={() => {

--- a/docs/en/getting-started/browser-room.md
+++ b/docs/en/getting-started/browser-room.md
@@ -29,8 +29,9 @@ container - not from the browser. Two paths exist:
   Runtime itself and joins your Room. See
   [Agent Room quick start](agent-room).
 - Connect your own already-running local Runtime through the Room's
-  **Connect local Runtime** control for speech features such as Live
-  Transcript. See [Live Transcript](/docs/guides/live-transcript).
+  **Live Transcript** control (it offers a setup command when no
+  transcription Runtime is connected). See
+  [Live Transcript](/docs/guides/live-transcript).
 
 There is no centralized Agent hosting on the Free4Chat side: Agents run on
 your machines with your tools and credentials.

--- a/docs/en/guides/live-transcript.md
+++ b/docs/en/guides/live-transcript.md
@@ -27,11 +27,12 @@ and provisioning contract is [/speech.md](/speech.md).
 
 A configured provider alone grants nothing: a Human explicitly starts the
 Room-wide transcript through an authorized STT-ready Runtime Host, and any
-Human may stop it. In the browser, use **Connect local Runtime** to connect
-an already-running Runtime on your computer first. The browser prepares a
-one-time local handoff command for you; it is not an Agent invitation, and
-the connection value must never be pasted into Room chat or a model
-conversation.
+Human may stop it. In the browser, open **Live Transcript** in the Room.
+If transcription setup is needed, use **Copy setup command** and run the
+copied command on the computer where the Free4Chat Runtime is running. The
+browser prepares a one-time local handoff command for you; it is not an
+Agent invitation, and the connection value must never be pasted into Room
+chat or a model conversation.
 
 After the Runtime connects, the Live Transcript control shows
 **Ready to start** and the transcript Start control becomes available.

--- a/docs/en/guides/live-transcript.md
+++ b/docs/en/guides/live-transcript.md
@@ -33,8 +33,8 @@ one-time local handoff command for you; it is not an Agent invitation, and
 the connection value must never be pasted into Room chat or a model
 conversation.
 
-After the Runtime connects, the Room shows **Local Runtime ready** and the
-transcript Start control becomes available.
+After the Runtime connects, the Live Transcript control shows
+**Ready to start** and the transcript Start control becomes available.
 
 ## Transcript visibility never wakes an Agent
 

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -127,7 +127,7 @@ free4chat-agent room join ... --provider-claim <opaque-secret>
 ```
 
 `--provider-claim` carries the one-time opaque connection value produced by
-the browser's **Connect local Runtime** flow (used for speech features such
-as Live Transcript). It is not an Agent invitation; never paste such a
-handoff value into Room chat or a model conversation. See
+the setup command copied from the Room's **Live Transcript** control (used
+for speech features such as Live Transcript). It is not an Agent invitation;
+never paste such a handoff value into Room chat or a model conversation. See
 [Live Transcript](../guides/live-transcript).


### PR DESCRIPTION
Closes #236

## Problem

The Room header could look like:

```text
Copy link | Invite Agent | Live Transcript | No transcription Runtime connected | Connect local Runtime | Connection command copied | Leave
```

One feature exposed several implementation states (dependency detail, setup plumbing, transient copy feedback) at the same visual level. The toolbar became a Runtime diagnostics strip instead of a user-goal bar.

## Result

The Room header now has exactly ONE Live Transcript control:

```text
Copy link | Invite Agent | Live Transcript | Leave
```

(compact active state: `● Live Transcript`). All setup / readiness / provider / Start / Stop / copy feedback lives inside a small popover anchored to that button. The toolbar never renders `No transcription Runtime connected`, `Local Runtime ready`, `Connect local Runtime`, `Connection command copied`, STT / Runtime Host / provider claim wording, or `runtimeHostId`.

### Interaction per state (all inside the popover)

- **Unavailable (off, no authorized transcription Runtime):** short Human-facing explanation ("Turn room audio into shared text." / "A local Free4Chat Runtime with transcription is needed to start.") + **Copy setup command**. The primary action stays `Copy setup command` in every status; `Preparing…` while producing the one-time claim; after copying a separate transient `✓ Setup command copied. Run it in your terminal.` line appears — the button never mutates into "Connection command copied".
- **Ready (exactly one authorized STT-ready Runtime):** "Ready to start." + **Start** → calls the exact existing `onStart(runtimeHostId)`; no `runtimeHostId` is ever rendered.
- **Multiple authorized Runtimes:** chooser ("Choose a transcription Runtime" + "Your STT-ready Runtime N") inside the popover; selecting calls `onStart` with the correct id.
- **Active:** compact `● Live Transcript` header; popover shows "Live Transcript is on" / "Provided by \<truthful Human-readable provider name\>" / **Stop** — Stop remains visible to ANY Human (never hidden behind provider ownership).
- **Errors:** `runtimeConnectError` is rendered inside the popover (moved out of the header), recoverable, no server codes beyond existing conventions, no claim/secret text.

### Preserved (presentation only)

- Entire `handleConnectRuntime` / `runtimeConnectionStatus` / `runtimeConnectError` secure claim flow reused — no second claim mechanism; one-time opaque provider claim never leaves the clipboard path (no chat/model/log/analytics/header).
- #176 / #177 / #206 invariants: readiness ≠ authorization, `runtimeHostId` ≠ provider permission, Room-scoped ephemeral Human↔Runtime association, literal Transcript visibility ≠ Agent activation, any-Human Stop, epoch/start/stop semantics, refresh/recovery, Agent Voice independence, media gating.
- No Durable Object / provider-claim protocol / Go Runtime / speech config / media controller / transcript sequence changes.

## Tests

- `yarn vitest run` — **57 files / 557 tests passed**, including rewritten `LiveTranscript.test.tsx` (14 tests) covering: unavailable setup popover + copy action, copied-transient-feedback (header/action never become "Connection command copied"), preparing disabled state, ready/Start with exact host id without rendering ids, multi-host chooser, active/Stop for any Human, provider resolution, errors inside popover, outside-click/Escape close, epoch/Off follow, plus the unchanged segments tests.
- `RoomContent.test.tsx` (5) — updated Start flow through the popover + new header-composition test proving the toolbar renders only Copy link / Invite Agent / Live Transcript / Leave and never the plumbing labels.
- `yarn type-check`, `yarn lint --max-warnings 0`, `npx prettier --check .`, `yarn docs:check` — all clean.

## Docs

Minimal updates where Browser docs referenced a permanent header **Connect local Runtime** control: now described as the **Live Transcript** control offering a setup command when needed (`docs/en/getting-started/browser-room.md`, `docs/en/guides/live-transcript.md`, `docs/en/reference/cli.md`). `llms-full.txt` regenerated through the canonical generator.

## Release impact

Browser/Worker deployment only — **no Agent Runtime release expected** (no Go files changed).
