### PR TITLE
[codex] preserve bounded expiry waiter responses

### DIFF
--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1340,9 +1340,11 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
     // The Room is already durably expired. Do not make the bounded
     // wait_for_events response wait for best-effort external media cleanup.
-    await executeMediaCloseEffects(
-      this.env,
-      snapshotMediaCloseEffects(pendingClose)
+    this.ctx.waitUntil(
+      executeMediaCloseEffects(
+        this.env,
+        snapshotMediaCloseEffects(pendingClose)
+      )
     )
   }
 

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1319,10 +1319,6 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     // no storage backend assumption is needed here.
     await this.ctx.storage.deleteAlarm()
     await this.ctx.storage.deleteAll()
-    await executeMediaCloseEffects(
-      this.env,
-      snapshotMediaCloseEffects(pendingClose)
-    )
     for (const waiter of expiringWaiters) {
       if (!waiter) continue
       waiter.resolve(
@@ -1342,6 +1338,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         // A socket may already be closed while the room is expiring.
       }
     }
+    // The Room is already durably expired. Do not make the bounded
+    // wait_for_events response wait for best-effort external media cleanup.
+    await executeMediaCloseEffects(
+      this.env,
+      snapshotMediaCloseEffects(pendingClose)
+    )
   }
 
   private async broadcast(message: unknown, except?: WebSocket): Promise<void> {

--- a/app/src/do/roomSessionLifecycle.test.ts
+++ b/app/src/do/roomSessionLifecycle.test.ts
@@ -179,7 +179,7 @@ function agentEventRoom(): RoomRecord {
 describe("RoomSession expiry cleanup", () => {
   afterEach(() => vi.unstubAllGlobals())
 
-  it("deletes the alarm and all storage after snapshotting cleanup effects", async () => {
+  it("notifies expiry recipients before external media cleanup", async () => {
     const { session, room, store, order, socket } = lifecycleHarness()
     const closeFetch = vi.fn(async () => {
       expect(store.size).toBe(0)
@@ -216,7 +216,8 @@ describe("RoomSession expiry cleanup", () => {
     expect(order.indexOf("mediaClose")).toBeGreaterThan(
       order.indexOf("deleteAll")
     )
-    expect(order.indexOf("waiter")).toBeGreaterThan(order.indexOf("mediaClose"))
+    expect(order.indexOf("waiter")).toBeGreaterThan(order.indexOf("deleteAll"))
+    expect(order.indexOf("waiter")).toBeLessThan(order.indexOf("mediaClose"))
     expect(closeFetch).toHaveBeenCalledOnce()
     expect(JSON.parse(await waiterResponse!.text())).toMatchObject({
       expired: true,
@@ -390,19 +391,20 @@ describe("RoomSession expiry cleanup", () => {
     expect(freshConnection.status).toBe(101)
     expect(sockets).toContain(freshSocket)
 
-    mediaClose.resolve(new Response(null, { status: 204 }))
-    await expiry
-
-    expect(oldWaiterResponse).toBeDefined()
-    expect(JSON.parse(await oldWaiterResponse!.text())).toMatchObject({
-      expired: true,
-      cursor: oldRoom.nextMessageSequence,
-    })
+    await vi.waitFor(() => expect(oldWaiterResponse).toBeDefined())
     expect(oldSocket.closed).toContainEqual({
       code: 4001,
       reason: "Room expired",
     })
     expect(freshSocket.closed).toEqual([])
+
+    mediaClose.resolve(new Response(null, { status: 204 }))
+    await expiry
+
+    expect(JSON.parse(await oldWaiterResponse!.text())).toMatchObject({
+      expired: true,
+      cursor: oldRoom.nextMessageSequence,
+    })
     expect(freshSocket.sent.some((value) => value.includes('"expired"'))).toBe(
       false
     )

--- a/app/src/do/roomSessionLifecycle.test.ts
+++ b/app/src/do/roomSessionLifecycle.test.ts
@@ -96,6 +96,7 @@ function lifecycleHarness() {
       },
     },
     getWebSockets: () => [socket],
+    waitUntil: (promise: Promise<unknown>) => void promise,
   }
   const session = new RoomSession(
     ctx as never,
@@ -304,6 +305,7 @@ describe("RoomSession expiry cleanup", () => {
         sockets.push(socket)
         socketTags.set(socket, tags)
       }),
+      waitUntil: (promise: Promise<unknown>) => void promise,
     }
     const session = new RoomSession(
       ctx as never,
@@ -410,6 +412,47 @@ describe("RoomSession expiry cleanup", () => {
     )
     const freshRoom = store.get("room") as RoomRecord
     expect(freshRoom.participants[freshAgent.id]).toBeDefined()
+  })
+
+  it("returns room_expired when the wait request triggers expiry", async () => {
+    const { session, store } = lifecycleHarness()
+    const mediaClose = deferred<Response>()
+    const fetchMock = vi.fn(() => mediaClose.promise)
+    vi.stubGlobal("fetch", fetchMock)
+
+    const responsePromise = session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "agent-wait",
+          participantId: "agent",
+          token: "agent-token",
+          cursor: 0,
+          timeoutSeconds: 25,
+        }),
+      })
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    expect(store.has("room")).toBe(false)
+
+    let expiryTimeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      const response = await Promise.race([
+        responsePromise,
+        new Promise<Response>((_, reject) => {
+          expiryTimeout = setTimeout(
+            () => reject(new Error("expiry response timed out")),
+            100
+          )
+        }),
+      ])
+      expect(response.status).toBe(410)
+      expect(await response.json()).toEqual({ error: "room_expired" })
+    } finally {
+      if (expiryTimeout) clearTimeout(expiryTimeout)
+      mediaClose.resolve(new Response(null, { status: 204 }))
+      await responsePromise
+    }
   })
 
   it("authenticates, reconnects, and delivers canonical events on the hibernatable socket", async () => {


### PR DESCRIPTION
## Summary

Refs #239.

This is a Worker-only follow-up to #242. It preserves recycled-room-generation isolation and keeps every expiry-triggering `wait_for_events` request bounded even when Cloudflare media cleanup stalls.

## Problem

`expireRoom()` already detached old-generation waiters and sockets before external media cleanup, and #244 moved their expiry notification ahead of that cleanup. However, a stale client whose own `agent-wait` request entered `activeRoom()` could still wait for `expireRoom()` itself to finish. Since `executeMediaCloseEffects()` calls the external Realtime API without a request-critical timeout, that request could remain pending indefinitely.

## Fix

After the room storage and alarm are deleted, `expireRoom()` immediately resolves the captured old-generation waiters with `expired: true` and closes the captured sockets. It then starts the exact captured media-close effects through the Durable Object background-work hook without awaiting them. The expiry path therefore returns `room_expired` promptly to a request that triggered expiry, while new-generation waiters and sockets remain untouched.

## Validation

- `yarn vitest run src/do/roomSessionLifecycle.test.ts` (6 tests)
- `yarn test` (575 tests)
- `yarn type-check`
- `yarn eslint src`
- `yarn prettier --check src/do/RoomSession.ts src/do/roomSessionLifecycle.test.ts`
- `yarn docs:check`
- `CI=1 yarn cf-build`
- `git diff --check`

The lifecycle suite now covers both the existing waiter path and an actual `agent-wait` control request whose `activeRoom()` triggers expiry while media cleanup remains pending. The test asserts the control request returns HTTP 410 before releasing the cleanup promise.

No Go Runtime, MCP public contract, analytics, #223 behavior, storage backend, or release artifact changes are included.
