### PR TITLE
Retry transient remote media subscriptions and preserve file order

### DIFF
--- a/app/src/common/messageReconciliation.ts
+++ b/app/src/common/messageReconciliation.ts
@@ -12,6 +12,45 @@ export function mergeRoomAndEphemeralMessages(
   return [...roomMessages, ...ephemeralMessages]
     .map((message, index) => ({ message, index }))
     .sort((left, right) => {
+      const leftSequence = left.message.sequence
+      const rightSequence = right.message.sequence
+      const leftAfterSequence = left.message.afterSequence
+      const rightAfterSequence = right.message.afterSequence
+      const hasLeftSequence =
+        typeof leftSequence === "number" &&
+        Number.isSafeInteger(leftSequence) &&
+        leftSequence >= 0
+      const hasRightSequence =
+        typeof rightSequence === "number" &&
+        Number.isSafeInteger(rightSequence) &&
+        rightSequence >= 0
+      const hasLeftAnchor =
+        typeof leftAfterSequence === "number" &&
+        Number.isSafeInteger(leftAfterSequence) &&
+        leftAfterSequence >= 0
+      const hasRightAnchor =
+        typeof rightAfterSequence === "number" &&
+        Number.isSafeInteger(rightAfterSequence) &&
+        rightAfterSequence >= 0
+
+      // Room messages occupy their canonical integer sequence. An ephemeral
+      // file anchored after N belongs after all Room messages <= N and before
+      // later Room messages. This is causal ordering, not wall-clock fusion.
+      if (hasLeftSequence && hasRightSequence)
+        return leftSequence - rightSequence || left.index - right.index
+      if (hasLeftSequence && hasRightAnchor)
+        return leftSequence <= rightAfterSequence ? -1 : 1
+      if (hasLeftAnchor && hasRightSequence)
+        return rightSequence <= leftAfterSequence ? 1 : -1
+      if (hasLeftAnchor && hasRightAnchor)
+        return (
+          leftAfterSequence - rightAfterSequence || left.index - right.index
+        )
+
+      // Legacy/old-client ephemeral messages have no causal anchor. Keep
+      // their previous local fallback order, after anchored Room content.
+      if (hasLeftSequence || hasLeftAnchor) return -1
+      if (hasRightSequence || hasRightAnchor) return 1
       const leftCreatedAt = left.message.createdAt ?? 0
       const rightCreatedAt = right.message.createdAt ?? 0
       return leftCreatedAt - rightCreatedAt || left.index - right.index

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -39,6 +39,10 @@ export interface Message {
   messageId?: string
   createdAt?: number
   sequence?: number
+  // Browser-local causal anchor for an ephemeral file message. It means the
+  // sender had observed Room messages through this sequence when the file
+  // transfer started; it is not a Room sequence and is never server-issued.
+  afterSequence?: number
   ephemeral?: boolean
   text?: string
   fileLink?: string

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -549,7 +549,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
-  it("releases a timed-out track admission so a later resync can retry", async () => {
+  it("reconnects after a Human track admission times out before allowing retry", async () => {
     const { socket, pc, unmount } = await connect()
     vi.useFakeTimers()
     const state = roomState([
@@ -561,11 +561,17 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5000)
+      await flushAsync()
     })
-    sendState(socket, state)
+
+    expect(pc.connectionState).toBe("closed")
+    expect(TestPeerConnection.instances).toHaveLength(2)
+    const newPc = TestPeerConnection.instances[1]
+    const newSocket = TestWebSocket.instances[1]
+    sendState(newSocket, state)
     await flushAsync()
     expect(trackRequestNumber).toBe(2)
-    expect(pc.ontrack).not.toBeNull()
+    expect(newPc.ontrack).not.toBeNull()
     unmount()
   })
 
@@ -781,6 +787,79 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
       ["file-1", "text-1"]
     )
     expect(createObjectUrl).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it("keeps a file after its sender anchor when the receiver Room socket is behind", async () => {
+    const { result, socket, unmount } = await connect()
+    const state = roomState([participant("publisher-a", [], "session-a", true)])
+    state.messages = [1, 2, 3].map((sequence) => ({
+      id: `text-${sequence}`,
+      peerId: "publisher-a",
+      name: "publisher-a",
+      kind: "human" as const,
+      type: "text" as const,
+      text: `message ${sequence}`,
+      createdAt: sequence,
+      sequence,
+    }))
+    sendState(socket, state)
+    await waitFor(() =>
+      expect(
+        TestPeerConnection.instances[0].createdChannels.filter((channel) =>
+          channel.name.includes("subscriber")
+        )
+      ).toHaveLength(1)
+    )
+    const channel = TestPeerConnection.instances[0].createdChannels.find(
+      (candidate) => candidate.name.includes("subscriber")
+    )!
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:file-behind"),
+    })
+
+    act(() =>
+      channel.emit("message", {
+        data: JSON.stringify({
+          type: "file-start",
+          id: "file-behind",
+          name: "behind.txt",
+          mime: "text/plain",
+          size: 3,
+          afterSequence: 5,
+        }),
+      })
+    )
+    act(() => {
+      channel.emit("message", { data: new Uint8Array([1, 2, 3]).buffer })
+      channel.emit("message", {
+        data: JSON.stringify({ type: "file-end", id: "file-behind" }),
+      })
+    })
+
+    for (const sequence of [4, 5])
+      act(() =>
+        socket.onmessage?.({
+          data: JSON.stringify({
+            type: "message",
+            message: {
+              id: `text-${sequence}`,
+              peerId: "publisher-a",
+              name: "publisher-a",
+              kind: "human",
+              type: "text",
+              text: `message ${sequence}`,
+              createdAt: sequence,
+              sequence,
+            },
+          }),
+        })
+      )
+
+    expect(result.current.messages.map((message) => message.messageId)).toEqual(
+      ["text-1", "text-2", "text-3", "text-4", "text-5", "file-behind"]
+    )
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -234,6 +234,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
   let sessionNumber: number
   let trackRequestNumber: number
   let remoteChannelNumber: number
+  let transientRemoteTrackResponses: number
 
   beforeEach(() => {
     TestPeerConnection.instances.length = 0
@@ -242,6 +243,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     sessionNumber = 0
     trackRequestNumber = 0
     remoteChannelNumber = 100
+    transientRemoteTrackResponses = 0
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       TestPeerConnection
     ;(global as unknown as { MediaStream: unknown }).MediaStream =
@@ -283,6 +285,12 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         }
         if (body.tracks[0].location !== "remote") return jsonResponse({})
         trackRequestNumber += 1
+        if (transientRemoteTrackResponses > 0) {
+          transientRemoteTrackResponses -= 1
+          return jsonResponse({
+            tracks: [{ errorCode: "empty_track_error" }],
+          })
+        }
         return jsonResponse({
           sessionDescription: { type: "offer", sdp: "remote-offer" },
           tracks: [
@@ -436,6 +444,40 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         })
       ).toHaveLength(1)
     )
+    unmount()
+  })
+
+  it("retries a Human video subscription after a transient track admission failure", async () => {
+    const { result, socket, pc, unmount } = await connect()
+    transientRemoteTrackResponses = 1
+    vi.useFakeTimers()
+    sendState(
+      socket,
+      roomState([
+        participant("publisher-a", [{ trackName: "screen-a", kind: "video" }]),
+      ])
+    )
+    await flushAsync()
+    expect(trackRequestNumber).toBe(1)
+    expect(
+      result.current.participants.find(
+        (entry) => entry.peerId === "publisher-a"
+      )?.screenShareStream
+    ).toBeNull()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+      await flushAsync()
+    })
+    expect(trackRequestNumber).toBe(2)
+
+    const stream = deliverTrack(pc, "remote-mid-2", "video")
+    await flushAsync()
+    expect(
+      result.current.participants.find(
+        (entry) => entry.peerId === "publisher-a"
+      )?.screenShareStream
+    ).toBe(stream)
     unmount()
   })
 
@@ -637,7 +679,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
-  it("orders a received file by transfer start before later Room text", async () => {
+  it("orders a received file by sender transfer start when file-start arrives after Room text", async () => {
     const { result, socket, unmount } = await connect()
     const state = roomState([participant("publisher-a", [], "session-a", true)])
     sendState(socket, state)
@@ -663,18 +705,6 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     })
 
     vi.useFakeTimers()
-    vi.setSystemTime(1000)
-    act(() =>
-      channel.emit("message", {
-        data: JSON.stringify({
-          type: "file-start",
-          id: "file-1",
-          name: "first.txt",
-          mime: "text/plain",
-          size: 3,
-        }),
-      })
-    )
     vi.setSystemTime(2000)
     act(() =>
       socket.onmessage?.({
@@ -690,6 +720,19 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
             createdAt: 2000,
             sequence: 1,
           },
+        }),
+      })
+    )
+    vi.setSystemTime(3000)
+    act(() =>
+      channel.emit("message", {
+        data: JSON.stringify({
+          type: "file-start",
+          id: "file-1",
+          name: "first.txt",
+          mime: "text/plain",
+          size: 3,
+          createdAt: 1000,
         }),
       })
     )
@@ -754,6 +797,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         name: "a.txt",
         mime: "text/plain",
         size: 1,
+        createdAt: 1000,
       })
     )
 

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -60,6 +60,7 @@ class TestDataChannel {
 
 class TestPeerConnection {
   static instances: TestPeerConnection[] = []
+  static remoteDescriptionFailures = 0
   connectionState = "connected"
   ontrack: ((event: unknown) => void) | null = null
   onconnectionstatechange: (() => void) | null = null
@@ -97,6 +98,10 @@ class TestPeerConnection {
   }
 
   setRemoteDescription() {
+    if (TestPeerConnection.remoteDescriptionFailures > 0) {
+      TestPeerConnection.remoteDescriptionFailures -= 1
+      return Promise.reject(new Error("remote description failed"))
+    }
     return Promise.resolve()
   }
 
@@ -239,6 +244,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
   beforeEach(() => {
     TestPeerConnection.instances.length = 0
     TestPeerConnection.channelFactory = null
+    TestPeerConnection.remoteDescriptionFailures = 0
     TestWebSocket.instances.length = 0
     sessionNumber = 0
     trackRequestNumber = 0
@@ -481,6 +487,34 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
+  it("does not retry a Human track after a mid has been admitted", async () => {
+    const { socket, unmount } = await connect()
+    TestPeerConnection.remoteDescriptionFailures = 1
+    sendState(
+      socket,
+      roomState([
+        participant("publisher-a", [{ trackName: "screen-a", kind: "video" }]),
+      ])
+    )
+    await waitForRemoteTrackRequests(1)
+    await flushAsync()
+    vi.useFakeTimers()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000)
+      await flushAsync()
+    })
+    sendState(
+      socket,
+      roomState([
+        participant("publisher-a", [{ trackName: "screen-a", kind: "video" }]),
+      ])
+    )
+    await flushAsync()
+    expect(trackRequestNumber).toBe(1)
+    unmount()
+  })
+
   it("ignores a delayed event from a rotated publisher session", async () => {
     const { result, socket, pc, unmount } = await connect()
     const oldTrack = { trackName: "screen", kind: "video" } as const
@@ -679,7 +713,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
-  it("orders a received file by sender transfer start when file-start arrives after Room text", async () => {
+  it("orders a received file by Room sequence anchor despite sender clock skew", async () => {
     const { result, socket, unmount } = await connect()
     const state = roomState([participant("publisher-a", [], "session-a", true)])
     sendState(socket, state)
@@ -705,7 +739,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     })
 
     vi.useFakeTimers()
-    vi.setSystemTime(2000)
+    vi.setSystemTime(30_000)
     act(() =>
       socket.onmessage?.({
         data: JSON.stringify({
@@ -717,13 +751,13 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
             kind: "human",
             type: "text",
             text: "later text",
-            createdAt: 2000,
+            createdAt: 1,
             sequence: 1,
           },
         }),
       })
     )
-    vi.setSystemTime(3000)
+    vi.setSystemTime(60_000)
     act(() =>
       channel.emit("message", {
         data: JSON.stringify({
@@ -732,7 +766,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
           name: "first.txt",
           mime: "text/plain",
           size: 3,
-          createdAt: 1000,
+          afterSequence: 0,
         }),
       })
     )
@@ -797,7 +831,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         name: "a.txt",
         mime: "text/plain",
         size: 1,
-        createdAt: 1000,
+        afterSequence: 0,
       })
     )
 
@@ -833,11 +867,18 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
       localChannel.send.mock.calls
         .map(([data]) =>
           typeof data === "string" && data.includes('"type":"file-start"')
-            ? JSON.parse(data).id
+            ? JSON.parse(data)
             : undefined
         )
         .filter(Boolean)
-    ).toEqual(["file-a", "file-b"])
+        .map((message) => ({
+          id: message.id,
+          afterSequence: message.afterSequence,
+        }))
+    ).toEqual([
+      { id: "file-a", afterSequence: 0 },
+      { id: "file-b", afterSequence: 1 },
+    ])
     expect(result.current.messages.map((message) => message.messageId)).toEqual(
       ["file-a", "text-between", "file-b"]
     )

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -240,6 +240,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
   let trackRequestNumber: number
   let remoteChannelNumber: number
   let transientRemoteTrackResponses: number
+  let admittedRemoteTrackResponsesWithoutDescription: number
 
   beforeEach(() => {
     TestPeerConnection.instances.length = 0
@@ -250,6 +251,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     trackRequestNumber = 0
     remoteChannelNumber = 100
     transientRemoteTrackResponses = 0
+    admittedRemoteTrackResponsesWithoutDescription = 0
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       TestPeerConnection
     ;(global as unknown as { MediaStream: unknown }).MediaStream =
@@ -295,6 +297,17 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
           transientRemoteTrackResponses -= 1
           return jsonResponse({
             tracks: [{ errorCode: "empty_track_error" }],
+          })
+        }
+        if (admittedRemoteTrackResponsesWithoutDescription > 0) {
+          admittedRemoteTrackResponsesWithoutDescription -= 1
+          return jsonResponse({
+            tracks: [
+              {
+                mid: `remote-mid-${trackRequestNumber}`,
+                trackName: body.tracks[0].trackName,
+              },
+            ],
           })
         }
         return jsonResponse({
@@ -512,6 +525,53 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     )
     await flushAsync()
     expect(trackRequestNumber).toBe(1)
+    unmount()
+  })
+
+  it("reconnects when a Human track is admitted without a session description", async () => {
+    const { result, socket, unmount } = await connect()
+    admittedRemoteTrackResponsesWithoutDescription = 1
+    const state = roomState([
+      participant("publisher-a", [{ trackName: "screen-a", kind: "video" }]),
+    ])
+    sendState(socket, state)
+    await waitForRemoteTrackRequests(1)
+    await waitFor(() => expect(TestPeerConnection.instances).toHaveLength(2))
+
+    expect(trackRequestNumber).toBe(1)
+    const newPc = TestPeerConnection.instances[1]
+    const newSocket = TestWebSocket.instances[1]
+    sendState(newSocket, state)
+    await waitForRemoteTrackRequests(2)
+    expect(trackRequestNumber).toBe(2)
+
+    const requests = fetchMock.mock.calls
+      .filter(([input, init]) => {
+        if (!String(input).endsWith("/api/sfu/tracks")) return false
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          tracks?: Array<{ location?: string }>
+        }
+        return body.tracks?.[0]?.location === "remote"
+      })
+      .map(
+        ([, init]) =>
+          JSON.parse(String(init?.body ?? "{}")) as {
+            sessionId: string
+          }
+      )
+    expect(requests.map((request) => request.sessionId)).toEqual([
+      "subscriber-session-1",
+      "subscriber-session-2",
+    ])
+
+    const stream = deliverTrack(newPc, "remote-mid-2", "video")
+    await waitFor(() =>
+      expect(
+        result.current.participants.find(
+          (entry) => entry.peerId === "publisher-a"
+        )?.screenShareStream
+      ).toBe(stream)
+    )
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -802,20 +802,31 @@ export function useSfuChatRoom(
       }
       binding.timeout = window.setTimeout(() => {
         if (remoteTrackBindingsRef.current.get(binding.mid) !== binding) return
+        const participant = participantMapRef.current.get(binding.participantId)
+        const isCurrentSubscriber =
+          peerConnectionRef.current === binding.peerConnection &&
+          sessionRef.current?.sessionId === binding.subscriberSessionId
         removeRemoteTrackBinding(binding)
         sfuClientDiagnostic("remote_track_wait_timeout", {
-          participant_kind: diagnosticParticipantKind(
-            participantMapRef.current.get(binding.participantId)?.kind
-          ),
+          participant_kind: diagnosticParticipantKind(participant?.kind),
           track_kind: binding.kind,
         })
-        sfuClientDiagnostic("remote_track_retry_allowed", {
-          participant_kind: diagnosticParticipantKind(
-            participantMapRef.current.get(binding.participantId)?.kind
-          ),
-          track_kind: binding.kind,
-          reason: "wait_timeout",
-        })
+        if (
+          participant?.kind === "human" &&
+          isCurrentSubscriber &&
+          !closingRef.current
+        ) {
+          // Cloudflare already admitted this mid. Keep the dedup marker until
+          // the existing media reconnect replaces the PeerConnection/session;
+          // a Room resync on this connection must not create another mid.
+          subscribedTracksRef.current.add(binding.subscriptionKey)
+          readySubscribedTracksRef.current.delete(binding.subscriptionKey)
+          sfuClientDiagnostic("remote_track_reconnect_requested", {
+            track_kind: binding.kind,
+            reason: "wait_timeout",
+          })
+          void mediaReconnectRef.current?.()
+        }
       }, REMOTE_TRACK_READY_TIMEOUT_MS)
       remoteTrackBindingsRef.current.set(input.mid, binding)
       sfuClientDiagnostic("remote_track_mid_registered", {
@@ -1222,14 +1233,14 @@ export function useSfuChatRoom(
             mime: message.mime.slice(0, 128),
             size: message.size,
             // The sender reports the latest Room sequence it had observed at
-            // transfer start. Clamp untrusted/future anchors to the latest
-            // sequence this receiver knows, while preserving an older anchor
-            // so a late file-start frame can still precede later Room text.
+            // transfer start. Preserve it even when this receiver's Room
+            // socket is behind; later Room messages can still arrive and
+            // complete the causal ordering.
             afterSequence:
               typeof message.afterSequence === "number" &&
               Number.isSafeInteger(message.afterSequence) &&
               message.afterSequence >= 0
-                ? Math.min(message.afterSequence, latestObservedRoomSequence())
+                ? message.afterSequence
                 : undefined,
             received: 0,
             chunks: [],
@@ -1262,7 +1273,7 @@ export function useSfuChatRoom(
         void event.data.arrayBuffer().then(consumeChunk)
       }
     },
-    [addReceivedFileMessage, latestObservedRoomSequence]
+    [addReceivedFileMessage]
   )
 
   const establishDataChannelTransport = useCallback(async () => {
@@ -1878,7 +1889,8 @@ export function useSfuChatRoom(
                 subscriberSessionId,
                 subscriberPeerConnection
               )
-            : isTransientRemoteTrackAdmissionError(response) &&
+            : !responseSummary.trackHasMid &&
+              isTransientRemoteTrackAdmissionError(response) &&
               scheduleRemoteTrackSubscriptionRetry(
                 key,
                 participant.id,

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1902,8 +1902,26 @@ export function useSfuChatRoom(
                 subscriberPeerConnection
               )
           if (!scheduled) {
-            subscribedTracksRef.current.delete(key)
-            readySubscribedTracksRef.current.delete(key)
+            if (
+              responseSummary.trackHasMid &&
+              participant.kind === "human" &&
+              !closingRef.current
+            ) {
+              // A MID means Cloudflare admitted the subscription even though
+              // it did not return an SDP offer. Keep this key occupied until
+              // the existing media reconnect replaces the PC/session; a Room
+              // resync must not create another upstream subscription here.
+              subscribedTracksRef.current.add(key)
+              readySubscribedTracksRef.current.delete(key)
+              sfuClientDiagnostic("remote_track_reconnect_requested", {
+                track_kind: track.kind,
+                reason: "mid_admitted_no_description",
+              })
+              void mediaReconnectRef.current?.()
+            } else {
+              subscribedTracksRef.current.delete(key)
+              readySubscribedTracksRef.current.delete(key)
+            }
             if (isAgentAudioSubscription && !hasRemoteTrackError(response))
               voiceDownstreamDiagnostic(
                 "agent_audio_subscription_retry_exhausted",

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -82,6 +82,13 @@ const AGENT_TEXT_EXTENSIONS = new Set([
 const AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS = [100, 300] as const
 const MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS =
   1 + AGENT_AUDIO_SUBSCRIPTION_RETRY_DELAYS_MS.length
+// A newly published Human screen-share track can be visible in Room state
+// before Cloudflare makes it available to tracks/new. Keep the retry bounded
+// and shared by Human audio/video subscriptions so one transient admission
+// response cannot permanently lose a remote screen share.
+const REMOTE_TRACK_SUBSCRIPTION_RETRY_DELAYS_MS = [
+  100, 300, 1000, 3000,
+] as const
 const REMOTE_TRACK_READY_TIMEOUT_MS = 5000
 const REMOTE_FILE_CHANNEL_OPEN_TIMEOUT_MS = 5000
 
@@ -148,6 +155,13 @@ interface SfuApiResponse {
 }
 
 interface AgentAudioSubscriptionRetry {
+  attempt: number
+  timeout: ReturnType<typeof setTimeout>
+  subscriberSessionId: string
+  subscriberPeerConnection: RTCPeerConnection
+}
+
+interface RemoteTrackSubscriptionRetry {
   attempt: number
   timeout: ReturnType<typeof setTimeout>
   subscriberSessionId: string
@@ -452,6 +466,9 @@ export function useSfuChatRoom(
   const agentAudioSubscriptionRetriesRef = useRef(
     new Map<string, AgentAudioSubscriptionRetry>()
   )
+  const remoteTrackSubscriptionRetriesRef = useRef(
+    new Map<string, RemoteTrackSubscriptionRetry>()
+  )
   const subscribeTrackRef = useRef<
     (
       participant: SfuParticipant,
@@ -696,6 +713,39 @@ export function useSfuChatRoom(
     [removeRemoteTrackBinding]
   )
 
+  const clearRemoteTrackSubscriptionRetry = useCallback(
+    (key: string, reason?: string) => {
+      const retry = remoteTrackSubscriptionRetriesRef.current.get(key)
+      if (!retry) return
+      clearTimeout(retry.timeout)
+      remoteTrackSubscriptionRetriesRef.current.delete(key)
+      if (reason)
+        sfuClientDiagnostic("remote_track_retry_cancelled", {
+          attempt: retry.attempt,
+          reason,
+        })
+    },
+    []
+  )
+
+  const clearRemoteTrackSubscriptionRetriesForParticipant = useCallback(
+    (participantId: string, reason: string) => {
+      for (const key of remoteTrackSubscriptionRetriesRef.current.keys()) {
+        if (key.startsWith(`${participantId}:`))
+          clearRemoteTrackSubscriptionRetry(key, reason)
+      }
+    },
+    [clearRemoteTrackSubscriptionRetry]
+  )
+
+  const clearAllRemoteTrackSubscriptionRetries = useCallback(
+    (reason: string) => {
+      for (const key of remoteTrackSubscriptionRetriesRef.current.keys())
+        clearRemoteTrackSubscriptionRetry(key, reason)
+    },
+    [clearRemoteTrackSubscriptionRetry]
+  )
+
   const resetRemoteTrackSubscription = useCallback(
     (
       participantId: string,
@@ -704,6 +754,7 @@ export function useSfuChatRoom(
       kind: "audio" | "video"
     ) => {
       const subscriptionKey = `${participantId}:${publisherSessionId}:${trackName}`
+      clearRemoteTrackSubscriptionRetry(subscriptionKey, "track_reset")
       for (const binding of remoteTrackBindingsRef.current.values()) {
         if (binding.subscriptionKey === subscriptionKey)
           removeRemoteTrackBinding(binding)
@@ -718,7 +769,7 @@ export function useSfuChatRoom(
       stream?.getTracks().forEach((track) => track.stop())
       streams.delete(participantId)
     },
-    [removeRemoteTrackBinding]
+    [clearRemoteTrackSubscriptionRetry, removeRemoteTrackBinding]
   )
 
   const registerRemoteTrackBinding = useCallback(
@@ -1055,6 +1106,10 @@ export function useSfuChatRoom(
         participantId,
         "participant_reset"
       )
+      clearRemoteTrackSubscriptionRetriesForParticipant(
+        participantId,
+        "participant_reset"
+      )
       for (const key of subscribedTracksRef.current) {
         if (key.startsWith(`${participantId}:`))
           subscribedTracksRef.current.delete(key)
@@ -1102,6 +1157,7 @@ export function useSfuChatRoom(
     },
     [
       clearAgentAudioSubscriptionRetriesForParticipant,
+      clearRemoteTrackSubscriptionRetriesForParticipant,
       clearRemoteTrackBindingsForParticipant,
       cleanupRemoteFileChannel,
     ]
@@ -1116,6 +1172,7 @@ export function useSfuChatRoom(
           name?: string
           mime?: string
           size?: number
+          createdAt?: number
         }
         try {
           message = JSON.parse(event.data) as typeof message
@@ -1136,7 +1193,15 @@ export function useSfuChatRoom(
             name: message.name.slice(0, 256),
             mime: message.mime.slice(0, 128),
             size: message.size,
-            startedAt: Date.now(),
+            // The sender reserves this timestamp immediately before the
+            // actual file-start frame. Use it when present so a slower
+            // DataChannel cannot move the file behind later Room text.
+            startedAt:
+              typeof message.createdAt === "number" &&
+              Number.isFinite(message.createdAt) &&
+              message.createdAt >= 0
+                ? message.createdAt
+                : Date.now(),
             received: 0,
             chunks: [],
           })
@@ -1536,6 +1601,75 @@ export function useSfuChatRoom(
     [isCurrentAgentAudioPublication, isCurrentSubscriberSession]
   )
 
+  const scheduleRemoteTrackSubscriptionRetry = useCallback(
+    (
+      key: string,
+      participantId: string,
+      sessionId: string,
+      trackName: string,
+      kind: "audio" | "video",
+      attempt: number,
+      subscriberSessionId: string,
+      subscriberPeerConnection: RTCPeerConnection
+    ) => {
+      const delay = REMOTE_TRACK_SUBSCRIPTION_RETRY_DELAYS_MS[attempt - 2]
+      if (delay === undefined) return false
+      if (remoteTrackSubscriptionRetriesRef.current.has(key)) return true
+      const timeout = setTimeout(() => {
+        const pending = remoteTrackSubscriptionRetriesRef.current.get(key)
+        if (!pending || pending.attempt !== attempt) return
+        remoteTrackSubscriptionRetriesRef.current.delete(key)
+        if (
+          !isCurrentSubscriberSession(
+            pending.subscriberSessionId,
+            pending.subscriberPeerConnection
+          )
+        ) {
+          sfuClientDiagnostic("remote_track_retry_cancelled", {
+            attempt,
+            reason: "stale_subscriber_session",
+          })
+          return
+        }
+        const participant = participantMapRef.current.get(participantId)
+        const track = participant?.media?.tracks.find(
+          (candidate) =>
+            candidate.kind === kind &&
+            candidate.trackName === trackName &&
+            participant.media?.sessionId === sessionId
+        )
+        if (!participant || !track) {
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
+          sfuClientDiagnostic("remote_track_retry_cancelled", {
+            attempt,
+            reason: "publication_missing",
+          })
+          return
+        }
+        // Keep the dedup set occupied until this timer is the sole logical
+        // retry chain. Clearing immediately before the synchronous retry lets
+        // that retry claim it again without a parallel Room-state attempt.
+        subscribedTracksRef.current.delete(key)
+        readySubscribedTracksRef.current.delete(key)
+        void subscribeTrackRef.current(participant, track, attempt)
+      }, delay)
+      remoteTrackSubscriptionRetriesRef.current.set(key, {
+        attempt,
+        timeout,
+        subscriberSessionId,
+        subscriberPeerConnection,
+      })
+      sfuClientDiagnostic("remote_track_retry_scheduled", {
+        attempt,
+        delay_ms: delay,
+        track_kind: kind,
+      })
+      return true
+    },
+    [isCurrentSubscriberSession]
+  )
+
   const subscribeTrack = useCallback(
     async (participant: SfuParticipant, track: SfuTrack, attempt = 1) => {
       const session = sessionRef.current
@@ -1703,19 +1837,28 @@ export function useSfuChatRoom(
         if (cancelStaleAgentAudioSubscription("tracks_new_response")) return
         if (!isCurrentRemoteSubscription()) return
         if (!hasUsableSessionDescription(response)) {
-          const scheduled =
-            isAgentAudioSubscription &&
-            !hasRemoteTrackError(response) &&
-            attempt < MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS &&
-            scheduleAgentAudioSubscriptionRetry(
-              key,
-              participant.id,
-              media.sessionId,
-              track.trackName,
-              attempt + 1,
-              subscriberSessionId,
-              subscriberPeerConnection
-            )
+          const scheduled = isAgentAudioSubscription
+            ? !hasRemoteTrackError(response) &&
+              attempt < MAX_AGENT_AUDIO_SUBSCRIPTION_ATTEMPTS &&
+              scheduleAgentAudioSubscriptionRetry(
+                key,
+                participant.id,
+                media.sessionId,
+                track.trackName,
+                attempt + 1,
+                subscriberSessionId,
+                subscriberPeerConnection
+              )
+            : scheduleRemoteTrackSubscriptionRetry(
+                key,
+                participant.id,
+                media.sessionId,
+                track.trackName,
+                track.kind,
+                attempt + 1,
+                subscriberSessionId,
+                subscriberPeerConnection
+              )
           if (!scheduled) {
             subscribedTracksRef.current.delete(key)
             readySubscribedTracksRef.current.delete(key)
@@ -1743,8 +1886,22 @@ export function useSfuChatRoom(
               typeof candidate.mid === "string" && candidate.mid.length > 0
           )
         if (!responseTrack?.mid) {
-          subscribedTracksRef.current.delete(key)
-          readySubscribedTracksRef.current.delete(key)
+          const scheduled =
+            !isAgentAudioSubscription &&
+            scheduleRemoteTrackSubscriptionRetry(
+              key,
+              participant.id,
+              media.sessionId,
+              track.trackName,
+              track.kind,
+              attempt + 1,
+              subscriberSessionId,
+              subscriberPeerConnection
+            )
+          if (!scheduled) {
+            subscribedTracksRef.current.delete(key)
+            readySubscribedTracksRef.current.delete(key)
+          }
           sfuClientDiagnostic("remote_track_mid_missing", {
             participant_kind: participant.kind,
             track_kind: track.kind,
@@ -1873,8 +2030,21 @@ export function useSfuChatRoom(
         }
       }).catch((error) => {
         if (binding) removeRemoteTrackBinding(binding)
+        const scheduled =
+          participant.kind === "human" &&
+          isCurrentRemoteSubscription() &&
+          scheduleRemoteTrackSubscriptionRetry(
+            key,
+            participant.id,
+            media.sessionId,
+            track.trackName,
+            track.kind,
+            attempt + 1,
+            subscriberSessionId,
+            subscriberPeerConnection
+          )
         if (
-          isCurrentRemoteSubscription() ||
+          (!scheduled && isCurrentRemoteSubscription()) ||
           (isAgentAudioSubscription &&
             isCurrentSubscriberSession(
               subscriberSessionId,
@@ -1883,7 +2053,7 @@ export function useSfuChatRoom(
         ) {
           subscribedTracksRef.current.delete(key)
           readySubscribedTracksRef.current.delete(key)
-        } else {
+        } else if (isAgentAudioSubscription) {
           voiceDownstreamDiagnostic(
             "agent_audio_subscription_retry_cancelled",
             { attempt, reason: "stale_subscriber_session", stage: "failed" }
@@ -1903,6 +2073,7 @@ export function useSfuChatRoom(
       removeRemoteTrackBinding,
       roomName,
       scheduleAgentAudioSubscriptionRetry,
+      scheduleRemoteTrackSubscriptionRetry,
       sendSocketMessage,
     ]
   )
@@ -2035,6 +2206,7 @@ export function useSfuChatRoom(
   )
 
   const createPeerConnection = useCallback(() => {
+    clearAllRemoteTrackSubscriptionRetries("peer_connection_replaced")
     clearRemoteTrackBindings()
     clearAllRemoteFileChannels("peer_connection_replaced")
     const pc = new RTCPeerConnection({
@@ -2132,6 +2304,7 @@ export function useSfuChatRoom(
     return pc
   }, [
     clearAllRemoteFileChannels,
+    clearAllRemoteTrackSubscriptionRetries,
     clearRemoteTrackBindings,
     rebuildParticipants,
     removeRemoteTrackBinding,
@@ -2402,6 +2575,7 @@ export function useSfuChatRoom(
         dataChannelReadyRef.current = false
         localTrackMidsRef.current.clear()
         clearAllAgentAudioSubscriptionRetries("media_reconnect")
+        clearAllRemoteTrackSubscriptionRetries("media_reconnect")
         subscribedTracksRef.current.clear()
         readySubscribedTracksRef.current.clear()
         remoteAudioStreamsRef.current.clear()
@@ -2492,6 +2666,7 @@ export function useSfuChatRoom(
     [
       closeDataChannels,
       clearAllAgentAudioSubscriptionRetries,
+      clearAllRemoteTrackSubscriptionRetries,
       clearAllRemoteFileChannels,
       clearRemoteTrackBindings,
       connectWebSocket,
@@ -2585,6 +2760,7 @@ export function useSfuChatRoom(
       closingRef.current = true
       sampleSfuEgress("disconnect", peerConnectionRef.current)
       clearAllAgentAudioSubscriptionRetries("unmount")
+      clearAllRemoteTrackSubscriptionRetries("unmount")
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
       if (mediaReconnectTimerRef.current)
         clearTimeout(mediaReconnectTimerRef.current)
@@ -2622,6 +2798,7 @@ export function useSfuChatRoom(
   }, [
     closeDataChannels,
     clearAllAgentAudioSubscriptionRetries,
+    clearAllRemoteTrackSubscriptionRetries,
     clearAllRemoteFileChannels,
     connectMediaSession,
     clearRemoteTrackBindings,
@@ -2936,6 +3113,7 @@ export function useSfuChatRoom(
             name: file.name,
             mime,
             size: file.size,
+            createdAt,
           })
         )
         for (let offset = 0; offset < file.size; offset += FILE_CHUNK_SIZE) {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -136,7 +136,7 @@ interface IncomingFileTransfer {
   name: string
   mime: string
   size: number
-  startedAt: number
+  afterSequence?: number
   received: number
   chunks: ArrayBuffer[]
 }
@@ -210,6 +210,25 @@ function hasRemoteTrackError(response: SfuApiResponse): boolean {
         (track) =>
           typeof track.errorCode === "string" && track.errorCode.length > 0
       )
+  )
+}
+
+const TRANSIENT_REMOTE_TRACK_ADMISSION_ERRORS = new Set([
+  "empty_track_error",
+  "not_found_track_error",
+])
+
+function isTransientRemoteTrackAdmissionError(
+  response: SfuApiResponse
+): boolean {
+  const errorCodes = [
+    response.errorCode,
+    ...(response.tracks?.map((track) => track.errorCode) ?? []),
+  ]
+  return errorCodes.some(
+    (code) =>
+      typeof code === "string" &&
+      TRANSIENT_REMOTE_TRACK_ADMISSION_ERRORS.has(code)
   )
 }
 
@@ -1070,13 +1089,25 @@ export function useSfuChatRoom(
     )
   }, [])
 
+  const latestObservedRoomSequence = useCallback(() => {
+    return roomMessagesRef.current.reduce(
+      (latest, message) =>
+        typeof message.sequence === "number" &&
+        Number.isSafeInteger(message.sequence) &&
+        message.sequence >= 0
+          ? Math.max(latest, message.sequence)
+          : latest,
+      0
+    )
+  }, [])
+
   const addReceivedFileMessage = useCallback(
     (
       peerId: string,
       name: string,
       file: Pick<
         IncomingFileTransfer,
-        "id" | "name" | "mime" | "size" | "startedAt"
+        "id" | "name" | "mime" | "size" | "afterSequence"
       >,
       chunks: ArrayBuffer[]
     ) => {
@@ -1088,10 +1119,7 @@ export function useSfuChatRoom(
         name,
         type: file.mime.startsWith("image/") ? "image" : "file",
         messageId: file.id,
-        // A file's position is the time its transfer started, not the time
-        // the last chunk arrived. Otherwise later text can render above a
-        // file that was sent first when the file transfer is slow.
-        createdAt: file.startedAt,
+        afterSequence: file.afterSequence,
         fileLink,
         fileName: file.name,
         fileSize: file.size,
@@ -1172,7 +1200,7 @@ export function useSfuChatRoom(
           name?: string
           mime?: string
           size?: number
-          createdAt?: number
+          afterSequence?: number
         }
         try {
           message = JSON.parse(event.data) as typeof message
@@ -1193,15 +1221,16 @@ export function useSfuChatRoom(
             name: message.name.slice(0, 256),
             mime: message.mime.slice(0, 128),
             size: message.size,
-            // The sender reserves this timestamp immediately before the
-            // actual file-start frame. Use it when present so a slower
-            // DataChannel cannot move the file behind later Room text.
-            startedAt:
-              typeof message.createdAt === "number" &&
-              Number.isFinite(message.createdAt) &&
-              message.createdAt >= 0
-                ? message.createdAt
-                : Date.now(),
+            // The sender reports the latest Room sequence it had observed at
+            // transfer start. Clamp untrusted/future anchors to the latest
+            // sequence this receiver knows, while preserving an older anchor
+            // so a late file-start frame can still precede later Room text.
+            afterSequence:
+              typeof message.afterSequence === "number" &&
+              Number.isSafeInteger(message.afterSequence) &&
+              message.afterSequence >= 0
+                ? Math.min(message.afterSequence, latestObservedRoomSequence())
+                : undefined,
             received: 0,
             chunks: [],
           })
@@ -1233,7 +1262,7 @@ export function useSfuChatRoom(
         void event.data.arrayBuffer().then(consumeChunk)
       }
     },
-    [addReceivedFileMessage]
+    [addReceivedFileMessage, latestObservedRoomSequence]
   )
 
   const establishDataChannelTransport = useCallback(async () => {
@@ -1849,7 +1878,8 @@ export function useSfuChatRoom(
                 subscriberSessionId,
                 subscriberPeerConnection
               )
-            : scheduleRemoteTrackSubscriptionRetry(
+            : isTransientRemoteTrackAdmissionError(response) &&
+              scheduleRemoteTrackSubscriptionRetry(
                 key,
                 participant.id,
                 media.sessionId,
@@ -1886,22 +1916,8 @@ export function useSfuChatRoom(
               typeof candidate.mid === "string" && candidate.mid.length > 0
           )
         if (!responseTrack?.mid) {
-          const scheduled =
-            !isAgentAudioSubscription &&
-            scheduleRemoteTrackSubscriptionRetry(
-              key,
-              participant.id,
-              media.sessionId,
-              track.trackName,
-              track.kind,
-              attempt + 1,
-              subscriberSessionId,
-              subscriberPeerConnection
-            )
-          if (!scheduled) {
-            subscribedTracksRef.current.delete(key)
-            readySubscribedTracksRef.current.delete(key)
-          }
+          subscribedTracksRef.current.delete(key)
+          readySubscribedTracksRef.current.delete(key)
           sfuClientDiagnostic("remote_track_mid_missing", {
             participant_kind: participant.kind,
             track_kind: track.kind,
@@ -2029,36 +2045,34 @@ export function useSfuChatRoom(
           throw error
         }
       }).catch((error) => {
+        const hadAdmittedBinding = binding !== null
         if (binding) removeRemoteTrackBinding(binding)
-        const scheduled =
-          participant.kind === "human" &&
-          isCurrentRemoteSubscription() &&
-          scheduleRemoteTrackSubscriptionRetry(
-            key,
-            participant.id,
-            media.sessionId,
-            track.trackName,
-            track.kind,
-            attempt + 1,
-            subscriberSessionId,
-            subscriberPeerConnection
-          )
-        if (
-          (!scheduled && isCurrentRemoteSubscription()) ||
-          (isAgentAudioSubscription &&
-            isCurrentSubscriberSession(
-              subscriberSessionId,
-              subscriberPeerConnection
-            ))
-        ) {
-          subscribedTracksRef.current.delete(key)
-          readySubscribedTracksRef.current.delete(key)
+        const currentSubscriberSession = isCurrentSubscriberSession(
+          subscriberSessionId,
+          subscriberPeerConnection
+        )
+        if (isCurrentRemoteSubscription() || currentSubscriberSession) {
+          // A Human binding means Cloudflare already admitted this mid. Keep
+          // the dedup marker so a later Room resync cannot create a duplicate
+          // upstream subscription without first replacing the PeerConnection.
+          if (hadAdmittedBinding && !isAgentAudioSubscription) {
+            subscribedTracksRef.current.add(key)
+            readySubscribedTracksRef.current.delete(key)
+          } else {
+            subscribedTracksRef.current.delete(key)
+            readySubscribedTracksRef.current.delete(key)
+          }
         } else if (isAgentAudioSubscription) {
           voiceDownstreamDiagnostic(
             "agent_audio_subscription_retry_cancelled",
             { attempt, reason: "stale_subscriber_session", stage: "failed" }
           )
         }
+        if (hadAdmittedBinding && participant.kind === "human")
+          sfuClientDiagnostic("remote_track_retry_blocked", {
+            track_kind: track.kind,
+            reason: "mid_admitted",
+          })
         console.warn("sfu_remote_subscribe_failed", {
           errorType: error instanceof Error ? error.name : typeof error,
         })
@@ -3102,10 +3116,10 @@ export function useSfuChatRoom(
         const channel = localFileChannelRef.current
         if (!channel) throw new Error("SFU file data channel is unavailable")
         await waitForDataChannelOpen(channel)
-        // This is deliberately inside the serialized operation and directly
-        // before file-start. A queued file must not claim a timeline position
+        // Capture the latest Room sequence observed by this browser directly
+        // before file-start. A queued file must not claim a causal position
         // before the preceding transfer has actually started.
-        const createdAt = Date.now()
+        const afterSequence = latestObservedRoomSequence()
         channel.send(
           JSON.stringify({
             type: "file-start",
@@ -3113,7 +3127,7 @@ export function useSfuChatRoom(
             name: file.name,
             mime,
             size: file.size,
-            createdAt,
+            afterSequence,
           })
         )
         for (let offset = 0; offset < file.size; offset += FILE_CHUNK_SIZE) {
@@ -3132,7 +3146,7 @@ export function useSfuChatRoom(
           name: nickName,
           type: mime.startsWith("image/") ? "image" : "file",
           messageId: id,
-          createdAt,
+          afterSequence,
           fileLink,
           fileName: file.name,
           fileSize: file.size,
@@ -3183,6 +3197,7 @@ export function useSfuChatRoom(
     },
     [
       appendEphemeralMessage,
+      latestObservedRoomSequence,
       nickName,
       roomName,
       waitForDataChannelOpen,


### PR DESCRIPTION
## Why

PR #250 did not fully fix two production races:

- File metadata was timestamped at receiver arrival, so a Room text sent between transfer start and file-start delivery could still sort above the file.
- Cloudflare can return a transient `empty_track_error` or `not_found_track_error` while a newly published Human track is becoming available, and the browser previously dropped that subscription without retrying.

## What changed

- Send a browser-local `afterSequence` anchor in `file-start`, representing the latest Room sequence observed when the transfer actually starts.
- Merge ephemeral files after all Room messages through that anchor and before later Room sequences; preserve the validated sender anchor even when the receiving Room socket is behind. Do not compare sender and server wall clocks.
- Retry Human audio/video only for explicit pre-admission transient errors (`empty_track_error` and `not_found_track_error`) when the response has no usable MID, with bounded, per-track retries.
- Once `tracks/new` returns a usable `mid`, do not automatically call `tracks/new` again after WebRTC negotiation failure; retain the dedup marker until PeerConnection/session replacement.
- If a Human MID-admitted binding waits five seconds without `ontrack`, or returns a MID without a usable SDP, retain the old-session dedup marker and trigger the existing media reconnect. The fresh PeerConnection/session can then resubscribe from canonical Room state.
- Cancel pre-admission retries on publisher, session, and PeerConnection replacement.
- Keep Agent retry behavior and the Room/DO/protocol surface unchanged.

## Verification

- Focused SFU reliability tests: 15 passed
- Full app test suite: 605 passed across 62 test files
- Type-check, ESLint, diff check, and production build passed

Follow-up to #250.