### PR TITLE
Fix browser media timing and attachment ordering

### DIFF
--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -706,4 +706,97 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     expect(createObjectUrl).toHaveBeenCalledTimes(1)
     unmount()
   })
+
+  it("orders queued files by actual transfer start around an intervening Room text", async () => {
+    const { result, socket, pc, unmount } = await connect()
+    const localChannel = pc.createdChannels.find(
+      (channel) => channel.name === "files-human-local"
+    )!
+    const createObjectUrl = vi.fn((file: File) => `blob:${file.name}`)
+    const revokeObjectUrl = vi.fn()
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectUrl,
+    })
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectUrl,
+    })
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("file-a")
+      .mockReturnValueOnce("file-b")
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    localChannel.bufferedAmount = 256 * 1024 + 1
+    const fileA = {
+      name: "a.txt",
+      type: "text/plain",
+      size: 1,
+      slice: () => ({
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1]).buffer),
+      }),
+    } as unknown as File
+    const fileB = {
+      name: "b.txt",
+      type: "text/plain",
+      size: 1,
+      slice: () => ({
+        arrayBuffer: () => Promise.resolve(new Uint8Array([2]).buffer),
+      }),
+    } as unknown as File
+
+    const firstSend = result.current.sendFileMessage(fileA)
+    await flushAsync()
+    expect(localChannel.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "file-start",
+        id: "file-a",
+        name: "a.txt",
+        mime: "text/plain",
+        size: 1,
+      })
+    )
+
+    const secondSend = result.current.sendFileMessage(fileB)
+    vi.setSystemTime(2000)
+    act(() =>
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "message",
+          message: {
+            id: "text-between",
+            peerId: "human-other",
+            name: "Other",
+            kind: "human",
+            type: "text",
+            text: "between files",
+            createdAt: 2000,
+            sequence: 1,
+          },
+        }),
+      })
+    )
+
+    vi.setSystemTime(3000)
+    localChannel.bufferedAmount = 0
+    await act(async () => {
+      localChannel.emit("bufferedamountlow")
+      await firstSend
+      await secondSend
+    })
+
+    expect(
+      localChannel.send.mock.calls
+        .map(([data]) =>
+          typeof data === "string" && data.includes('"type":"file-start"')
+            ? JSON.parse(data).id
+            : undefined
+        )
+        .filter(Boolean)
+    ).toEqual(["file-a", "file-b"])
+    expect(result.current.messages.map((message) => message.messageId)).toEqual(
+      ["file-a", "text-between", "file-b"]
+    )
+    unmount()
+  })
 })

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -60,7 +60,7 @@ class TestDataChannel {
 
 class TestPeerConnection {
   static instances: TestPeerConnection[] = []
-  connectionState = "new"
+  connectionState = "connected"
   ontrack: ((event: unknown) => void) | null = null
   onconnectionstatechange: (() => void) | null = null
   createdChannels: TestDataChannel[] = []
@@ -395,6 +395,50 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
+  it("waits for a connected PeerConnection before replaying initial remote media", async () => {
+    const { socket, pc, unmount } = await connect()
+    pc.connectionState = "new"
+    const state = roomState([
+      participant(
+        "publisher-a",
+        [{ trackName: "screen-a", kind: "video" }],
+        "session-a",
+        true
+      ),
+    ])
+
+    sendState(socket, state)
+    await flushAsync()
+    expect(trackRequestNumber).toBe(0)
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) => {
+        if (!String(input).endsWith("/api/sfu/datachannels/new")) return false
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          dataChannels?: Array<{ location?: string }>
+        }
+        return body.dataChannels?.[0]?.location === "remote"
+      })
+    ).toHaveLength(0)
+
+    act(() => {
+      pc.connectionState = "connected"
+      pc.onconnectionstatechange?.()
+    })
+    await waitForRemoteTrackRequests(1)
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.filter(([input, init]) => {
+          if (!String(input).endsWith("/api/sfu/datachannels/new")) return false
+          const body = JSON.parse(String(init?.body ?? "{}")) as {
+            dataChannels?: Array<{ location?: string }>
+          }
+          return body.dataChannels?.[0]?.location === "remote"
+        })
+      ).toHaveLength(1)
+    )
+    unmount()
+  })
+
   it("ignores a delayed event from a rotated publisher session", async () => {
     const { result, socket, pc, unmount } = await connect()
     const oldTrack = { trackName: "screen", kind: "video" } as const
@@ -590,6 +634,76 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         )
       ).toHaveLength(4)
     )
+    unmount()
+  })
+
+  it("orders a received file by transfer start before later Room text", async () => {
+    const { result, socket, unmount } = await connect()
+    const state = roomState([participant("publisher-a", [], "session-a", true)])
+    sendState(socket, state)
+    await waitFor(() =>
+      expect(
+        TestPeerConnection.instances[0].createdChannels.filter((channel) =>
+          channel.name.includes("subscriber")
+        )
+      ).toHaveLength(1)
+    )
+    const channel = TestPeerConnection.instances[0].createdChannels.find(
+      (candidate) => candidate.name.includes("subscriber")
+    )!
+    const createObjectUrl = vi.fn(() => "blob:file-1")
+    const revokeObjectUrl = vi.fn()
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectUrl,
+    })
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectUrl,
+    })
+
+    vi.useFakeTimers()
+    vi.setSystemTime(1000)
+    act(() =>
+      channel.emit("message", {
+        data: JSON.stringify({
+          type: "file-start",
+          id: "file-1",
+          name: "first.txt",
+          mime: "text/plain",
+          size: 3,
+        }),
+      })
+    )
+    vi.setSystemTime(2000)
+    act(() =>
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "message",
+          message: {
+            id: "text-1",
+            peerId: "publisher-a",
+            name: "publisher-a",
+            kind: "human",
+            type: "text",
+            text: "later text",
+            createdAt: 2000,
+            sequence: 1,
+          },
+        }),
+      })
+    )
+    act(() => {
+      channel.emit("message", { data: new Uint8Array([1, 2, 3]).buffer })
+      channel.emit("message", {
+        data: JSON.stringify({ type: "file-end", id: "file-1" }),
+      })
+    })
+
+    expect(result.current.messages.map((message) => message.messageId)).toEqual(
+      ["file-1", "text-1"]
+    )
+    expect(createObjectUrl).toHaveBeenCalledTimes(1)
     unmount()
   })
 })

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -29,7 +29,7 @@ class FakeDataChannel {
 
 class FakePeerConnection {
   static instances: FakePeerConnection[] = []
-  connectionState = "new"
+  connectionState = "connected"
   ontrack: ((event: unknown) => void) | null = null
   onconnectionstatechange: (() => void) | null = null
   private mids = 0

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -129,6 +129,7 @@ interface IncomingFileTransfer {
   name: string
   mime: string
   size: number
+  startedAt: number
   received: number
   chunks: ArrayBuffer[]
 }
@@ -1022,7 +1023,10 @@ export function useSfuChatRoom(
     (
       peerId: string,
       name: string,
-      file: Pick<IncomingFileTransfer, "id" | "name" | "mime" | "size">,
+      file: Pick<
+        IncomingFileTransfer,
+        "id" | "name" | "mime" | "size" | "startedAt"
+      >,
       chunks: ArrayBuffer[]
     ) => {
       const blob = new Blob(chunks, { type: file.mime })
@@ -1033,7 +1037,10 @@ export function useSfuChatRoom(
         name,
         type: file.mime.startsWith("image/") ? "image" : "file",
         messageId: file.id,
-        createdAt: Date.now(),
+        // A file's position is the time its transfer started, not the time
+        // the last chunk arrived. Otherwise later text can render above a
+        // file that was sent first when the file transfer is slow.
+        createdAt: file.startedAt,
         fileLink,
         fileName: file.name,
         fileSize: file.size,
@@ -1129,6 +1136,7 @@ export function useSfuChatRoom(
             name: message.name.slice(0, 256),
             mime: message.mime.slice(0, 128),
             size: message.size,
+            startedAt: Date.now(),
             received: 0,
             chunks: [],
           })
@@ -1246,6 +1254,16 @@ export function useSfuChatRoom(
         remoteFileChannelAttemptsRef.current.has(participant.id)
       )
         return
+      // Cloudflare's SFU requires the subscriber PeerConnection to be
+      // connected before session operations are accepted. Room state can
+      // arrive earlier, so leave this attempt unclaimed and let the
+      // connection-state resync below make the first real request.
+      if (pc.connectionState !== "connected") {
+        sfuClientDiagnostic("remote_file_channel_waiting_for_connection", {
+          participant_kind: participant.kind,
+        })
+        return
+      }
       const media = participant.media
       const channelKey = participant.id
       const fileChannelName = `files-${participant.id}`
@@ -1529,6 +1547,17 @@ export function useSfuChatRoom(
         media_present: media ? 1 : 0,
       })
       if (!session || !pc || !media) return
+      // A Room state update often races ICE/DTLS establishment. Do not spend
+      // the one logical subscription attempt while Cloudflare would reject
+      // the PeerConnection for not being connected yet. The connected
+      // handler replays the current participant map independently.
+      if (pc.connectionState !== "connected") {
+        sfuClientDiagnostic("remote_track_waiting_for_connection", {
+          participant_kind: participant.kind,
+          track_kind: diagnosticTrackKind(track.kind),
+        })
+        return
+      }
       const key = `${participant.id}:${media.sessionId}:${track.trackName}`
       const isAgentAudioSubscription =
         participant.kind === "agent" && track.kind === "audio"
@@ -1882,6 +1911,19 @@ export function useSfuChatRoom(
     subscribeTrackRef.current = subscribeTrack
   }, [subscribeTrack])
 
+  const resubscribeRemoteMedia = useCallback(() => {
+    const pc = peerConnectionRef.current
+    const session = sessionRef.current
+    if (!pc || !session || pc.connectionState !== "connected") return
+    for (const participant of participantMapRef.current.values()) {
+      if (participant.id === session.participantId) continue
+      for (const track of participant.media?.tracks ?? [])
+        void subscribeTrack(participant, track)
+      if (participant.media?.fileChannelReady)
+        void subscribeFileChannel(participant)
+    }
+  }, [subscribeFileChannel, subscribeTrack])
+
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
       roomStateRef.current = state
@@ -1981,25 +2023,14 @@ export function useSfuChatRoom(
         )
       )
       rebuildParticipants()
-      const localId = sessionRef.current?.participantId
-      for (const participant of state.participants) {
-        if (participant.id === localId) continue
-        const fullParticipant = participantMapRef.current.get(participant.id)
-        if (!fullParticipant) continue
-        for (const track of participant.media?.tracks ?? []) {
-          void subscribeTrack(fullParticipant, track)
-        }
-        if (fullParticipant.media?.fileChannelReady)
-          void subscribeFileChannel(fullParticipant)
-      }
+      resubscribeRemoteMedia()
     },
     [
       rebuildParticipants,
       resetRemoteParticipant,
       resetRemoteTrackSubscription,
       replaceRoomMessages,
-      subscribeFileChannel,
-      subscribeTrack,
+      resubscribeRemoteMedia,
     ]
   )
 
@@ -2086,6 +2117,10 @@ export function useSfuChatRoom(
         mediaReconnectAttemptsRef.current = 0
         setConnectionStatus("connected")
         sampleSfuEgress("interval", pc)
+        // Room state and ICE/DTLS completion are independent events. Replay
+        // all currently published remote media at this boundary so an early
+        // state notification cannot permanently lose a subscription.
+        resubscribeRemoteMedia()
       } else if (
         pc.connectionState === "failed" ||
         pc.connectionState === "disconnected"
@@ -2100,6 +2135,7 @@ export function useSfuChatRoom(
     clearRemoteTrackBindings,
     rebuildParticipants,
     removeRemoteTrackBinding,
+    resubscribeRemoteMedia,
     sampleSfuEgress,
   ])
 
@@ -2879,14 +2915,18 @@ export function useSfuChatRoom(
 
   const sendFileMessage = useCallback(
     async (file: File) => {
+      // Reserve the timeline position when the user starts sending, rather
+      // than when the final chunk finishes. The send queue may serialize
+      // large files, and completion order is not message order.
+      const id = crypto.randomUUID()
+      const mime = file.type || "application/octet-stream"
+      const createdAt = Date.now()
       const send = async () => {
         if (file.size > MAX_FILE_SIZE)
           throw new Error("File exceeds the 20 MB limit")
         const channel = localFileChannelRef.current
         if (!channel) throw new Error("SFU file data channel is unavailable")
         await waitForDataChannelOpen(channel)
-        const id = crypto.randomUUID()
-        const mime = file.type || "application/octet-stream"
         channel.send(
           JSON.stringify({
             type: "file-start",
@@ -2912,7 +2952,7 @@ export function useSfuChatRoom(
           name: nickName,
           type: mime.startsWith("image/") ? "image" : "file",
           messageId: id,
-          createdAt: Date.now(),
+          createdAt,
           fileLink,
           fileName: file.name,
           fileSize: file.size,

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -2915,18 +2915,20 @@ export function useSfuChatRoom(
 
   const sendFileMessage = useCallback(
     async (file: File) => {
-      // Reserve the timeline position when the user starts sending, rather
-      // than when the final chunk finishes. The send queue may serialize
-      // large files, and completion order is not message order.
+      // Allocate the transfer id before queueing so the queued wire messages
+      // and the eventual local bubble share one stable identity.
       const id = crypto.randomUUID()
       const mime = file.type || "application/octet-stream"
-      const createdAt = Date.now()
       const send = async () => {
         if (file.size > MAX_FILE_SIZE)
           throw new Error("File exceeds the 20 MB limit")
         const channel = localFileChannelRef.current
         if (!channel) throw new Error("SFU file data channel is unavailable")
         await waitForDataChannelOpen(channel)
+        // This is deliberately inside the serialized operation and directly
+        // before file-start. A queued file must not claim a timeline position
+        // before the preceding transfer has actually started.
+        const createdAt = Date.now()
         channel.send(
           JSON.stringify({
             type: "file-start",


### PR DESCRIPTION
## Summary

- wait for a connected subscriber PeerConnection before requesting remote RTP or file-channel subscriptions, then replay the current Room media state at the connected boundary
- keep file-message ordering anchored to transfer start instead of transfer completion, so later text stays below files sent first
- add focused regressions for the connection race and slow file/text interleaving

## Why

Room state and ICE/DTLS completion arrive independently. The browser could issue a valid remote subscription while its PeerConnection was not yet connected; if that request failed, the media or file channel had no guaranteed retry until a later Room update. This made screen-share and file delivery appear asymmetric across devices.

File bubbles were timestamped when the final chunk arrived. A slow attachment could therefore be inserted after text messages that were sent later.

## Validation

- `yarn test --run --reporter=dot` (600 tests)
- `yarn eslint src`
- `yarn type-check`
- `yarn prettier --check ...`
- `yarn build`
- `yarn cf-build`

No Runtime, Durable Object, protocol, analytics schema, or five-minute egress interval changes.
