### PR TITLE
[codex] Add estimated SFU egress observability

### DIFF
--- a/app/src/common/sfuEgress.test.ts
+++ b/app/src/common/sfuEgress.test.ts
@@ -151,7 +151,7 @@ describe("SFU egress stats", () => {
     )
   })
 
-  it("counts deltas only for matching stats ids and re-baselines reset or new ids", () => {
+  it("counts new stats ids after the initial baseline and re-baselines resets", () => {
     const previous = aggregateSfuEgressStats(
       report(
         { id: "audio", type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
@@ -179,7 +179,7 @@ describe("SFU egress stats", () => {
 
     expect(sfuEgressDelta(previous, current)).toEqual({
       audioBytes: 50,
-      videoBytes: 0,
+      videoBytes: 10,
       dataChannelBytes: 0,
     })
     expect(sfuEgressDelta(null, current)).toBeNull()
@@ -267,7 +267,7 @@ describe("SFU egress stats", () => {
     )
   })
 
-  it("counts an existing RTP stream while a replacement stream establishes its baseline", async () => {
+  it("counts an existing RTP stream and a newly appearing video stream", async () => {
     let now = 1_000
     const emit = vi.fn()
     const sampler = createSfuEgressSampler(emit, () => now)
@@ -331,9 +331,9 @@ describe("SFU egress stats", () => {
     expect(emit).toHaveBeenLastCalledWith(
       {
         audioBytes: 50,
-        videoBytes: 0,
+        videoBytes: 10,
         dataChannelBytes: 0,
-        totalBytes: 50,
+        totalBytes: 60,
         intervalMs: 300_000,
         sampleReason: "interval",
       },
@@ -395,6 +395,52 @@ describe("SFU egress stats", () => {
         videoBytes: 0,
         dataChannelBytes: 0,
         totalBytes: 40,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      peerConnection
+    )
+  })
+
+  it("counts a newly appearing DataChannel stats object", async () => {
+    let now = 1_000
+    const emit = vi.fn()
+    const sampler = createSfuEgressSampler(emit, () => now)
+    const peerConnection = {}
+    const getStats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 100,
+        })
+      )
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 140,
+          },
+          { id: "dc", type: "data-channel", bytesReceived: 25 }
+        )
+      )
+
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    now += 300_000
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+
+    expect(emit).toHaveBeenCalledWith(
+      {
+        audioBytes: 40,
+        videoBytes: 0,
+        dataChannelBytes: 25,
+        totalBytes: 65,
         intervalMs: 300_000,
         sampleReason: "interval",
       },

--- a/app/src/common/sfuEgress.test.ts
+++ b/app/src/common/sfuEgress.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  aggregateSfuEgressStats,
+  createSfuEgressSampler,
+  sfuEgressDelta,
+  SFU_EGRESS_SAMPLE_INTERVAL_MS,
+} from "./sfuEgress"
+
+async function settle() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+describe("SFU egress stats", () => {
+  it("samples at a bounded five-minute interval", () => {
+    expect(SFU_EGRESS_SAMPLE_INTERVAL_MS).toBe(5 * 60 * 1000)
+  })
+
+  it("aggregates inbound audio rows and ignores outbound or unrelated rows", () => {
+    expect(
+      aggregateSfuEgressStats(
+        new Map([
+          [
+            "audio-1",
+            { type: "inbound-rtp", kind: "audio", bytesReceived: 120 },
+          ],
+          [
+            "audio-2",
+            { type: "inbound-rtp", mediaType: "audio", bytesReceived: 30 },
+          ],
+          ["outbound", { type: "outbound-rtp", kind: "audio", bytesSent: 999 }],
+          ["candidate", { type: "candidate-pair", bytesReceived: 500 }],
+        ])
+      )
+    ).toEqual({ audioBytes: 150, videoBytes: 0, dataChannelBytes: 0 })
+  })
+
+  it("aggregates inbound video and DataChannel rows when exposed", () => {
+    expect(
+      aggregateSfuEgressStats([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 80 },
+        { type: "inbound-rtp", kind: "video", bytesReceived: 1_000 },
+        { type: "inbound-rtp", mediaType: "video", bytesReceived: 250 },
+        { type: "data-channel", bytesReceived: 70 },
+        { type: "data-channel", bytesReceived: 30 },
+      ])
+    ).toEqual({ audioBytes: 80, videoBytes: 1_250, dataChannelBytes: 100 })
+  })
+
+  it("gracefully handles unavailable or malformed browser stats", () => {
+    expect(
+      aggregateSfuEgressStats({
+        type: "inbound-rtp",
+        kind: "audio",
+        bytesReceived: 12,
+      })
+    ).toEqual({ audioBytes: 12, videoBytes: 0, dataChannelBytes: 0 })
+    expect(aggregateSfuEgressStats(undefined)).toEqual({
+      audioBytes: 0,
+      videoBytes: 0,
+      dataChannelBytes: 0,
+    })
+    expect(
+      aggregateSfuEgressStats({
+        audio: { type: "inbound-rtp", kind: "audio", bytesReceived: -1 },
+        video: { type: "inbound-rtp", kind: "video", bytesReceived: NaN },
+        data: { type: "data-channel" },
+      })
+    ).toEqual({ audioBytes: 0, videoBytes: 0, dataChannelBytes: 0 })
+  })
+
+  it("returns null for a baseline or a counter reset and never returns negative bytes", () => {
+    const current = { audioBytes: 40, videoBytes: 25, dataChannelBytes: 10 }
+    expect(sfuEgressDelta(null, current)).toBeNull()
+    expect(
+      sfuEgressDelta(
+        { audioBytes: 50, videoBytes: 25, dataChannelBytes: 10 },
+        current
+      )
+    ).toBeNull()
+    expect(
+      sfuEgressDelta(
+        { audioBytes: 20, videoBytes: 5, dataChannelBytes: 4 },
+        current
+      )
+    ).toEqual({ audioBytes: 20, videoBytes: 20, dataChannelBytes: 6 })
+  })
+
+  it("emits only new non-zero deltas and re-baselines a new PeerConnection", async () => {
+    let now = 1_000
+    const emit = vi.fn()
+    const sampler = createSfuEgressSampler(emit, () => now)
+    const firstPeerConnection = {}
+    const firstStats = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
+      ])
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
+      ])
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 175 },
+      ])
+
+    sampler.sample(firstPeerConnection, firstStats, "interval")
+    await settle()
+    now += 300_000
+    sampler.sample(firstPeerConnection, firstStats, "interval")
+    await settle()
+    expect(emit).not.toHaveBeenCalled()
+
+    now += 300_000
+    sampler.sample(firstPeerConnection, firstStats, "interval")
+    await settle()
+    expect(emit).toHaveBeenCalledWith(
+      {
+        audioBytes: 75,
+        videoBytes: 0,
+        dataChannelBytes: 0,
+        totalBytes: 75,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      firstPeerConnection
+    )
+
+    const secondPeerConnection = {}
+    const secondStats = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 12 },
+      ])
+    now += 300_000
+    sampler.sample(secondPeerConnection, secondStats, "disconnect")
+    await settle()
+    expect(emit).toHaveBeenCalledTimes(1)
+
+    now += 60_000
+    secondStats.mockResolvedValueOnce([
+      { type: "inbound-rtp", kind: "audio", bytesReceived: 12 },
+      { type: "data-channel", bytesReceived: 20 },
+      { type: "inbound-rtp", kind: "video", bytesReceived: 8 },
+    ])
+    sampler.sample(secondPeerConnection, secondStats, "leave")
+    await settle()
+    expect(emit).toHaveBeenLastCalledWith(
+      {
+        audioBytes: 0,
+        videoBytes: 8,
+        dataChannelBytes: 20,
+        totalBytes: 28,
+        intervalMs: 60_000,
+        sampleReason: "leave",
+      },
+      secondPeerConnection
+    )
+  })
+
+  it("swallows getStats and analytics failures", async () => {
+    const emit = vi.fn(() => {
+      throw new Error("analytics unavailable")
+    })
+    const sampler = createSfuEgressSampler(emit)
+    const peerConnection = {}
+    const getStats = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("stats unavailable"))
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 10 },
+      ])
+      .mockResolvedValueOnce([
+        { type: "inbound-rtp", kind: "audio", bytesReceived: 20 },
+      ])
+
+    expect(() =>
+      sampler.sample(peerConnection, getStats, "pagehide")
+    ).not.toThrow()
+    await settle()
+    expect(() =>
+      sampler.sample(peerConnection, getStats, "pagehide")
+    ).not.toThrow()
+    await settle()
+    expect(() =>
+      sampler.sample(peerConnection, getStats, "pagehide")
+    ).not.toThrow()
+    await settle()
+    expect(emit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/common/sfuEgress.test.ts
+++ b/app/src/common/sfuEgress.test.ts
@@ -3,12 +3,24 @@ import { describe, expect, it, vi } from "vitest"
 import {
   aggregateSfuEgressStats,
   createSfuEgressSampler,
-  sfuEgressDelta,
   SFU_EGRESS_SAMPLE_INTERVAL_MS,
+  sfuEgressDelta,
 } from "./sfuEgress"
 
 async function settle() {
   await new Promise<void>((resolve) => setTimeout(resolve, 0))
+}
+
+function report(
+  ...stats: Array<{
+    id: string
+    type: string
+    kind?: string
+    mediaType?: string
+    bytesReceived?: number
+  }>
+) {
+  return new Map(stats.map((stat) => [stat.id, stat]))
 }
 
 describe("SFU egress stats", () => {
@@ -16,148 +28,437 @@ describe("SFU egress stats", () => {
     expect(SFU_EGRESS_SAMPLE_INTERVAL_MS).toBe(5 * 60 * 1000)
   })
 
-  it("aggregates inbound audio rows and ignores outbound or unrelated rows", () => {
-    expect(
-      aggregateSfuEgressStats(
-        new Map([
-          [
-            "audio-1",
-            { type: "inbound-rtp", kind: "audio", bytesReceived: 120 },
-          ],
-          [
-            "audio-2",
-            { type: "inbound-rtp", mediaType: "audio", bytesReceived: 30 },
-          ],
-          ["outbound", { type: "outbound-rtp", kind: "audio", bytesSent: 999 }],
-          ["candidate", { type: "candidate-pair", bytesReceived: 500 }],
-        ])
-      )
-    ).toEqual({ audioBytes: 150, videoBytes: 0, dataChannelBytes: 0 })
+  it("collects inbound rows by stats.id and ignores outbound or unrelated rows", () => {
+    const stats = aggregateSfuEgressStats(
+      new Map([
+        [
+          "map-key-is-not-used",
+          {
+            id: "audio-1",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 120,
+          },
+        ],
+        [
+          "audio-2",
+          {
+            id: "audio-2",
+            type: "inbound-rtp",
+            mediaType: "audio",
+            bytesReceived: 30,
+          },
+        ],
+        [
+          "outbound",
+          {
+            id: "outbound",
+            type: "outbound-rtp",
+            kind: "audio",
+            bytesSent: 999,
+          },
+        ],
+        [
+          "candidate",
+          { id: "candidate", type: "candidate-pair", bytesReceived: 500 },
+        ],
+        [
+          "missing-id",
+          { type: "inbound-rtp", kind: "audio", bytesReceived: 500 },
+        ],
+      ])
+    )
+
+    expect([...stats.entries()]).toEqual([
+      ["audio-1", { category: "audio", bytesReceived: 120 }],
+      ["audio-2", { category: "audio", bytesReceived: 30 }],
+    ])
   })
 
-  it("aggregates inbound video and DataChannel rows when exposed", () => {
+  it("collects separate video and DataChannel receive counters when exposed", () => {
     expect(
-      aggregateSfuEgressStats([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 80 },
-        { type: "inbound-rtp", kind: "video", bytesReceived: 1_000 },
-        { type: "inbound-rtp", mediaType: "video", bytesReceived: 250 },
-        { type: "data-channel", bytesReceived: 70 },
-        { type: "data-channel", bytesReceived: 30 },
+      aggregateSfuEgressStats(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 80,
+          },
+          {
+            id: "video-1",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: 1_000,
+          },
+          {
+            id: "video-2",
+            type: "inbound-rtp",
+            mediaType: "video",
+            bytesReceived: 250,
+          },
+          { id: "dc-1", type: "data-channel", bytesReceived: 70 },
+          { id: "dc-2", type: "data-channel", bytesReceived: 30 }
+        )
+      )
+    ).toEqual(
+      new Map([
+        ["audio", { category: "audio", bytesReceived: 80 }],
+        ["video-1", { category: "video", bytesReceived: 1_000 }],
+        ["video-2", { category: "video", bytesReceived: 250 }],
+        ["dc-1", { category: "dataChannel", bytesReceived: 70 }],
+        ["dc-2", { category: "dataChannel", bytesReceived: 30 }],
       ])
-    ).toEqual({ audioBytes: 80, videoBytes: 1_250, dataChannelBytes: 100 })
+    )
   })
 
   it("gracefully handles unavailable or malformed browser stats", () => {
     expect(
       aggregateSfuEgressStats({
+        id: "single-audio",
         type: "inbound-rtp",
         kind: "audio",
         bytesReceived: 12,
       })
-    ).toEqual({ audioBytes: 12, videoBytes: 0, dataChannelBytes: 0 })
-    expect(aggregateSfuEgressStats(undefined)).toEqual({
-      audioBytes: 0,
+    ).toEqual(
+      new Map([["single-audio", { category: "audio", bytesReceived: 12 }]])
+    )
+    expect(aggregateSfuEgressStats(undefined)).toEqual(new Map())
+    expect(
+      aggregateSfuEgressStats(
+        report(
+          {
+            id: "bad-audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: -1,
+          },
+          {
+            id: "bad-video",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: NaN,
+          },
+          { id: "missing-bytes", type: "data-channel" }
+        )
+      )
+    ).toEqual(
+      new Map([
+        ["bad-audio", { category: "audio", bytesReceived: 0 }],
+        ["bad-video", { category: "video", bytesReceived: 0 }],
+        ["missing-bytes", { category: "dataChannel", bytesReceived: 0 }],
+      ])
+    )
+  })
+
+  it("counts deltas only for matching stats ids and re-baselines reset or new ids", () => {
+    const previous = aggregateSfuEgressStats(
+      report(
+        { id: "audio", type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
+        {
+          id: "video-old",
+          type: "inbound-rtp",
+          kind: "video",
+          bytesReceived: 200,
+        },
+        { id: "dc", type: "data-channel", bytesReceived: 50 }
+      )
+    )
+    const current = aggregateSfuEgressStats(
+      report(
+        { id: "audio", type: "inbound-rtp", kind: "audio", bytesReceived: 150 },
+        {
+          id: "video-new",
+          type: "inbound-rtp",
+          kind: "video",
+          bytesReceived: 10,
+        },
+        { id: "dc", type: "data-channel", bytesReceived: 50 }
+      )
+    )
+
+    expect(sfuEgressDelta(previous, current)).toEqual({
+      audioBytes: 50,
       videoBytes: 0,
       dataChannelBytes: 0,
     })
-    expect(
-      aggregateSfuEgressStats({
-        audio: { type: "inbound-rtp", kind: "audio", bytesReceived: -1 },
-        video: { type: "inbound-rtp", kind: "video", bytesReceived: NaN },
-        data: { type: "data-channel" },
-      })
-    ).toEqual({ audioBytes: 0, videoBytes: 0, dataChannelBytes: 0 })
-  })
-
-  it("returns null for a baseline or a counter reset and never returns negative bytes", () => {
-    const current = { audioBytes: 40, videoBytes: 25, dataChannelBytes: 10 }
     expect(sfuEgressDelta(null, current)).toBeNull()
-    expect(
-      sfuEgressDelta(
-        { audioBytes: 50, videoBytes: 25, dataChannelBytes: 10 },
-        current
-      )
-    ).toBeNull()
-    expect(
-      sfuEgressDelta(
-        { audioBytes: 20, videoBytes: 5, dataChannelBytes: 4 },
-        current
-      )
-    ).toEqual({ audioBytes: 20, videoBytes: 20, dataChannelBytes: 6 })
   })
 
-  it("emits only new non-zero deltas and re-baselines a new PeerConnection", async () => {
+  it("re-baselines one reset stats id without suppressing unrelated deltas", () => {
+    const previous = aggregateSfuEgressStats(
+      report(
+        { id: "audio", type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
+        {
+          id: "video",
+          type: "inbound-rtp",
+          kind: "video",
+          bytesReceived: 200,
+        }
+      )
+    )
+    const current = aggregateSfuEgressStats(
+      report(
+        { id: "audio", type: "inbound-rtp", kind: "audio", bytesReceived: 150 },
+        {
+          id: "video",
+          type: "inbound-rtp",
+          kind: "video",
+          bytesReceived: 10,
+        }
+      )
+    )
+
+    expect(sfuEgressDelta(previous, current)).toEqual({
+      audioBytes: 50,
+      videoBytes: 0,
+      dataChannelBytes: 0,
+    })
+  })
+
+  it("emits valid audio when a video stats object disappears", async () => {
+    let now = 1_000
+    const emit = vi.fn()
+    const sampler = createSfuEgressSampler(emit, () => now)
+    const peerConnection = {}
+    const getStats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 100,
+          },
+          {
+            id: "video",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: 200,
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 160,
+        })
+      )
+
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    now += 300_000
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+
+    expect(emit).toHaveBeenCalledWith(
+      {
+        audioBytes: 60,
+        videoBytes: 0,
+        dataChannelBytes: 0,
+        totalBytes: 60,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      peerConnection
+    )
+  })
+
+  it("counts an existing RTP stream while a replacement stream establishes its baseline", async () => {
+    let now = 1_000
+    const emit = vi.fn()
+    const sampler = createSfuEgressSampler(emit, () => now)
+    const peerConnection = {}
+    const getStats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 100,
+          },
+          {
+            id: "video-old",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: 200,
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 150,
+          },
+          {
+            id: "video-new",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: 10,
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 180,
+          },
+          {
+            id: "video-new",
+            type: "inbound-rtp",
+            kind: "video",
+            bytesReceived: 30,
+          }
+        )
+      )
+
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    now += 300_000
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    expect(emit).toHaveBeenLastCalledWith(
+      {
+        audioBytes: 50,
+        videoBytes: 0,
+        dataChannelBytes: 0,
+        totalBytes: 50,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      peerConnection
+    )
+
+    now += 300_000
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    expect(emit).toHaveBeenLastCalledWith(
+      {
+        audioBytes: 30,
+        videoBytes: 20,
+        dataChannelBytes: 0,
+        totalBytes: 50,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      peerConnection
+    )
+  })
+
+  it("keeps RTP deltas when a DataChannel stats object disappears", async () => {
+    let now = 1_000
+    const emit = vi.fn()
+    const sampler = createSfuEgressSampler(emit, () => now)
+    const peerConnection = {}
+    const getStats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        report(
+          {
+            id: "audio",
+            type: "inbound-rtp",
+            kind: "audio",
+            bytesReceived: 100,
+          },
+          { id: "dc", type: "data-channel", bytesReceived: 50 }
+        )
+      )
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 140,
+        })
+      )
+
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+    now += 300_000
+    sampler.sample(peerConnection, getStats, "interval")
+    await settle()
+
+    expect(emit).toHaveBeenCalledWith(
+      {
+        audioBytes: 40,
+        videoBytes: 0,
+        dataChannelBytes: 0,
+        totalBytes: 40,
+        intervalMs: 300_000,
+        sampleReason: "interval",
+      },
+      peerConnection
+    )
+  })
+
+  it("establishes a completely fresh baseline after PeerConnection replacement", async () => {
     let now = 1_000
     const emit = vi.fn()
     const sampler = createSfuEgressSampler(emit, () => now)
     const firstPeerConnection = {}
-    const firstStats = vi
+    const secondPeerConnection = {}
+    const firstStats = vi.fn().mockResolvedValueOnce(
+      report({
+        id: "audio",
+        type: "inbound-rtp",
+        kind: "audio",
+        bytesReceived: 100,
+      })
+    )
+    const secondStats = vi
       .fn()
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
-      ])
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 100 },
-      ])
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 175 },
-      ])
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 100,
+        })
+      )
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 130,
+        })
+      )
 
     sampler.sample(firstPeerConnection, firstStats, "interval")
     await settle()
     now += 300_000
-    sampler.sample(firstPeerConnection, firstStats, "interval")
+    sampler.sample(secondPeerConnection, secondStats, "interval")
     await settle()
     expect(emit).not.toHaveBeenCalled()
 
     now += 300_000
-    sampler.sample(firstPeerConnection, firstStats, "interval")
+    sampler.sample(secondPeerConnection, secondStats, "interval")
     await settle()
     expect(emit).toHaveBeenCalledWith(
       {
-        audioBytes: 75,
+        audioBytes: 30,
         videoBytes: 0,
         dataChannelBytes: 0,
-        totalBytes: 75,
+        totalBytes: 30,
         intervalMs: 300_000,
         sampleReason: "interval",
-      },
-      firstPeerConnection
-    )
-
-    const secondPeerConnection = {}
-    const secondStats = vi
-      .fn()
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 12 },
-      ])
-    now += 300_000
-    sampler.sample(secondPeerConnection, secondStats, "disconnect")
-    await settle()
-    expect(emit).toHaveBeenCalledTimes(1)
-
-    now += 60_000
-    secondStats.mockResolvedValueOnce([
-      { type: "inbound-rtp", kind: "audio", bytesReceived: 12 },
-      { type: "data-channel", bytesReceived: 20 },
-      { type: "inbound-rtp", kind: "video", bytesReceived: 8 },
-    ])
-    sampler.sample(secondPeerConnection, secondStats, "leave")
-    await settle()
-    expect(emit).toHaveBeenLastCalledWith(
-      {
-        audioBytes: 0,
-        videoBytes: 8,
-        dataChannelBytes: 20,
-        totalBytes: 28,
-        intervalMs: 60_000,
-        sampleReason: "leave",
       },
       secondPeerConnection
     )
   })
 
-  it("swallows getStats and analytics failures", async () => {
+  it("emits only non-zero deltas and swallows stats or analytics failures", async () => {
     const emit = vi.fn(() => {
       throw new Error("analytics unavailable")
     })
@@ -166,13 +467,35 @@ describe("SFU egress stats", () => {
     const getStats = vi
       .fn()
       .mockRejectedValueOnce(new Error("stats unavailable"))
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 10 },
-      ])
-      .mockResolvedValueOnce([
-        { type: "inbound-rtp", kind: "audio", bytesReceived: 20 },
-      ])
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 10,
+        })
+      )
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 10,
+        })
+      )
+      .mockResolvedValueOnce(
+        report({
+          id: "audio",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 20,
+        })
+      )
 
+    expect(() =>
+      sampler.sample(peerConnection, getStats, "pagehide")
+    ).not.toThrow()
+    await settle()
     expect(() =>
       sampler.sample(peerConnection, getStats, "pagehide")
     ).not.toThrow()

--- a/app/src/common/sfuEgress.ts
+++ b/app/src/common/sfuEgress.ts
@@ -1,0 +1,210 @@
+export const SFU_EGRESS_SAMPLE_INTERVAL_MS = 5 * 60 * 1000
+
+export type SfuEgressSampleReason =
+  | "interval"
+  | "leave"
+  | "pagehide"
+  | "disconnect"
+
+export interface SfuEgressBytes {
+  audioBytes: number
+  videoBytes: number
+  dataChannelBytes: number
+}
+
+export interface SfuEgressSample extends SfuEgressBytes {
+  totalBytes: number
+  intervalMs: number
+  sampleReason: SfuEgressSampleReason
+}
+
+const EMPTY_BYTES: SfuEgressBytes = {
+  audioBytes: 0,
+  videoBytes: 0,
+  dataChannelBytes: 0,
+}
+
+function nonNegativeInteger(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+    return 0
+  return Math.min(Math.floor(value), Number.MAX_SAFE_INTEGER)
+}
+
+function addBytes(current: number, value: unknown): number {
+  const next = current + nonNegativeInteger(value)
+  return Math.min(next, Number.MAX_SAFE_INTEGER)
+}
+
+function eachStat(
+  report: unknown,
+  callback: (stat: Record<string, unknown>) => void
+) {
+  if (!report || typeof report !== "object") return
+
+  const record = report as Record<string, unknown>
+  if (typeof record.type === "string") {
+    callback(record)
+    return
+  }
+
+  const candidate = report as {
+    forEach?: (callback: (value: unknown) => void) => void
+    values?: () => Iterable<unknown>
+  }
+  if (typeof candidate.forEach === "function") {
+    candidate.forEach((value) => {
+      if (value && typeof value === "object")
+        callback(value as Record<string, unknown>)
+    })
+    return
+  }
+  if (typeof candidate.values === "function") {
+    for (const value of candidate.values()) {
+      if (value && typeof value === "object")
+        callback(value as Record<string, unknown>)
+    }
+    return
+  }
+  if (Symbol.iterator in report) {
+    for (const value of report as Iterable<unknown>) {
+      if (value && typeof value === "object")
+        callback(value as Record<string, unknown>)
+    }
+    return
+  }
+  for (const value of Object.values(report)) {
+    if (value && typeof value === "object")
+      callback(value as Record<string, unknown>)
+  }
+}
+
+/** Aggregate only browser-observed Cloudflare -> browser counters. */
+export function aggregateSfuEgressStats(report: unknown): SfuEgressBytes {
+  const bytes = { ...EMPTY_BYTES }
+  eachStat(report, (stat) => {
+    const type = stat.type
+    const received = stat.bytesReceived
+    if (type === "inbound-rtp") {
+      const kind = stat.kind ?? stat.mediaType
+      if (kind === "audio")
+        bytes.audioBytes = addBytes(bytes.audioBytes, received)
+      else if (kind === "video")
+        bytes.videoBytes = addBytes(bytes.videoBytes, received)
+    } else if (type === "data-channel") {
+      bytes.dataChannelBytes = addBytes(bytes.dataChannelBytes, received)
+    }
+  })
+  return bytes
+}
+
+/** Return a non-negative delta, or null when a counter needs re-baselining. */
+export function sfuEgressDelta(
+  previous: SfuEgressBytes | null,
+  current: SfuEgressBytes
+): SfuEgressBytes | null {
+  if (!previous) return null
+  if (
+    current.audioBytes < previous.audioBytes ||
+    current.videoBytes < previous.videoBytes ||
+    current.dataChannelBytes < previous.dataChannelBytes
+  )
+    return null
+  return {
+    audioBytes: current.audioBytes - previous.audioBytes,
+    videoBytes: current.videoBytes - previous.videoBytes,
+    dataChannelBytes: current.dataChannelBytes - previous.dataChannelBytes,
+  }
+}
+
+function totalBytes(bytes: SfuEgressBytes): number {
+  return Math.min(
+    bytes.audioBytes + bytes.videoBytes + bytes.dataChannelBytes,
+    Number.MAX_SAFE_INTEGER
+  )
+}
+
+type StatsSource = () => PromiseLike<unknown> | unknown
+
+export interface SfuEgressSampler {
+  sample(
+    source: unknown,
+    getStats: StatsSource,
+    reason: SfuEgressSampleReason
+  ): void
+}
+
+/**
+ * Keep WebRTC stats accounting local to one browser session. Sampling is
+ * asynchronous and best-effort; errors are deliberately swallowed so an
+ * analytics problem can never affect Room or media behavior.
+ */
+export function createSfuEgressSampler(
+  emit: (sample: SfuEgressSample, source: unknown) => void,
+  now: () => number = () => Date.now()
+): SfuEgressSampler {
+  let source: unknown = undefined
+  let previous: SfuEgressBytes | null = null
+  let lastObservedAt: number | null = null
+  let pending: Promise<void> | null = null
+
+  const run = (
+    nextSource: unknown,
+    getStats: StatsSource,
+    reason: SfuEgressSampleReason
+  ): Promise<void> => {
+    if (source !== nextSource) {
+      source = nextSource
+      previous = null
+      lastObservedAt = null
+    }
+
+    let report: PromiseLike<unknown> | unknown
+    try {
+      // Call getStats before the caller can close the PeerConnection during a
+      // best-effort leave/pagehide cleanup.
+      report = getStats()
+    } catch {
+      return Promise.resolve()
+    }
+
+    return Promise.resolve(report)
+      .then((value) => {
+        const current = aggregateSfuEgressStats(value)
+        const observedAt = now()
+        const delta = sfuEgressDelta(previous, current)
+        const intervalMs =
+          lastObservedAt === null ? 0 : Math.max(0, observedAt - lastObservedAt)
+        previous = current
+        lastObservedAt = observedAt
+        if (!delta || totalBytes(delta) === 0) return
+        try {
+          emit(
+            {
+              ...delta,
+              totalBytes: totalBytes(delta),
+              intervalMs,
+              sampleReason: reason,
+            },
+            nextSource
+          )
+        } catch {
+          // Analytics must never block the product flow.
+        }
+      })
+      .catch(() => {
+        // getStats() is not uniformly available or reliable across browsers.
+      })
+  }
+
+  return {
+    sample(nextSource, getStats, reason) {
+      const runNext = () => run(nextSource, getStats, reason)
+      const next = pending ? pending.then(runNext, runNext) : runNext()
+      let settled: Promise<void>
+      settled = next.finally(() => {
+        if (pending === settled) pending = null
+      })
+      pending = settled
+    },
+  }
+}

--- a/app/src/common/sfuEgress.ts
+++ b/app/src/common/sfuEgress.ts
@@ -12,6 +12,15 @@ export interface SfuEgressBytes {
   dataChannelBytes: number
 }
 
+export type SfuEgressStatCategory = "audio" | "video" | "dataChannel"
+
+export interface SfuEgressStat {
+  category: SfuEgressStatCategory
+  bytesReceived: number
+}
+
+export type SfuEgressStats = ReadonlyMap<string, SfuEgressStat>
+
 export interface SfuEgressSample extends SfuEgressBytes {
   totalBytes: number
   intervalMs: number
@@ -78,42 +87,57 @@ function eachStat(
   }
 }
 
-/** Aggregate only browser-observed Cloudflare -> browser counters. */
-export function aggregateSfuEgressStats(report: unknown): SfuEgressBytes {
-  const bytes = { ...EMPTY_BYTES }
+/** Collect only browser-observed receive counters, keyed by local stats.id. */
+export function aggregateSfuEgressStats(report: unknown): SfuEgressStats {
+  const stats = new Map<string, SfuEgressStat>()
   eachStat(report, (stat) => {
     const type = stat.type
-    const received = stat.bytesReceived
+    const rawId = stat.id
+    if (
+      (typeof rawId !== "string" && typeof rawId !== "number") ||
+      String(rawId).length === 0
+    )
+      return
+    const id = String(rawId)
+    const received = nonNegativeInteger(stat.bytesReceived)
+    let category: SfuEgressStatCategory | undefined
     if (type === "inbound-rtp") {
       const kind = stat.kind ?? stat.mediaType
-      if (kind === "audio")
-        bytes.audioBytes = addBytes(bytes.audioBytes, received)
-      else if (kind === "video")
-        bytes.videoBytes = addBytes(bytes.videoBytes, received)
-    } else if (type === "data-channel") {
-      bytes.dataChannelBytes = addBytes(bytes.dataChannelBytes, received)
-    }
+      if (kind === "audio") category = "audio"
+      else if (kind === "video") category = "video"
+    } else if (type === "data-channel") category = "dataChannel"
+    if (category) stats.set(id, { category, bytesReceived: received })
   })
-  return bytes
+  return stats
 }
 
-/** Return a non-negative delta, or null when a counter needs re-baselining. */
+/**
+ * Compare only the same WebRTC stats objects. A missing or reset object is
+ * re-baselined by the caller's next current-stats Map and does not affect
+ * deltas from unrelated objects.
+ */
 export function sfuEgressDelta(
-  previous: SfuEgressBytes | null,
-  current: SfuEgressBytes
+  previous: SfuEgressStats | null,
+  current: SfuEgressStats
 ): SfuEgressBytes | null {
   if (!previous) return null
-  if (
-    current.audioBytes < previous.audioBytes ||
-    current.videoBytes < previous.videoBytes ||
-    current.dataChannelBytes < previous.dataChannelBytes
-  )
-    return null
-  return {
-    audioBytes: current.audioBytes - previous.audioBytes,
-    videoBytes: current.videoBytes - previous.videoBytes,
-    dataChannelBytes: current.dataChannelBytes - previous.dataChannelBytes,
+  const bytes = { ...EMPTY_BYTES }
+  for (const [id, currentStat] of current) {
+    const previousStat = previous.get(id)
+    if (
+      !previousStat ||
+      previousStat.category !== currentStat.category ||
+      currentStat.bytesReceived < previousStat.bytesReceived
+    )
+      continue
+    const delta = currentStat.bytesReceived - previousStat.bytesReceived
+    if (currentStat.category === "audio")
+      bytes.audioBytes = addBytes(bytes.audioBytes, delta)
+    else if (currentStat.category === "video")
+      bytes.videoBytes = addBytes(bytes.videoBytes, delta)
+    else bytes.dataChannelBytes = addBytes(bytes.dataChannelBytes, delta)
   }
+  return bytes
 }
 
 function totalBytes(bytes: SfuEgressBytes): number {
@@ -143,7 +167,7 @@ export function createSfuEgressSampler(
   now: () => number = () => Date.now()
 ): SfuEgressSampler {
   let source: unknown = undefined
-  let previous: SfuEgressBytes | null = null
+  let previous: SfuEgressStats | null = null
   let lastObservedAt: number | null = null
   let pending: Promise<void> | null = null
 

--- a/app/src/common/sfuEgress.ts
+++ b/app/src/common/sfuEgress.ts
@@ -112,9 +112,9 @@ export function aggregateSfuEgressStats(report: unknown): SfuEgressStats {
 }
 
 /**
- * Compare only the same WebRTC stats objects. A missing or reset object is
- * re-baselined by the caller's next current-stats Map and does not affect
- * deltas from unrelated objects.
+ * Compare WebRTC stats objects independently. New objects count their
+ * current counter after the first PeerConnection snapshot has established
+ * the initial baseline; reset objects are re-baselined without counting.
  */
 export function sfuEgressDelta(
   previous: SfuEgressStats | null,
@@ -124,8 +124,19 @@ export function sfuEgressDelta(
   const bytes = { ...EMPTY_BYTES }
   for (const [id, currentStat] of current) {
     const previousStat = previous.get(id)
+    if (!previousStat) {
+      if (currentStat.category === "audio")
+        bytes.audioBytes = addBytes(bytes.audioBytes, currentStat.bytesReceived)
+      else if (currentStat.category === "video")
+        bytes.videoBytes = addBytes(bytes.videoBytes, currentStat.bytesReceived)
+      else
+        bytes.dataChannelBytes = addBytes(
+          bytes.dataChannelBytes,
+          currentStat.bytesReceived
+        )
+      continue
+    }
     if (
-      !previousStat ||
       previousStat.category !== currentStat.category ||
       currentStat.bytesReceived < previousStat.bytesReceived
     )

--- a/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
@@ -148,14 +148,48 @@ describe("useSfuChatRoom SFU egress analytics", () => {
       .fn()
       .mockResolvedValueOnce(
         new Map([
-          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 100 }],
+          [
+            "audio",
+            {
+              id: "audio",
+              type: "inbound-rtp",
+              kind: "audio",
+              bytesReceived: 100,
+            },
+          ],
+          [
+            "video",
+            {
+              id: "video",
+              type: "inbound-rtp",
+              kind: "video",
+              bytesReceived: 0,
+            },
+          ],
+          ["dc", { id: "dc", type: "data-channel", bytesReceived: 0 }],
         ])
       )
       .mockResolvedValueOnce(
         new Map([
-          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 180 }],
-          ["video", { type: "inbound-rtp", kind: "video", bytesReceived: 20 }],
-          ["dc", { type: "data-channel", bytesReceived: 5 }],
+          [
+            "audio",
+            {
+              id: "audio",
+              type: "inbound-rtp",
+              kind: "audio",
+              bytesReceived: 180,
+            },
+          ],
+          [
+            "video",
+            {
+              id: "video",
+              type: "inbound-rtp",
+              kind: "video",
+              bytesReceived: 20,
+            },
+          ],
+          ["dc", { id: "dc", type: "data-channel", bytesReceived: 5 }],
         ])
       )
 
@@ -204,17 +238,41 @@ describe("useSfuChatRoom SFU egress analytics", () => {
       .fn()
       .mockResolvedValueOnce(
         new Map([
-          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 40 }],
+          [
+            "audio",
+            {
+              id: "audio",
+              type: "inbound-rtp",
+              kind: "audio",
+              bytesReceived: 40,
+            },
+          ],
         ])
       )
       .mockResolvedValueOnce(
         new Map([
-          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 40 }],
+          [
+            "audio",
+            {
+              id: "audio",
+              type: "inbound-rtp",
+              kind: "audio",
+              bytesReceived: 40,
+            },
+          ],
         ])
       )
       .mockResolvedValueOnce(
         new Map([
-          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 65 }],
+          [
+            "audio",
+            {
+              id: "audio",
+              type: "inbound-rtp",
+              kind: "audio",
+              bytesReceived: 65,
+            },
+          ],
         ])
       )
 

--- a/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
@@ -1,0 +1,251 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@common/utils", async () => {
+  const actual = await vi.importActual<typeof import("@common/utils")>(
+    "@common/utils"
+  )
+  return { ...actual, trackAnalyticsEvent: vi.fn() }
+})
+
+import { trackAnalyticsEvent } from "@common/utils"
+
+import { useSfuChatRoom } from "./useSfuChatRoom"
+
+class FakeTrack {
+  kind: "audio" | "video" = "audio"
+  enabled = true
+  readyState = "live"
+  stop = vi.fn()
+}
+
+class FakeDataChannel {
+  binaryType = ""
+  bufferedAmountLowThreshold = 0
+  bufferedAmount = 0
+  readyState = "open"
+  addEventListener() {}
+  removeEventListener() {}
+  send() {}
+  close() {}
+}
+
+class FakePeerConnection {
+  static instances: FakePeerConnection[] = []
+  connectionState: RTCPeerConnectionState = "new"
+  ontrack: ((event: unknown) => void) | null = null
+  onconnectionstatechange: (() => void) | null = null
+  getStats = vi.fn().mockResolvedValue(new Map())
+  private mids = 0
+  private transceivers: { sender: { track: FakeTrack }; mid: string }[] = []
+
+  constructor() {
+    FakePeerConnection.instances.push(this)
+  }
+
+  addTrack(track: FakeTrack) {
+    const mid = String(this.mids++)
+    this.transceivers.push({ sender: { track }, mid })
+    return { track }
+  }
+  getTransceivers() {
+    return this.transceivers
+  }
+  createOffer() {
+    return Promise.resolve({ type: "offer", sdp: "fake-offer" })
+  }
+  createAnswer() {
+    return Promise.resolve({ type: "answer", sdp: "fake-answer" })
+  }
+  setLocalDescription() {
+    return Promise.resolve()
+  }
+  setRemoteDescription() {
+    return Promise.resolve()
+  }
+  createDataChannel() {
+    return new FakeDataChannel()
+  }
+  removeTrack() {}
+  close() {}
+}
+
+class FakeWebSocket {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+  readyState = 1
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor() {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {}
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response)
+}
+
+describe("useSfuChatRoom SFU egress analytics", () => {
+  beforeEach(() => {
+    FakePeerConnection.instances.length = 0
+    FakeWebSocket.instances.length = 0
+    ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakePeerConnection
+    ;(global as unknown as { MediaStream: unknown }).MediaStream = class {
+      constructor(_tracks: FakeTrack[] = []) {}
+      getAudioTracks() {
+        return []
+      }
+      getTracks() {
+        return []
+      }
+    }
+    ;(global as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getAudioTracks: () => [new FakeTrack()],
+        }),
+      },
+      configurable: true,
+    })
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      return jsonResponse({})
+    }) as unknown as typeof fetch
+    vi.mocked(trackAnalyticsEvent).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("flushes a leave sample without delaying the leave control message", async () => {
+    const stats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Map([
+          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 100 }],
+        ])
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 180 }],
+          ["video", { type: "inbound-rtp", kind: "video", bytesReceived: 20 }],
+          ["dc", { type: "data-channel", bytesReceived: 5 }],
+        ])
+      )
+
+    const { result, unmount } = renderHook(() =>
+      useSfuChatRoom("private-room-id", "Alice", "screenshare")
+    )
+    await waitFor(() => expect(FakePeerConnection.instances).toHaveLength(1))
+    const peerConnection = FakePeerConnection.instances[0]
+    peerConnection.getStats = stats
+
+    act(() => {
+      peerConnection.connectionState = "connected"
+      peerConnection.onconnectionstatechange?.()
+    })
+    await waitFor(() => expect(stats).toHaveBeenCalledTimes(1))
+
+    // The browser-facing leave call is synchronous even though getStats is not.
+    act(() => result.current.leaveRoom())
+    expect(trackAnalyticsEvent).not.toHaveBeenCalled()
+    expect(JSON.parse(FakeWebSocket.instances[0].sent.at(-1) ?? "{}")).toEqual({
+      type: "leave",
+    })
+
+    await waitFor(() =>
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith("SFUEgressSample", {
+        roomHash: expect.not.stringMatching("private-room-id"),
+        roomType: "screenshare",
+        participantBucket: "1",
+        audioBytes: 80,
+        videoBytes: 20,
+        dataChannelBytes: 5,
+        totalBytes: 105,
+        intervalMs: expect.any(Number),
+        sampleReason: "leave",
+      })
+    )
+    const payload = vi.mocked(trackAnalyticsEvent).mock.calls[0]?.[1]
+    expect(JSON.stringify(payload)).not.toContain("private-room-id")
+    expect(JSON.stringify(payload)).not.toContain("participant-1")
+    expect(JSON.stringify(payload)).not.toContain("session-1")
+    unmount()
+  })
+
+  it("flushes pagehide samples and does not emit zero-delta intervals", async () => {
+    const stats = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Map([
+          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 40 }],
+        ])
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 40 }],
+        ])
+      )
+      .mockResolvedValueOnce(
+        new Map([
+          ["audio", { type: "inbound-rtp", kind: "audio", bytesReceived: 65 }],
+        ])
+      )
+
+    const { unmount } = renderHook(() =>
+      useSfuChatRoom("room-id", "Alice", "audio")
+    )
+    await waitFor(() => expect(FakePeerConnection.instances).toHaveLength(1))
+    const peerConnection = FakePeerConnection.instances[0]
+    peerConnection.getStats = stats
+    act(() => {
+      peerConnection.connectionState = "connected"
+      peerConnection.onconnectionstatechange?.()
+    })
+    await waitFor(() => expect(stats).toHaveBeenCalledTimes(1))
+
+    window.dispatchEvent(new Event("pagehide"))
+    await waitFor(() => expect(stats).toHaveBeenCalledTimes(2))
+    expect(trackAnalyticsEvent).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event("pagehide"))
+    await waitFor(() => expect(stats).toHaveBeenCalledTimes(3))
+    await waitFor(() =>
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith(
+        "SFUEgressSample",
+        expect.objectContaining({
+          audioBytes: 25,
+          totalBytes: 25,
+          sampleReason: "pagehide",
+        })
+      )
+    )
+    unmount()
+  })
+})

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -8,7 +8,17 @@ import {
   createRuntimeProviderSecret,
   deriveRuntimeProviderReattachHash,
 } from "@common/runtimeProviderCredential"
+import {
+  createSfuEgressSampler,
+  SFU_EGRESS_SAMPLE_INTERVAL_MS,
+  type SfuEgressSampleReason,
+} from "@common/sfuEgress"
 import { ActionType, Message, UserInfo } from "@common/types"
+import {
+  hashRoom,
+  participantsBucket,
+  trackAnalyticsEvent,
+} from "@common/utils"
 import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
 import type {
@@ -455,6 +465,67 @@ export function useSfuChatRoom(
   const fileSendQueueRef = useRef(Promise.resolve())
   const dataChannelReadyRef = useRef(false)
   const closingRef = useRef(false)
+  const sfuEgressSamplerRef = useRef<ReturnType<
+    typeof createSfuEgressSampler
+  > | null>(null)
+  const sfuEgressTimerRef = useRef<number | null>(null)
+  const sfuEgressContextRef = useRef(
+    new WeakMap<
+      object,
+      {
+        roomHash: string
+        roomType: "audio" | "screenshare"
+        participantBucket: ReturnType<typeof participantsBucket>
+      }
+    >()
+  )
+  const analyticsContextRef = useRef({ roomName, roomType: resolvedRoomType })
+  analyticsContextRef.current = { roomName, roomType: resolvedRoomType }
+  if (!sfuEgressSamplerRef.current) {
+    sfuEgressSamplerRef.current = createSfuEgressSampler((sample, source) => {
+      const sourceContext =
+        typeof source === "object" && source !== null
+          ? sfuEgressContextRef.current.get(source)
+          : undefined
+      const currentContext = analyticsContextRef.current
+      const participantCount =
+        participantMapRef.current.size || (sessionRef.current ? 1 : 0)
+      const context = sourceContext ?? {
+        roomHash: hashRoom(currentContext.roomName),
+        roomType: currentContext.roomType,
+        participantBucket: participantsBucket(participantCount),
+      }
+      trackAnalyticsEvent("SFUEgressSample", {
+        roomHash: context.roomHash,
+        roomType: context.roomType,
+        participantBucket: context.participantBucket,
+        ...sample,
+      })
+    })
+  }
+
+  const sampleSfuEgress = useCallback(
+    (
+      reason: SfuEgressSampleReason,
+      peerConnection: RTCPeerConnection | null = peerConnectionRef.current
+    ) => {
+      if (!peerConnection || typeof peerConnection.getStats !== "function")
+        return
+      const participantCount =
+        participantMapRef.current.size || (sessionRef.current ? 1 : 0)
+      sfuEgressContextRef.current.set(peerConnection, {
+        roomHash: hashRoom(analyticsContextRef.current.roomName),
+        roomType: analyticsContextRef.current.roomType,
+        participantBucket: participantsBucket(participantCount),
+      })
+      sfuEgressSamplerRef.current?.sample(
+        peerConnection,
+        () => peerConnection.getStats(),
+        reason
+      )
+    },
+    []
+  )
 
   const rebuildParticipants = useCallback(() => {
     const state = roomStateRef.current
@@ -1583,15 +1654,17 @@ export function useSfuChatRoom(
       if (pc.connectionState === "connected") {
         mediaReconnectAttemptsRef.current = 0
         setConnectionStatus("connected")
+        sampleSfuEgress("interval", pc)
       } else if (
         pc.connectionState === "failed" ||
         pc.connectionState === "disconnected"
       ) {
+        sampleSfuEgress("disconnect", pc)
         void mediaReconnectRef.current?.()
       }
     }
     return pc
-  }, [rebuildParticipants])
+  }, [rebuildParticipants, sampleSfuEgress])
 
   const connectWebSocket = useCallback(() => {
     const session = sessionRef.current
@@ -1816,7 +1889,11 @@ export function useSfuChatRoom(
           channel.close()
         remoteFileChannelsRef.current.clear()
         remoteFileChannelIdsRef.current.clear()
-        peerConnectionRef.current?.close()
+        const oldPeerConnection = peerConnectionRef.current
+        if (oldPeerConnection) {
+          sampleSfuEgress("disconnect", oldPeerConnection)
+          oldPeerConnection.close()
+        }
         peerConnectionRef.current = null
         dataChannelReadyRef.current = false
         localTrackMidsRef.current.clear()
@@ -1920,6 +1997,7 @@ export function useSfuChatRoom(
       publishTrack,
       rebuildParticipants,
       roomName,
+      sampleSfuEgress,
     ]
   )
 
@@ -1980,6 +2058,15 @@ export function useSfuChatRoom(
     }
     mediaReconnectRef.current = reconnectMedia
     initialConnectRef.current = start
+    sfuEgressTimerRef.current = window.setInterval(() => {
+      const peerConnection = peerConnectionRef.current
+      if (peerConnection?.connectionState === "connected")
+        sampleSfuEgress("interval", peerConnection)
+    }, SFU_EGRESS_SAMPLE_INTERVAL_MS)
+    const handlePageHide = () => {
+      sampleSfuEgress("pagehide", peerConnectionRef.current)
+    }
+    window.addEventListener("pagehide", handlePageHide)
     void start()
 
     const remoteFileChannels = remoteFileChannelsRef.current
@@ -1991,10 +2078,16 @@ export function useSfuChatRoom(
 
     return () => {
       closingRef.current = true
+      sampleSfuEgress("disconnect", peerConnectionRef.current)
       clearAllAgentAudioSubscriptionRetries("unmount")
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
       if (mediaReconnectTimerRef.current)
         clearTimeout(mediaReconnectTimerRef.current)
+      if (sfuEgressTimerRef.current) {
+        clearInterval(sfuEgressTimerRef.current)
+        sfuEgressTimerRef.current = null
+      }
+      window.removeEventListener("pagehide", handlePageHide)
       void closeDataChannels(sessionRef.current)
       websocketRef.current?.close()
       localAudioTrackRef.current?.stop()
@@ -2027,6 +2120,7 @@ export function useSfuChatRoom(
     nickName,
     reconnectMedia,
     roomName,
+    sampleSfuEgress,
     sendSocketMessage,
   ])
 
@@ -2214,8 +2308,9 @@ export function useSfuChatRoom(
   }, [sendSocketMessage])
 
   const leaveRoom = useCallback(() => {
+    sampleSfuEgress("leave", peerConnectionRef.current)
     sendSocketMessage({ type: "leave" })
-  }, [sendSocketMessage])
+  }, [sampleSfuEgress, sendSocketMessage])
 
   const setAgentVoice = useCallback(
     (agentParticipantId: string, enabled: boolean) => {


### PR DESCRIPTION
## Summary

Implements issue #247 by adding a small browser-side observability layer for estimated Cloudflare Realtime SFU egress.

The missing signal was an approximate view of which downstream traffic Free4Chat rooms generate. Cloudflare billing and the Realtime dashboard remain the authoritative source for billed usage; this PR only reports client-observed estimates to the existing analytics bridge so the separate `Free4Chat · Realtime cost` board can analyze audio, video/screen sharing, and DataChannel trends.

## What changed

- Added a pure WebRTC stats aggregator and delta sampler.
- Reads only `inbound-rtp.bytesReceived` for audio/video and `data-channel.bytesReceived` when available.
- Samples on a bounded five-minute interval and performs best-effort flushes on leave, pagehide, and media disconnect.
- Emits the canonical `SFUEgressSample` event only for non-zero deltas, with `intervalMs` and `sampleReason`.
- Re-baselines the local counters on the first observation, counter reset, or PeerConnection replacement.
- Handles standard `RTCStatsReport` collections plus common Map/array/object shapes without affecting media or signaling behavior.

## Privacy and scope

The event uses the existing `hashRoom()` convention and `participantsBucket()`. It contains no raw Room id, participant id/name, SFU session id, track id/name, SSRC, credentials, transcript, message, artifact, filename, IP, cookie, or arbitrary user input. No Runtime telemetry, server-side accounting, billing changes, bitrate changes, or Room semantics are included. Existing analytics boards are untouched.

## Validation

- `yarn test` — 61 test files, 584 tests passed.
- `yarn type-check` — passed.
- Targeted Prettier and ESLint checks — passed.
- `yarn build` — production Next.js build passed. The existing Durable Object export/config warning remains unchanged.

Closes #247
