### PR TITLE
[codex] Align collaboration pattern diagrams

### DIFF
--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -562,10 +562,10 @@ Room. It is what they do not share.
 
 ```
 Human
- ├─ Codex @ laptop
- ├─ Ops Agent @ VPS
- └─ Browser-capable Agent
-          │
+|-- Codex @ laptop
+|-- Ops Agent @ VPS
++-- Browser-capable Agent
+          |
      Temporary Room
 ```
 
@@ -586,7 +586,7 @@ incident workflow.
 Alice + Alice's Agent
 Bob + Bob's Agent
 Carol + Carol's Agent
-          │
+          |
      Temporary Room
 ```
 
@@ -607,9 +607,9 @@ domains:
 
 ```
 Customer + Customer Agent
-          ↕
+          |
      Temporary Room
-          ↕
+          |
 Support engineer + Vendor Agent
 ```
 
@@ -624,9 +624,9 @@ as a selected-information exchange point.
 ## Pattern 4 - Personal Agent federation
 
 ```
-Phone Agent ─┐
-Laptop Agent ├─ Temporary Room
-Mac mini    ─┘
+Phone Agent  |
+Laptop Agent +-- Temporary Room
+Mac mini     |
 ```
 
 A person may eventually have Agents on a phone, laptop, Mac mini or home

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -299,9 +299,9 @@ export default function Home() {
                   </h2>
                   <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
                     <code>{`Human
-├─ Codex @ laptop
-├─ Ops Agent @ VPS
-└─ Browser Agent`}</code>
+|-- Codex @ laptop
+|-- Ops Agent @ VPS
++-- Browser Agent`}</code>
                   </pre>
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Separate tools and authority, one temporary Room for
@@ -314,9 +314,9 @@ export default function Home() {
                     Bring-your-own-Agent meeting
                   </h2>
                   <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Alice + Agent ─┐
-Bob + Agent   ├─ Temporary Room
-Carol + Agent ┘`}</code>
+                    <code>{`Alice + Agent  |
+Bob + Agent    +-- Temporary Room
+Carol + Agent  |`}</code>
                   </pre>
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Share the conversation or bounded transcript context, not
@@ -331,7 +331,9 @@ Carol + Agent ┘`}</code>
                   </h2>
                   <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
                     <code>{`Customer + Agent
-       ↕ Room
+       |
+   Temporary Room
+       |
 Support engineer + Vendor Agent`}</code>
                   </pre>
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
@@ -345,9 +347,9 @@ Support engineer + Vendor Agent`}</code>
                     Personal Agent federation
                   </h2>
                   <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Phone Agent ─┐
-Laptop Agent ├─ Temporary Room
-Cloud Agent ─┘`}</code>
+                    <code>{`Phone Agent  |
+Laptop Agent  +-- Temporary Room
+Cloud Agent   |`}</code>
                   </pre>
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Connect local capabilities when needed instead of creating

--- a/app/src/pages/multi-agent-collaboration.tsx
+++ b/app/src/pages/multi-agent-collaboration.tsx
@@ -122,10 +122,10 @@ Participant-owned, private
       <h3>1. Development war room</h3>
       <pre>
         <code>{`Human
- ├─ Codex @ laptop
- ├─ Ops Agent @ VPS
- └─ Browser-capable Agent
-          │
+ |-- Codex @ laptop
+ |-- Ops Agent @ VPS
+ +-- Browser-capable Agent
+          |
      Temporary Room`}</code>
       </pre>
       <p>
@@ -147,7 +147,7 @@ Participant-owned, private
         <code>{`Alice + Alice's Agent
 Bob + Bob's Agent
 Carol + Carol's Agent
-          │
+          |
      Temporary Room`}</code>
       </pre>
       <p>
@@ -163,9 +163,9 @@ Carol + Carol's Agent
       <h3>3. Agent-native support</h3>
       <pre>
         <code>{`Customer + Customer Agent
-          ↕
+          |
      Temporary Room
-          ↕
+          |
 Support engineer + Vendor Agent`}</code>
       </pre>
       <p>
@@ -178,9 +178,9 @@ Support engineer + Vendor Agent`}</code>
 
       <h3>4. Personal Agent federation</h3>
       <pre>
-        <code>{`Phone Agent ─┐
-Laptop Agent ├─ Temporary Room
-Mac mini    ─┘`}</code>
+        <code>{`Phone Agent  |
+Laptop Agent  +-- Temporary Room
+Mac mini      |`}</code>
       </pre>
       <p>
         A person may have Agents on a phone, laptop, Mac mini or home server,

--- a/docs/en/patterns/collaboration-patterns.md
+++ b/docs/en/patterns/collaboration-patterns.md
@@ -42,10 +42,10 @@ Room. It is what they do not share.
 
 ```
 Human
- ├─ Codex @ laptop
- ├─ Ops Agent @ VPS
- └─ Browser-capable Agent
-          │
+|-- Codex @ laptop
+|-- Ops Agent @ VPS
++-- Browser-capable Agent
+          |
      Temporary Room
 ```
 
@@ -66,7 +66,7 @@ incident workflow.
 Alice + Alice's Agent
 Bob + Bob's Agent
 Carol + Carol's Agent
-          │
+          |
      Temporary Room
 ```
 
@@ -87,9 +87,9 @@ domains:
 
 ```
 Customer + Customer Agent
-          ↕
+          |
      Temporary Room
-          ↕
+          |
 Support engineer + Vendor Agent
 ```
 
@@ -104,9 +104,9 @@ as a selected-information exchange point.
 ## Pattern 4 - Personal Agent federation
 
 ```
-Phone Agent ─┐
-Laptop Agent ├─ Temporary Room
-Mac mini    ─┘
+Phone Agent  |
+Laptop Agent +-- Temporary Room
+Mac mini     |
 ```
 
 A person may eventually have Agents on a phone, laptop, Mac mini or home


### PR DESCRIPTION
## Summary

The new collaboration-pattern cards were visually uneven in some browser
font/rendering environments. The overall grid was aligned, but Unicode box
drawing and bidirectional-arrow glyphs used in the diagrams had inconsistent
widths and baselines, making the connectors look displaced or broken.

## Cause and user impact

The diagrams were rendered as text inside monospace blocks, but characters such
as `↕`, `├─`, `└─`, and `─` can fall back to different font glyphs. That changes
their visual width or vertical alignment even when the source text has the
correct spacing.

## Fix

- Replaced the collaboration diagrams with stable ASCII connectors such as
  `|` and `+--`.
- Applied the same representation to the homepage, multi-Agent discovery page,
  and Collaboration patterns documentation so the surfaces stay consistent.
- Regenerated the documentation corpus asset that embeds the Markdown page.

This is a presentation-only correction. It does not change Room behavior,
protocol features, authorization, or the exploratory positioning of the
patterns.

## Validation

- `yarn type-check` passed.
- `yarn docs:check` passed.
- Focused discovery/docs tests — 46 tests passed.
- `yarn prettier --check ...` passed.
- `yarn build` passed; the existing Durable Object binding warning remains.

Related: #241
