### PR TITLE
ux(room): make Agent invitation and speech setup understandable

### DIFF
--- a/app/src/components/AgentInviteControl.test.tsx
+++ b/app/src/components/AgentInviteControl.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { trackAnalyticsEvent } from "@common/utils"
+
+import AgentInviteControl from "./AgentInviteControl"
+
+// #236 follow-up: AgentInviteCopied must keep EXACTLY its long-lived meaning
+// — one event per ACTUAL successful clipboard write. Opening, viewing or
+// closing the popover, and clipboard failures emit zero.
+vi.mock("@common/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@common/utils")>()
+  return { ...actual, trackAnalyticsEvent: vi.fn() }
+})
+
+const INVITE_PROMPT = "Join my temporary Free4Chat room as an Agent.\n\nRoom: …"
+
+function renderControl(open = false, onOpenChange = vi.fn()) {
+  return render(
+    <AgentInviteControl
+      roomType="audio"
+      invitePrompt={INVITE_PROMPT}
+      open={open}
+      onOpenChange={onOpenChange}
+    />
+  )
+}
+
+function installClipboard(resolve: boolean) {
+  const writeText = resolve
+    ? vi.fn().mockResolvedValue(undefined)
+    : vi.fn().mockRejectedValue(new Error("blocked"))
+  Object.assign(navigator, { clipboard: { writeText } })
+  return writeText
+}
+
+function promptPreview(): HTMLElement {
+  const element = screen
+    .getAllByText((_content, node) => node?.tagName === "PRE")
+    .find((node) => node.textContent === INVITE_PROMPT)
+  if (!element) throw new Error("invite prompt preview not found")
+  return element
+}
+
+beforeEach(() => {
+  vi.mocked(trackAnalyticsEvent).mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("AgentInviteControl (#236 follow-up)", () => {
+  it("opens via the header button without copying anything", () => {
+    installClipboard(true)
+    const onOpenChange = vi.fn()
+    renderControl(false, onOpenChange)
+    fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+    expect(screen.queryByText("Invite an Agent")).not.toBeInTheDocument()
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "AgentInviteCopied",
+      expect.anything()
+    )
+  })
+
+  it("shows the actual invite prompt read-only and the explicit copy action", () => {
+    installClipboard(true)
+    renderControl(true)
+    expect(screen.getByText("Invite an Agent")).toBeInTheDocument()
+    expect(screen.getByText(/Bring an Agent you're already using/)).toBeTruthy()
+    expect(
+      screen.getByText(
+        /The Agent will set up Free4Chat locally if needed and join this Room itself/
+      )
+    ).toBeTruthy()
+    expect(promptPreview()).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "Copy invite prompt" })
+    ).toBeTruthy()
+    // The header button never mutates into "Copied!".
+    expect(screen.getByRole("button", { name: "Invite Agent" })).toBeTruthy()
+  })
+
+  it("emits exactly one AgentInviteCopied only after a successful copy", async () => {
+    const writeText = installClipboard(true)
+    renderControl(true)
+
+    // Opening/viewing the popover emitted nothing.
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "AgentInviteCopied",
+      expect.anything()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy invite prompt" }))
+    expect(writeText).toHaveBeenCalledWith(INVITE_PROMPT)
+    expect(
+      await screen.findByText(
+        /✓ Invite prompt copied\. Paste it into your Agent\./
+      )
+    ).toBeInTheDocument()
+    // Exactly one AgentInviteCopied, only after the clipboard write settled.
+    await waitFor(() => expect(trackAnalyticsEvent).toHaveBeenCalledTimes(1))
+    expect(trackAnalyticsEvent).toHaveBeenCalledWith("AgentInviteCopied", {
+      surface: "room",
+      roomType: "audio",
+    })
+    // Header button and primary action stay stable.
+    expect(
+      screen.getByRole("button", { name: "Copy invite prompt" })
+    ).toBeTruthy()
+    expect(screen.queryByText("Copied!")).not.toBeInTheDocument()
+  })
+
+  it("emits zero AgentInviteCopied on clipboard failure and shows in-popover feedback", async () => {
+    installClipboard(false)
+    renderControl(true)
+    fireEvent.click(screen.getByRole("button", { name: "Copy invite prompt" }))
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "AgentInviteCopied",
+      expect.anything()
+    )
+    expect(
+      await screen.findByText("Clipboard access was blocked. Try again.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Copy invite prompt" })
+    ).toBeEnabled()
+  })
+
+  it("emits one additional AgentInviteCopied per successful re-copy", async () => {
+    installClipboard(true)
+    renderControl(true)
+    const copy = screen.getByRole("button", { name: "Copy invite prompt" })
+    fireEvent.click(copy)
+    fireEvent.click(copy)
+    await waitFor(() => expect(trackAnalyticsEvent).toHaveBeenCalledTimes(2))
+    expect(trackAnalyticsEvent).toHaveBeenCalledWith("AgentInviteCopied", {
+      surface: "room",
+      roomType: "audio",
+    })
+    expect(screen.getAllByRole("status").length).toBeGreaterThan(0)
+  })
+
+  it("closes on Escape and outside clicks", () => {
+    const onOpenChange = vi.fn()
+    renderControl(true, onOpenChange)
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    onOpenChange.mockClear()
+    renderControl(true, onOpenChange)
+    fireEvent.mouseDown(document.body)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/app/src/components/AgentInviteControl.tsx
+++ b/app/src/components/AgentInviteControl.tsx
@@ -92,7 +92,7 @@ export default function AgentInviteControl({
         <div
           role="dialog"
           aria-label="Invite an Agent"
-          className="absolute left-1/2 top-full z-20 mt-1 max-h-[calc(100vh-4rem)] w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-y-auto rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg lg:left-auto lg:right-0 lg:translate-x-0"
+          className="absolute left-1/2 top-full z-20 mt-1 max-h-[65dvh] w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-y-auto rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg lg:left-auto lg:right-0 lg:translate-x-0"
         >
           <p className="font-medium text-gray-100">Invite an Agent</p>
           <p className="mt-1 text-gray-400">

--- a/app/src/components/AgentInviteControl.tsx
+++ b/app/src/components/AgentInviteControl.tsx
@@ -92,7 +92,7 @@ export default function AgentInviteControl({
         <div
           role="dialog"
           aria-label="Invite an Agent"
-          className="absolute right-0 top-full z-20 mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg"
+          className="absolute left-1/2 top-full z-20 mt-1 max-h-[calc(100vh-4rem)] w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 overflow-y-auto rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg lg:left-auto lg:right-0 lg:translate-x-0"
         >
           <p className="font-medium text-gray-100">Invite an Agent</p>
           <p className="mt-1 text-gray-400">

--- a/app/src/components/AgentInviteControl.tsx
+++ b/app/src/components/AgentInviteControl.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from "react"
+
+import { trackAnalyticsEvent } from "@common/utils"
+
+interface AgentInviteControlProps {
+  roomType: string
+  /** The ACTUAL invite prompt (buildAgentInvitePrompt output) — the single
+   * source of truth rendered read-only in the feature popover. */
+  invitePrompt: string
+  /** #236 follow-up: controlled popover state so the Live Transcript popover
+   * can cross-open the invite popover without routing machinery. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * #236 follow-up: "Invite Agent" is a feature-first header control. Clicking
+ * it opens a compact anchored popover that explains the Human mental model
+ * (paste the prompt into the Agent you already use; the Agent handles
+ * Free4Chat setup itself) and offers ONE explicit copy action with
+ * in-popover feedback. Nothing is copied merely by opening the popover, and
+ * AgentInviteCopied fires ONLY after a successful clipboard write — the
+ * long-lived analytics semantics are unchanged.
+ */
+export default function AgentInviteControl({
+  roomType,
+  invitePrompt,
+  open,
+  onOpenChange,
+}: AgentInviteControlProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        onOpenChange(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onOpenChange(false)
+    }
+    document.addEventListener("mousedown", onPointerDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open, onOpenChange])
+
+  const copyInvite = () => {
+    // Direct user activation only (Firefox/Safari require it for clipboard).
+    if (!navigator.clipboard?.writeText) {
+      setError(
+        "Clipboard access is unavailable. Copy invite is not supported here."
+      )
+      return
+    }
+    setError("")
+    navigator.clipboard
+      .writeText(invitePrompt)
+      .then(() => {
+        // #236 follow-up: emit ONLY after the prompt actually reached the
+        // clipboard — one event per successful write, never on open/view.
+        trackAnalyticsEvent("AgentInviteCopied", {
+          surface: "room",
+          roomType,
+        })
+        setCopied(true)
+      })
+      .catch(() => {
+        setError("Clipboard access was blocked. Try again.")
+      })
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        aria-label="Invite Agent"
+        title="Copy an invite prompt for the Agent you already use"
+        className="rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-xs text-blue-200 hover:bg-blue-800/50"
+      >
+        Invite Agent
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Invite an Agent"
+          className="absolute right-0 top-full z-20 mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg"
+        >
+          <p className="font-medium text-gray-100">Invite an Agent</p>
+          <p className="mt-1 text-gray-400">
+            Bring an Agent you&apos;re already using into this Room.
+          </p>
+          <ol className="mt-1.5 list-decimal space-y-0.5 pl-4 text-gray-300">
+            <li>Open your Agent.</li>
+            <li>Copy the invite prompt below.</li>
+            <li>Paste it into the Agent.</li>
+          </ol>
+          <p className="mt-1.5 text-gray-400">
+            The Agent will set up Free4Chat locally if needed and join this Room
+            itself. You normally do not need to install or configure anything
+            manually.
+          </p>
+          <p className="mt-1 text-gray-400">
+            The same local Free4Chat setup can also provide Room features such
+            as Live Transcript when speech is configured.
+          </p>
+
+          <pre className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-gray-700 bg-gray-950 p-2 font-mono text-[11px] leading-relaxed text-gray-300">
+            {invitePrompt}
+          </pre>
+
+          <button
+            type="button"
+            onClick={copyInvite}
+            className="mt-2 rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-blue-200 hover:bg-blue-800/50"
+          >
+            Copy invite prompt
+          </button>
+          {copied && (
+            <p role="status" className="mt-2 text-emerald-300">
+              ✓ Invite prompt copied. Paste it into your Agent.
+            </p>
+          )}
+          {error && (
+            <p role="status" className="mt-2 text-rose-300">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/src/components/LiveTranscript.test.tsx
+++ b/app/src/components/LiveTranscript.test.tsx
@@ -86,6 +86,7 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
 
   it("keeps a single compact header control with setup inside the popover when no Host is authorized", () => {
     const onConnect = vi.fn()
+    const onSuggestInvite = vi.fn()
     render(
       <LiveTranscriptControl
         liveTranscript={{ active: false }}
@@ -95,6 +96,7 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
         onStart={vi.fn()}
         onStop={vi.fn()}
         onConnect={onConnect}
+        onSuggestInvite={onSuggestInvite}
       />
     )
 
@@ -114,11 +116,31 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        "A local Free4Chat Runtime with transcription is needed to start."
+        "Live Transcript needs transcription support from your local Free4Chat setup."
       )
     ).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: "Copy setup command" }))
+    // #236 follow-up: the setup copy points new Humans at the Agent-first
+    // path and never introduces unexplained Runtime jargon.
+    expect(
+      screen.getByText(/If you haven't connected an Agent yet/)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Start with Invite Agent" })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "Copy connection command" })
+    ).toBeTruthy()
+    expect(
+      screen.getByText(/Do not paste it into an Agent chat/)
+    ).toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy connection command" })
+    )
     expect(onConnect).toHaveBeenCalledTimes(1)
+    fireEvent.click(
+      screen.getByRole("button", { name: "Start with Invite Agent" })
+    )
+    expect(onSuggestInvite).toHaveBeenCalledTimes(1)
     expect(
       screen.queryByText(/provider claim|runtimeHostId/i)
     ).not.toBeInTheDocument()
@@ -139,7 +161,9 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
       />
     )
     openControl()
-    fireEvent.click(screen.getByRole("button", { name: "Copy setup command" }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy connection command" })
+    )
 
     rerender(
       <LiveTranscriptControl
@@ -157,12 +181,12 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
     // "Connection command copied"; success is a separate status line.
     expect(screen.getByRole("button", { name: "Live Transcript" })).toBeTruthy()
     expect(
-      screen.getByRole("button", { name: "Copy setup command" })
+      screen.getByRole("button", { name: "Copy connection command" })
     ).toBeTruthy()
     expect(
       screen.queryByText("Connection command copied")
     ).not.toBeInTheDocument()
-    expect(screen.getByText(/Setup command copied/i)).toBeInTheDocument()
+    expect(screen.getByText(/Connection command copied/i)).toBeInTheDocument()
   })
 
   it("disables the setup action truthfully while the claim is preparing", () => {
@@ -344,17 +368,17 @@ describe("Room-wide Live Transcript UI (#177 PR3 / #236 header simplification)",
     )
     openControl()
     expect(
-      screen.getByText(/A local Free4Chat Runtime with transcription/)
+      screen.getByText(/Live Transcript needs transcription support/)
     ).toBeInTheDocument()
     fireEvent.keyDown(document, { key: "Escape" })
     expect(
-      screen.queryByText(/A local Free4Chat Runtime with transcription/)
+      screen.queryByText(/Live Transcript needs transcription support/)
     ).not.toBeInTheDocument()
 
     openControl()
     fireEvent.mouseDown(document.body)
     expect(
-      screen.queryByText(/A local Free4Chat Runtime with transcription/)
+      screen.queryByText(/Live Transcript needs transcription support/)
     ).not.toBeInTheDocument()
   })
 

--- a/app/src/components/LiveTranscript.tsx
+++ b/app/src/components/LiveTranscript.tsx
@@ -154,7 +154,7 @@ export function LiveTranscriptControl({
         <div
           role="dialog"
           aria-label="Live Transcript"
-          className="absolute right-0 top-full z-20 mt-1 w-72 rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg"
+          className="absolute right-0 top-full z-20 mt-1 max-h-[65dvh] w-72 max-w-[calc(100vw-2rem)] overflow-y-auto rounded-md border border-gray-700 bg-gray-800 p-3 text-xs text-gray-200 shadow-lg"
         >
           {active ? (
             <>

--- a/app/src/components/LiveTranscript.tsx
+++ b/app/src/components/LiveTranscript.tsx
@@ -28,6 +28,9 @@ interface LiveTranscriptControlProps {
   /** #236: feature-specific setup error shown INSIDE the Live Transcript
    * popover; it never expands the Room header. */
   runtimeConnectError?: string
+  /** #236 follow-up: opens the Invite Agent popover (shared RoomContent
+   * state) so the setup copy can point new Humans at the Agent-first path. */
+  onSuggestInvite?: () => void
 }
 
 interface LiveTranscriptSegmentsProps {
@@ -89,6 +92,7 @@ export function LiveTranscriptControl({
   onConnect,
   runtimeConnectionStatus = "idle",
   runtimeConnectError = "",
+  onSuggestInvite,
 }: LiveTranscriptControlProps) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -181,20 +185,43 @@ export function LiveTranscriptControl({
                 Turn room audio into shared text.
               </p>
               <p className="mt-1 text-gray-400">
-                A local Free4Chat Runtime with transcription is needed to start.
+                Live Transcript needs transcription support from your local
+                Free4Chat setup.
+              </p>
+              {onSuggestInvite && (
+                <p className="mt-1 text-gray-400">
+                  If you haven&apos;t connected an Agent yet, start with Invite
+                  Agent.
+                </p>
+              )}
+              {onSuggestInvite && (
+                <button
+                  type="button"
+                  onClick={onSuggestInvite}
+                  className="mt-1.5 rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-blue-200 hover:bg-blue-800/50"
+                >
+                  Start with Invite Agent
+                </button>
+              )}
+              <p className="mt-1.5 text-gray-400">
+                Already have Free4Chat running locally?
               </p>
               <button
                 type="button"
                 onClick={onConnect}
                 disabled={connecting}
-                className="mt-2 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-gray-200 hover:bg-gray-700 disabled:cursor-wait disabled:opacity-50"
-                title="Copy the command for the computer where Free4Chat Runtime is running"
+                className="mt-1.5 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-gray-200 hover:bg-gray-700 disabled:cursor-wait disabled:opacity-50"
+                title="Copy the connection command for the computer where Free4Chat is running"
               >
-                {connecting ? "Preparing…" : "Copy setup command"}
+                {connecting ? "Preparing…" : "Copy connection command"}
               </button>
+              <p className="mt-1.5 text-gray-400">
+                Run this command in the terminal where Free4Chat is running. Do
+                not paste it into an Agent chat.
+              </p>
               {copied && (
                 <p role="status" className="mt-2 text-emerald-300">
-                  ✓ Setup command copied. Run it in your terminal.
+                  ✓ Connection command copied. Run it in your terminal.
                 </p>
               )}
               {runtimeConnectError && (

--- a/app/src/components/LiveTranscript.tsx
+++ b/app/src/components/LiveTranscript.tsx
@@ -197,7 +197,13 @@ export function LiveTranscriptControl({
               {onSuggestInvite && (
                 <button
                   type="button"
-                  onClick={onSuggestInvite}
+                  onClick={() => {
+                    // Cross-open satisfies the "one feature at a time" rule:
+                    // close THIS popover first, then ask the parent to open
+                    // the Invite Agent popover.
+                    setOpen(false)
+                    onSuggestInvite()
+                  }}
                   className="mt-1.5 rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-blue-200 hover:bg-blue-800/50"
                 >
                   Start with Invite Agent

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1,14 +1,30 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("next/router", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
+// Observe the long-lived analytics calls (AgentInviteCopied,
+// LiveTranscriptStarted/Stopped) without changing any other utility behavior.
+vi.mock("@common/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@common/utils")>()
+  return { ...actual, trackAnalyticsEvent: vi.fn() }
+})
+
 const mockUseSfuChatRoom = vi.fn()
 vi.mock("../hooks/useSfuChatRoom", () => ({
   useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
 }))
+
+import { trackAnalyticsEvent } from "@common/utils"
 
 import RoomContent from "./RoomContent"
 
@@ -155,9 +171,10 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(container.querySelector('[id^="cf-chl-widget"]')).toBeNull()
   })
 
-  it("copies an ordinary Agent invite without creating a Runtime provider claim", async () => {
+  it("copies the ordinary Agent invite only through the popover action, without a provider claim", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
+    vi.mocked(trackAnalyticsEvent).mockClear()
     mockUseSfuChatRoom.mockReturnValue({
       ...baseHookReturn,
       connectionStatus: "connected",
@@ -166,7 +183,16 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     render(
       <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
     )
+    // Opening the popover copies NOTHING and emits NOTHING.
     fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
+    expect(screen.getByText("Invite an Agent")).toBeInTheDocument()
+    expect(writeText).not.toHaveBeenCalled()
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "AgentInviteCopied",
+      expect.anything()
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy invite prompt" }))
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("Join my temporary")
     )
@@ -174,13 +200,24 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect.stringContaining("--provider-claim")
     )
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Copied!" })).toBeEnabled()
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith("AgentInviteCopied", {
+        surface: "room",
+        roomType: "audio",
+      })
     )
+    // Feedback stays inside the popover; the header button never becomes
+    // "Copied!".
+    expect(
+      await screen.findByText(/✓ Invite prompt copied\./)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Copied!" })).toBeNull()
+    expect(screen.getByRole("button", { name: "Invite Agent" })).toBeTruthy()
   })
 
-  it("shows a retryable clipboard error for an ordinary invite", async () => {
+  it("shows a retryable clipboard error inside the invite popover", async () => {
     const writeText = vi.fn().mockRejectedValue(new Error("blocked"))
     Object.assign(navigator, { clipboard: { writeText } })
+    vi.mocked(trackAnalyticsEvent).mockClear()
     mockUseSfuChatRoom.mockReturnValue({
       ...baseHookReturn,
       connectionStatus: "connected",
@@ -190,9 +227,14 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
     )
     fireEvent.click(screen.getByRole("button", { name: "Invite Agent" }))
+    fireEvent.click(screen.getByRole("button", { name: "Copy invite prompt" }))
 
     expect(await screen.findByRole("status")).toHaveTextContent(
-      "Clipboard access was blocked"
+      "Clipboard access was blocked. Try again."
+    )
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "AgentInviteCopied",
+      expect.anything()
     )
     expect(screen.getByRole("button", { name: "Invite Agent" })).toBeEnabled()
   })
@@ -275,7 +317,9 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     // appears once as a feature button — never as a status strip.
     expect(screen.getByRole("button", { name: "Copy link" })).toBeTruthy()
     expect(screen.getByRole("button", { name: "Invite Agent" })).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Leave" })).toBeTruthy()
+    expect(
+      screen.getAllByRole("button", { name: "Leave" }).length
+    ).toBeGreaterThan(0)
     expect(screen.getAllByText("Live Transcript").length).toBeGreaterThan(0)
     expect(
       screen.queryByText("No transcription Runtime connected")
@@ -284,5 +328,128 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       screen.queryByText("Connection command copied")
     ).not.toBeInTheDocument()
     expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
+  })
+
+  it("uses the intentional two-row mobile header layout with a truncating Room id", () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      liveTranscriptMediaAvailable: false,
+      agentVoiceMediaAvailable: false,
+      runtimeHosts: {},
+      runtimeHostProviders: {},
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    // Row 1: Room identity (truncating, min-width-safe container) plus the
+    // Leave lifecycle action on the same row.
+    const identity = within(screen.getByTestId("room-header-identity"))
+    expect(identity.getByText("#test-room")).toBeTruthy()
+    expect(identity.getByRole("button", { name: "Leave" })).toBeTruthy()
+
+    // Row 2: exactly the three feature actions. No plumbing labels.
+    const features = within(screen.getByTestId("room-header-features"))
+    expect(features.getByRole("button", { name: "Copy link" })).toBeTruthy()
+    expect(features.getByRole("button", { name: "Invite Agent" })).toBeTruthy()
+    expect(
+      features.getByRole("button", { name: "Live Transcript" })
+    ).toBeTruthy()
+    expect(
+      screen.queryByText("No transcription Runtime connected")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
+  })
+
+  it("opens the Invite Agent popover from the Live Transcript setup copy", () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      liveTranscriptMediaAvailable: false,
+      agentVoiceMediaAvailable: false,
+      runtimeHosts: {},
+      runtimeHostProviders: {},
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    // Unavailable Live Transcript setup copy points new Humans at the
+    // Agent-first path and cross-opens the invite popover.
+    fireEvent.click(screen.getByRole("button", { name: "Live Transcript" }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Start with Invite Agent" })
+    )
+    expect(screen.getByText("Invite an Agent")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Copy invite prompt" })
+    ).toBeTruthy()
+  })
+
+  it("emits LiveTranscriptStarted only on actual Start, never on popover open", () => {
+    vi.mocked(trackAnalyticsEvent).mockClear()
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      liveTranscriptMediaAvailable: true,
+      agentVoiceMediaAvailable: true,
+      runtimeHosts: {
+        "host-a": {
+          runtimeHostId: "host-a",
+          speech: { stt: true, tts: true },
+        },
+      },
+      runtimeHostProviders: {
+        "host-a": { humanParticipantId: "human-local", claimedAt: 1 },
+      },
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    // Opening the popover and viewing readiness emits nothing.
+    fireEvent.click(screen.getByRole("button", { name: "Live Transcript" }))
+    expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+      "LiveTranscriptStarted",
+      expect.anything()
+    )
+
+    // Actual Start emits exactly the existing event.
+    fireEvent.click(screen.getByRole("button", { name: "Start" }))
+    expect(trackAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(trackAnalyticsEvent).toHaveBeenCalledWith("LiveTranscriptStarted", {
+      roomType: "audio",
+    })
   })
 })

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -396,12 +396,21 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     )
 
     // Unavailable Live Transcript setup copy points new Humans at the
-    // Agent-first path and cross-opens the invite popover.
+    // Agent-first path. Cross-opening is one-feature-at-a-time: the Live
+    // Transcript dialog closes FIRST, then the Invite Agent dialog opens.
     fireEvent.click(screen.getByRole("button", { name: "Live Transcript" }))
+    expect(
+      screen.getByRole("dialog", { name: "Live Transcript" })
+    ).toBeInTheDocument()
     fireEvent.click(
       screen.getByRole("button", { name: "Start with Invite Agent" })
     )
-    expect(screen.getByText("Invite an Agent")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("dialog", { name: "Live Transcript" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("dialog", { name: "Invite an Agent" })
+    ).toBeInTheDocument()
     expect(
       screen.getByRole("button", { name: "Copy invite prompt" })
     ).toBeTruthy()

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
+import AgentInviteControl from "./AgentInviteControl"
 import { LiveTranscriptControl, LiveTranscriptSegments } from "./LiveTranscript"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
@@ -90,9 +91,10 @@ export default function RoomContent({
 }) {
   const router = useRouter()
   const [roomLinkCopied, setRoomLinkCopied] = useState(false)
-  const [agentInviteCopied, setAgentInviteCopied] = useState(false)
-  const [agentInviteError, setAgentInviteError] = useState("")
   const [runtimeConnectError, setRuntimeConnectError] = useState("")
+  // #236 follow-up: shared popover state so the Live Transcript setup copy
+  // can cross-open the Invite Agent popover (no routing machinery).
+  const [agentInviteOpen, setAgentInviteOpen] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<
     {
       id: string
@@ -402,39 +404,6 @@ export default function RoomContent({
     }
   }
 
-  const writeAgentInvite = (invite: string) => {
-    // This function is intentionally called directly from a click handler.
-    // Firefox and Safari require transient user activation for clipboard
-    // writes, so never move this call behind an asynchronous Room round-trip.
-    if (!navigator.clipboard?.writeText) {
-      setAgentInviteError(
-        "Clipboard access is unavailable. Copy invite is not supported here."
-      )
-      return
-    }
-    void navigator.clipboard
-      .writeText(invite)
-      .then(() => {
-        trackAnalyticsEvent("AgentInviteCopied", {
-          surface: "room",
-          roomType: resolvedRoomType,
-        })
-        setAgentInviteError("")
-        setAgentInviteCopied(true)
-        setTimeout(() => setAgentInviteCopied(false), 2000)
-      })
-      .catch(() => {
-        setAgentInviteError(
-          "Clipboard access was blocked. Click Copy invite to try again."
-        )
-      })
-  }
-
-  const copyAgentInvite = () => {
-    if (typeof window === "undefined") return
-    writeAgentInvite(buildAgentInvitePrompt(roomName))
-  }
-
   const handleConnectRuntime = () => {
     setRuntimeConnectError("")
     void connectLocalRuntime().catch((connectError) => {
@@ -515,69 +484,87 @@ export default function RoomContent({
         </div>
       )}
 
-      <div className="flex flex-none flex-wrap items-center gap-2 border-b border-gray-800 px-4 py-3">
-        <h1 className="min-w-0 truncate text-lg font-medium">#{roomName}</h1>
-        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={copyRoomLink}
-            className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-300 hover:bg-gray-700"
-            title="Copy room link"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-3.5 w-3.5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-              />
-            </svg>
-            {roomLinkCopied ? "Copied!" : "Copy link"}
-          </button>
-          <button
-            type="button"
-            onClick={copyAgentInvite}
-            className="rounded-md border border-blue-700/70 bg-blue-900/30 px-3 py-1 text-xs text-blue-200 hover:bg-blue-800/50"
-            title="Copy Agent invite prompt"
-          >
-            {agentInviteCopied ? "Copied!" : "Invite Agent"}
-          </button>
-          {agentInviteError && (
-            <span role="status" className="text-xs text-rose-300">
-              {agentInviteError}
-            </span>
-          )}
-          <LiveTranscriptControl
-            liveTranscript={liveTranscript}
-            runtimeHosts={runtimeHosts}
-            runtimeHostProviders={runtimeHostProviders}
-            localParticipantId={localParticipantId}
-            participants={participants}
-            mediaAvailable={liveTranscriptMediaAvailable}
-            onStart={handleStartLiveTranscript}
-            onStop={handleStopLiveTranscript}
-            onConnect={handleConnectRuntime}
-            runtimeConnectionStatus={runtimeConnectionStatus}
-            runtimeConnectError={runtimeConnectError}
-          />
+      <header className="flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center">
+        <div
+          data-testid="room-header-identity"
+          className="flex min-w-0 items-center gap-2"
+        >
+          <h1 className="min-w-0 flex-1 truncate text-lg font-medium lg:flex-none">
+            #{roomName}
+          </h1>
           <button
             type="button"
             onClick={() => {
               leaveRoom()
               router.push("/")
             }}
-            className="rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700"
+            className="shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:hidden"
           >
             Leave
           </button>
         </div>
-      </div>
+        <div
+          data-testid="room-header-features"
+          className="flex flex-none flex-col gap-2 lg:ml-auto lg:flex-row lg:items-center lg:gap-2"
+        >
+          <div className="grid grid-cols-3 gap-2 lg:flex lg:items-center">
+            <button
+              type="button"
+              onClick={copyRoomLink}
+              className="flex min-w-0 items-center justify-center gap-1 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-300 hover:bg-gray-700"
+              title="Copy room link"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-3.5 w-3.5 shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                />
+              </svg>
+              <span className="truncate">
+                {roomLinkCopied ? "Copied!" : "Copy link"}
+              </span>
+            </button>
+            <AgentInviteControl
+              roomType={resolvedRoomType}
+              invitePrompt={buildAgentInvitePrompt(roomName)}
+              open={agentInviteOpen}
+              onOpenChange={setAgentInviteOpen}
+            />
+            <LiveTranscriptControl
+              liveTranscript={liveTranscript}
+              runtimeHosts={runtimeHosts}
+              runtimeHostProviders={runtimeHostProviders}
+              localParticipantId={localParticipantId}
+              participants={participants}
+              mediaAvailable={liveTranscriptMediaAvailable}
+              onStart={handleStartLiveTranscript}
+              onStop={handleStopLiveTranscript}
+              onConnect={handleConnectRuntime}
+              runtimeConnectionStatus={runtimeConnectionStatus}
+              runtimeConnectError={runtimeConnectError}
+              onSuggestInvite={() => setAgentInviteOpen(true)}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              leaveRoom()
+              router.push("/")
+            }}
+            className="hidden shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:inline-flex"
+          >
+            Leave
+          </button>
+        </div>
+      </header>
 
       {error !== "" && (
         <div

--- a/app/src/pages/ai-agent-room.tsx
+++ b/app/src/pages/ai-agent-room.tsx
@@ -55,9 +55,9 @@ free4chat-agent room join <room-id> --agent codex --name Codex`}</code>
         </li>
         <li>
           <strong>Browser-assisted resident:</strong> open a room, click{" "}
-          <strong>Invite Agent</strong>, and paste the copied prompt into your
-          Agent&apos;s chat. It fetches <code>agent.md</code> and bootstraps the
-          local, user-owned Agent Runtime itself.
+          <strong>Invite Agent</strong>, then copy the invite prompt and paste
+          it into your Agent&apos;s chat. It fetches <code>agent.md</code> and
+          bootstraps the local, user-owned Agent Runtime itself.
         </li>
         <li>
           <strong>Direct (low-level):</strong> any MCP client can connect


### PR DESCRIPTION
Follow-up to #236/#237: make the two header features self-explanatory and keep the filtered header layout intentional on narrow screens.

## Problem

- **Invite Agent** copied the bootstrap prompt instantly on click and mutated the header button into `Copied!` — a new Human could not tell what was copied, where to paste it, or what the Agent will do.
- **Live Transcript** setup copy introduced "Runtime" without context (`A local Free4Chat Runtime with transcription is needed to start.`) — an architecture/developer concept in front of ordinary Humans.
- The mobile Room header relied on raw flex-wrap: `Leave` could orphan onto its own row and the header grew unpredictably.

## UX changes

### Invite Agent is now a guided popover (new `AgentInviteControl`)

Final copy inside the popover:

> **Invite an Agent**
>
> Bring an Agent you're already using into this Room.
>
> 1. Open your Agent.
> 2. Copy the invite prompt below.
> 3. Paste it into the Agent.
>
> The Agent will set up Free4Chat locally if needed and join this Room itself. You normally do not need to install or configure anything manually.
> The same local Free4Chat setup can also provide Room features such as Live Transcript when speech is configured.
>
> `[bootstrap prompt preview — read-only, monospace, bounded height, scrollable]`
>
> [Copy invite prompt]

- Opening the popover copies **nothing**; the header button stays `Invite Agent` (stable, `aria-expanded`).
- The prompt preview is the ACTUAL `buildAgentInvitePrompt(roomName)` output — single source of truth, never re-typed in UI.
- Copy success → in-popover `✓ Invite prompt copied. Paste it into your Agent.`; failure → in-popover `Clipboard access was blocked. Try again.` Never in the global header.
- Escape / outside-click close; popover bounded to viewport (`max-w-[calc(100vw-2rem)]`).

### Live Transcript setup copy is Human-first

Unavailable state now reads:

> **Live Transcript**
> Turn room audio into shared text.
> Live Transcript needs transcription support from your local Free4Chat setup.
> If you haven't connected an Agent yet, start with [Start with Invite Agent].
> Already have Free4Chat running locally?
> [Copy connection command]
> Run this command in the terminal where Free4Chat is running. Do not paste it into an Agent chat.

- No unexplained "Runtime" as the first concept; architecture remains truthful (the command still goes to the local Free4Chat connection that hosts STT).
- **Cross-open is implemented**: the unavailable popover's `Start with Invite Agent` opens the Invite Agent popover via simple shared `RoomContent` state (`agentInviteOpen`) — no routing machinery. The provider-claim command is NOT merged into the Agent invite prompt and is never pasted into Agent chat (security instruction shown in-popover; claim never rendered separately).

### Responsive header

Desktop unchanged: `#room … Copy link | Invite Agent | Live Transcript | Leave` single row.

Mobile (below `lg`) uses the intentional two-row layout:

```
#ff424285-0138-42b6…          Leave
Copy link | Invite Agent | Live Transcript
```

- Row 1: truncating Room id (`min-w-0` + `truncate`, truthful visual truncation only) + Leave on the same row (two Leave instances: `lg:hidden` mobile + `hidden lg:inline-flex` desktop — only one is in the accessibility tree at any time).
- Row 2: exact three feature actions in a stable 3-column grid, equal weight, no hamburger/overflow.
- Both popovers are viewport-bounded and vertically scrollable on narrow screens; no new analytics for layout.

## Tracking (unchanged semantics — verified by tests)

- `AgentInviteCopied`: ZERO on popover open/view/failure; EXACTLY ONE per successful clipboard write (surface=room, current roomType); one more per successful re-copy. No `AgentInviteOpened`/`PromptViewed` or any new event.
- `LiveTranscriptStarted` / `LiveTranscriptStopped`: only on actual Start/Stop. Popover open/view/copy emits zero; no new copy event for the connection command.
- All other events (`InviteLinkCopied`, RoomCreated, TargetedMessage, AgentJoined, CollabRequested, CollabOutcome, CollaborationDuration, AgentVoice*): untouched.

## Architecture

- Runtime/provider authorization, #206 claim security, readiness!=authorization, invite bootstrap (`agentInvite.ts`) unchanged. Provider claim remains a separate Human-controlled local handoff; never combined with an Agent invite, never in chat/model/log/analytics.

## Tests

- `yarn vitest run` — **58 files / 566 tests passed**
  - `AgentInviteControl.test.tsx` (6, new): open-without-copy; prompt preview single-source; exactly-one `AgentInviteCopied` after successful copy; zero on failure; one per re-copy; Escape/outside close.
  - `RoomContent.test.tsx` (8): invite copy now happens only via the popover action (no provider claim in prompt); clipboard error inside popover; two-row mobile header structure (identity row + 3-feature row, no plumbing labels); Live Transcript → Start with Invite Agent cross-open; `LiveTranscriptStarted` only on actual Start.
  - `LiveTranscript.test.tsx` (14): updated unavailable copy, `Copy connection command` naming with separate transient feedback, `Start with Invite Agent` callback, Escape/outside close.
- `yarn type-check` clean; `yarn lint --max-warnings 0` clean; `npx prettier --check .` clean. No docs files changed; `docs:check` unaffected.

## Release

Browser/Worker deployment only — **no Agent Runtime release expected** (no Go files changed).

Closes the #236 follow-up (Agent invitation / speech setup understandability + responsive header).
