### PR TITLE
[codex] Render collaboration diagrams with layout primitives

### DIFF
--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -624,9 +624,9 @@ as a selected-information exchange point.
 ## Pattern 4 - Personal Agent federation
 
 ```
-Phone Agent  |
-Laptop Agent +-- Temporary Room
-Mac mini     |
+Phone Agent   |
+Laptop Agent  +-- Temporary Room
+Mac mini      |
 ```
 
 A person may eventually have Agents on a phone, laptop, Mac mini or home

--- a/app/src/components/CollaborationDiagram.tsx
+++ b/app/src/components/CollaborationDiagram.tsx
@@ -1,0 +1,66 @@
+import { Fragment, type ReactNode } from "react"
+
+export interface CollaborationDiagramProps {
+  variant: "tree" | "branches" | "stack"
+  rows: string[]
+  target?: string
+}
+
+const baseClasses =
+  "mt-3 overflow-x-auto whitespace-nowrap font-mono text-[11px] leading-relaxed text-cyan-300"
+
+function Connector(): ReactNode {
+  return <span aria-hidden="true">|</span>
+}
+
+export default function CollaborationDiagram({
+  variant,
+  rows,
+  target,
+}: CollaborationDiagramProps) {
+  if (variant === "tree") {
+    return (
+      <div className={baseClasses}>
+        <div>{rows[0]}</div>
+        <div className="ml-1 border-l border-cyan-300/70 pl-2">
+          {rows.slice(1).map((row) => (
+            <div key={row}>{row}</div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (variant === "stack") {
+    return (
+      <div className={baseClasses + " flex min-w-full flex-col items-center"}>
+        <span>{rows[0]}</span>
+        <Connector />
+        <span>{target ?? rows[1]}</span>
+        <Connector />
+        <span>{rows[rows.length - 1]}</span>
+      </div>
+    )
+  }
+
+  const targetIndex = Math.floor(rows.length / 2)
+  return (
+    <div
+      className={
+        baseClasses +
+        " grid w-max min-w-full grid-cols-[max-content_auto] items-center gap-x-3"
+      }
+    >
+      {rows.map((row, index) => (
+        <Fragment key={row}>
+          <span>{row}</span>
+          <span aria-hidden="true">
+            {index === targetIndex
+              ? "+-- " + (target ?? "Temporary Room")
+              : "|"}
+          </span>
+        </Fragment>
+      ))}
+    </div>
+  )
+}

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -10,6 +10,7 @@ import {
   trackAnalyticsEvent,
   hashRoom,
 } from "../common/utils"
+import CollaborationDiagram from "../components/CollaborationDiagram"
 import DiscoveryFooter from "../components/DiscoveryFooter"
 import Header from "../components/Header"
 
@@ -297,12 +298,15 @@ export default function Home() {
                   <h2 className="text-sm font-bold uppercase tracking-wide text-emerald-300">
                     Development war room
                   </h2>
-                  <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Human
-|-- Codex @ laptop
-|-- Ops Agent @ VPS
-+-- Browser Agent`}</code>
-                  </pre>
+                  <CollaborationDiagram
+                    variant="tree"
+                    rows={[
+                      "Human",
+                      "Codex @ laptop",
+                      "Ops Agent @ VPS",
+                      "Browser Agent",
+                    ]}
+                  />
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Separate tools and authority, one temporary Room for
                     selected diagnostics, code changes, and UI checks.
@@ -313,11 +317,10 @@ export default function Home() {
                   <h2 className="text-sm font-bold uppercase tracking-wide text-emerald-300">
                     Bring-your-own-Agent meeting
                   </h2>
-                  <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Alice + Agent  |
-Bob + Agent    +-- Temporary Room
-Carol + Agent  |`}</code>
-                  </pre>
+                  <CollaborationDiagram
+                    variant="branches"
+                    rows={["Alice + Agent", "Bob + Agent", "Carol + Agent"]}
+                  />
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Share the conversation or bounded transcript context, not
                     the entire intelligence context. Each Agent keeps its own
@@ -329,13 +332,14 @@ Carol + Agent  |`}</code>
                   <h2 className="text-sm font-bold uppercase tracking-wide text-emerald-300">
                     Agent-native support
                   </h2>
-                  <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Customer + Agent
-       |
-   Temporary Room
-       |
-Support engineer + Vendor Agent`}</code>
-                  </pre>
+                  <CollaborationDiagram
+                    variant="stack"
+                    rows={[
+                      "Customer + Agent",
+                      "Support engineer + Vendor Agent",
+                    ]}
+                    target="Temporary Room"
+                  />
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Exchange selected diagnostics, screenshots, requests, and
                     results while local trust boundaries remain separate.
@@ -346,11 +350,10 @@ Support engineer + Vendor Agent`}</code>
                   <h2 className="text-sm font-bold uppercase tracking-wide text-emerald-300">
                     Personal Agent federation
                   </h2>
-                  <pre className="mt-3 overflow-x-auto text-[11px] leading-relaxed text-cyan-300">
-                    <code>{`Phone Agent  |
-Laptop Agent  +-- Temporary Room
-Cloud Agent   |`}</code>
-                  </pre>
+                  <CollaborationDiagram
+                    variant="branches"
+                    rows={["Phone Agent", "Laptop Agent", "Cloud Agent"]}
+                  />
                   <p className="mt-3 text-xs leading-relaxed text-emerald-600">
                     Connect local capabilities when needed instead of creating
                     one permanently privileged super-Agent.

--- a/app/src/pages/multi-agent-collaboration.tsx
+++ b/app/src/pages/multi-agent-collaboration.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 
+import CollaborationDiagram from "../components/CollaborationDiagram"
 import DiscoveryPageLayout from "../components/DiscoveryPageLayout"
 
 export default function MultiAgentCollaborationPage() {
@@ -120,14 +121,15 @@ Participant-owned, private
       </p>
 
       <h3>1. Development war room</h3>
-      <pre>
-        <code>{`Human
- |-- Codex @ laptop
- |-- Ops Agent @ VPS
- +-- Browser-capable Agent
-          |
-     Temporary Room`}</code>
-      </pre>
+      <CollaborationDiagram
+        variant="tree"
+        rows={[
+          "Human",
+          "Codex @ laptop",
+          "Ops Agent @ VPS",
+          "Browser-capable Agent",
+        ]}
+      />
       <p>
         A Human sees a production failure. An Ops Agent can inspect production
         state or logs with its own credentials, a coding Agent can work in the
@@ -143,13 +145,14 @@ Participant-owned, private
       </p>
 
       <h3>2. Bring-your-own-Agent meeting</h3>
-      <pre>
-        <code>{`Alice + Alice's Agent
-Bob + Bob's Agent
-Carol + Carol's Agent
-          |
-     Temporary Room`}</code>
-      </pre>
+      <CollaborationDiagram
+        variant="branches"
+        rows={[
+          "Alice + Alice's Agent",
+          "Bob + Bob's Agent",
+          "Carol + Carol's Agent",
+        ]}
+      />
       <p>
         Humans participate normally and may bring Agents from their own
         environments. An authorized, STT-ready Runtime Host can provide a
@@ -161,13 +164,11 @@ Carol + Carol's Agent
       </p>
 
       <h3>3. Agent-native support</h3>
-      <pre>
-        <code>{`Customer + Customer Agent
-          |
-     Temporary Room
-          |
-Support engineer + Vendor Agent`}</code>
-      </pre>
+      <CollaborationDiagram
+        variant="stack"
+        rows={["Customer + Customer Agent", "Support engineer + Vendor Agent"]}
+        target="Temporary Room"
+      />
       <p>
         As an exploratory pattern, a customer-side Agent and a vendor-side Agent
         could exchange intentional, bounded diagnostics, logs, screenshots,
@@ -177,11 +178,10 @@ Support engineer + Vendor Agent`}</code>
       </p>
 
       <h3>4. Personal Agent federation</h3>
-      <pre>
-        <code>{`Phone Agent  |
-Laptop Agent  +-- Temporary Room
-Mac mini      |`}</code>
-      </pre>
+      <CollaborationDiagram
+        variant="branches"
+        rows={["Phone Agent", "Laptop Agent", "Mac mini"]}
+      />
       <p>
         A person may have Agents on a phone, laptop, Mac mini or home server,
         and a cloud environment. Each can retain capabilities that make sense

--- a/docs/en/patterns/collaboration-patterns.md
+++ b/docs/en/patterns/collaboration-patterns.md
@@ -104,9 +104,9 @@ as a selected-information exchange point.
 ## Pattern 4 - Personal Agent federation
 
 ```
-Phone Agent  |
-Laptop Agent +-- Temporary Room
-Mac mini     |
+Phone Agent   |
+Laptop Agent  +-- Temporary Room
+Mac mini      |
 ```
 
 A person may eventually have Agents on a phone, laptop, Mac mini or home


### PR DESCRIPTION
## Summary

The new collaboration-pattern cards were visually uneven in some browser
font/rendering environments. The overall grid was aligned, but Unicode box
drawing and bidirectional-arrow glyphs used in the diagrams had inconsistent
widths and baselines, making the connectors look displaced or broken.

## Cause and user impact

The diagrams were rendered as text inside monospace blocks, but characters such
as `↕`, `├─`, `└─`, and `─` can fall back to different font glyphs. That changes
their visual width or vertical alignment even when the source text has the
correct spacing.

## Fix

- Replaced the collaboration diagrams with stable ASCII connectors such as
  `|` and `+--`.
- Applied the same representation to the homepage, multi-Agent discovery page,
  and Collaboration patterns documentation so the surfaces stay consistent.
- Regenerated the documentation corpus asset that embeds the Markdown page.

This is a presentation-only correction. It does not change Room behavior,
protocol features, authorization, or the exploratory positioning of the
patterns.

## Validation

- `yarn type-check` passed.
- `yarn docs:check` passed.
- Focused discovery/docs tests — 46 tests passed.
- `yarn prettier --check ...` passed.
- `yarn build` passed; the existing Durable Object binding warning remains.

Related: #241
