### PR TITLE
Fix multi-track screen-share negotiation recovery and file ordering

### DIFF
--- a/app/src/components/TextChatCard.attachment.test.tsx
+++ b/app/src/components/TextChatCard.attachment.test.tsx
@@ -110,6 +110,25 @@ describe("buildRoomTimeline (#234)", () => {
     expect(timeline[1].message?.text).toBe("local")
   })
 
+  it("keeps a Human file at its causal anchor when the timeline is re-sorted", () => {
+    const file: Message = {
+      ...message(0, "file"),
+      type: "file",
+      messageId: "file-1",
+      sequence: undefined,
+      afterSequence: 2,
+      fileName: "report.pdf",
+    }
+    const timeline = buildRoomTimeline(
+      [message(1, "before"), file, message(3, "after")],
+      []
+    )
+
+    expect(
+      timeline.map((item) => item.message?.text ?? item.message?.fileName)
+    ).toEqual(["before", "file", "after"])
+  })
+
   it("formats bounded sizes for the timeline card", () => {
     expect(formatAttachmentSize(2557)).toBe("2.5 KB")
     expect(formatAttachmentSize(512)).toBe("512 B")

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -263,8 +263,8 @@ function messageRecipientCues(
 // #234: canonical timeline merge — Room messages and standalone
 // Agent-authored attachment metadata interleave by the Room's shared
 // sequence counter (attachments consume message-sequence slots at upload).
-// Ephemeral/local messages carry no sequence and stay in their relative
-// order at the end. Human/unknown attachments are deliberately excluded:
+// Ephemeral/local messages without a sequence or causal anchor stay in their
+// relative order at the end. Human/unknown attachments are deliberately excluded:
 // Human browser files already render through the DataChannel file bubble
 // (their Agent-consumption Room copies must not appear twice).
 interface TimelineItem {
@@ -272,6 +272,28 @@ interface TimelineItem {
   seq: number
   message?: Message
   attachment?: RoomAttachmentProjection
+}
+
+function messageTimelineSequence(message: Message): number {
+  if (
+    typeof message.sequence === "number" &&
+    Number.isSafeInteger(message.sequence) &&
+    message.sequence >= 0
+  )
+    return message.sequence
+
+  // Human browser files are ephemeral and do not consume a Room sequence.
+  // Their sender-side anchor places them immediately after the last Room
+  // message observed when the transfer actually started. Keep the fractional
+  // position local to this UI merge; it is never sent back to the Room.
+  if (
+    typeof message.afterSequence === "number" &&
+    Number.isSafeInteger(message.afterSequence) &&
+    message.afterSequence >= 0
+  )
+    return message.afterSequence + 0.5
+
+  return Number.POSITIVE_INFINITY
 }
 
 export function buildRoomTimeline(
@@ -282,7 +304,7 @@ export function buildRoomTimeline(
   for (const message of messages) {
     items.push({
       type: "message",
-      seq: message.sequence ?? Number.POSITIVE_INFINITY,
+      seq: messageTimelineSequence(message),
       message,
     })
   }

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -360,6 +360,7 @@ type ControlRequest =
       action: "publish"
       participantId: string
       token: string
+      sessionId: string
       track: RoomMediaTrack
     }
   | {
@@ -3481,11 +3482,15 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return this.json({ ok: true, expiresAt: room.expiresAt })
     }
 
-    const participant = this.findParticipant(
-      room,
-      request.participantId,
-      request.token
-    )
+    const participant =
+      request.action === "publish"
+        ? this.findParticipant(
+            room,
+            request.participantId,
+            request.token,
+            request.sessionId
+          )
+        : this.findParticipant(room, request.participantId, request.token)
     if (!participant) return this.json({ error: "unauthorized" }, 401)
 
     if (request.action === "publish") {

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -1027,6 +1027,69 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     unmount()
   })
 
+  it("anchors a human file after the latest Agent attachment sequence", async () => {
+    const { result, socket, pc, unmount } = await connect()
+    const state = roomState([participant("publisher-a", [], "session-a", true)])
+    state.messages = [
+      {
+        id: "text-1",
+        peerId: "publisher-a",
+        name: "publisher-a",
+        kind: "human",
+        type: "text",
+        text: "before attachment",
+        createdAt: 1,
+        sequence: 1,
+      },
+    ]
+    state.attachments = [
+      {
+        id: "agent-attachment-2",
+        senderId: "agent-1",
+        senderName: "Agent",
+        senderKind: "agent",
+        fileName: "artifact.txt",
+        mimeType: "text/plain",
+        size: 1,
+        sequence: 2,
+        createdAt: 2,
+      },
+    ]
+    sendState(socket, state)
+
+    const localChannel = pc.createdChannels.find(
+      (channel) => channel.name === "files-human-local"
+    )!
+    const file = {
+      name: "human.txt",
+      type: "text/plain",
+      size: 1,
+      slice: () => ({
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1]).buffer),
+      }),
+    } as unknown as File
+
+    await act(async () => {
+      await result.current.sendFileMessage(file)
+    })
+
+    const fileStart = localChannel.send.mock.calls
+      .map(([data]) =>
+        typeof data === "string" && data.includes('"type":"file-start"')
+          ? JSON.parse(data)
+          : undefined
+      )
+      .find((message) => message?.id)
+    expect(fileStart).toMatchObject({
+      type: "file-start",
+      afterSequence: 2,
+    })
+    expect(
+      result.current.attachments.map((attachment) => attachment.id)
+    ).toEqual(["agent-attachment-2"])
+    unmount()
+  })
+
   it("orders queued files by actual transfer start around an intervening Room text", async () => {
     const { result, socket, pc, unmount } = await connect()
     const localChannel = pc.createdChannels.find(

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -71,9 +71,9 @@ class TestPeerConnection {
   createdChannels: TestDataChannel[] = []
   private mids = 0
   private readonly transceivers: Array<{
-    sender: { track: TestTrack }
+    sender: { track: TestTrack | null }
     mid: string
-    direction: "sendonly" | "recvonly"
+    direction: "sendonly" | "recvonly" | "sendrecv"
   }> = []
 
   constructor() {
@@ -81,13 +81,23 @@ class TestPeerConnection {
   }
 
   addTrack(track: TestTrack) {
+    const reusable = this.transceivers.find(
+      (transceiver) =>
+        transceiver.direction === "recvonly" &&
+        transceiver.sender.track === null
+    )
+    if (reusable) {
+      reusable.sender.track = track
+      reusable.direction = "sendrecv"
+      return reusable.sender
+    }
     const mid = String(this.mids++)
     this.transceivers.push({ sender: { track }, mid, direction: "sendonly" })
     return { track }
   }
 
   addTransceiver(
-    track: TestTrack,
+    track: TestTrack | null,
     init: { direction?: "sendonly" | "recvonly" } = {}
   ) {
     const transceiver = {
@@ -272,7 +282,9 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     remoteChannelNumber = 100
     transientRemoteTrackResponses = 0
     admittedRemoteTrackResponsesWithoutDescription = 0
-    localTrackResponseWithDescription = false
+    // Human local publication responses must include the answer and assigned
+    // mid that production /api/sfu/tracks now requires before confirmation.
+    localTrackResponseWithDescription = true
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       TestPeerConnection
     ;(global as unknown as { MediaStream: unknown }).MediaStream =
@@ -421,8 +433,10 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
 
   it("uses a fresh sendonly transceiver for a local screen share beside remote video", async () => {
     const { result, pc, unmount } = await connect()
-    const remoteVideoTrack = new TestTrack("video")
-    const remoteTransceiver = pc.addTransceiver(remoteVideoTrack, {
+    // A remote recvonly transceiver has no local sender track. The browser's
+    // addTrack() would reuse this m-line; the production code must allocate a
+    // separate sendonly transceiver for the local screen publication.
+    const remoteTransceiver = pc.addTransceiver(null, {
       direction: "recvonly",
     })
     const screenTrack = new TestTrack("video")

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -19,6 +19,10 @@ class TestMediaStream {
     return this.tracks.filter((track) => track.kind === "audio")
   }
 
+  getVideoTracks() {
+    return this.tracks.filter((track) => track.kind === "video")
+  }
+
   getTracks() {
     return this.tracks
   }
@@ -69,6 +73,7 @@ class TestPeerConnection {
   private readonly transceivers: Array<{
     sender: { track: TestTrack }
     mid: string
+    direction: "sendonly" | "recvonly"
   }> = []
 
   constructor() {
@@ -77,8 +82,21 @@ class TestPeerConnection {
 
   addTrack(track: TestTrack) {
     const mid = String(this.mids++)
-    this.transceivers.push({ sender: { track }, mid })
+    this.transceivers.push({ sender: { track }, mid, direction: "sendonly" })
     return { track }
+  }
+
+  addTransceiver(
+    track: TestTrack,
+    init: { direction?: "sendonly" | "recvonly" } = {}
+  ) {
+    const transceiver = {
+      sender: { track },
+      mid: String(this.mids++),
+      direction: init.direction ?? "sendonly",
+    }
+    this.transceivers.push(transceiver)
+    return transceiver
   }
 
   getTransceivers() {
@@ -241,6 +259,8 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
   let remoteChannelNumber: number
   let transientRemoteTrackResponses: number
   let admittedRemoteTrackResponsesWithoutDescription: number
+  let getDisplayMedia: ReturnType<typeof vi.fn>
+  let localTrackResponseWithDescription: boolean
 
   beforeEach(() => {
     TestPeerConnection.instances.length = 0
@@ -252,6 +272,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     remoteChannelNumber = 100
     transientRemoteTrackResponses = 0
     admittedRemoteTrackResponsesWithoutDescription = 0
+    localTrackResponseWithDescription = false
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       TestPeerConnection
     ;(global as unknown as { MediaStream: unknown }).MediaStream =
@@ -262,6 +283,7 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         getUserMedia: vi.fn().mockResolvedValue({
           getAudioTracks: () => [new TestTrack("audio")],
         }),
+        getDisplayMedia: (getDisplayMedia = vi.fn()),
       },
       configurable: true,
     })
@@ -289,9 +311,20 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
       }
       if (url.endsWith("/api/sfu/tracks")) {
         const body = JSON.parse(String(init?.body ?? "{}")) as {
-          tracks: Array<{ location?: string; trackName: string }>
+          tracks: Array<{ location?: string; trackName: string; mid?: string }>
         }
-        if (body.tracks[0].location !== "remote") return jsonResponse({})
+        if (body.tracks[0].location !== "remote") {
+          if (!localTrackResponseWithDescription) return jsonResponse({})
+          return jsonResponse({
+            sessionDescription: { type: "answer", sdp: "local-answer" },
+            tracks: [
+              {
+                mid: body.tracks[0].mid ?? "local-mid",
+                trackName: body.tracks[0].trackName,
+              },
+            ],
+          })
+        }
         trackRequestNumber += 1
         if (transientRemoteTrackResponses > 0) {
           transientRemoteTrackResponses -= 1
@@ -383,6 +416,63 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
         )?.screenShareStream
       ).toBe(streamB)
     })
+    unmount()
+  })
+
+  it("uses a fresh sendonly transceiver for a local screen share beside remote video", async () => {
+    const { result, pc, unmount } = await connect()
+    const remoteVideoTrack = new TestTrack("video")
+    const remoteTransceiver = pc.addTransceiver(remoteVideoTrack, {
+      direction: "recvonly",
+    })
+    const screenTrack = new TestTrack("video")
+    getDisplayMedia.mockResolvedValue(new TestMediaStream([screenTrack]))
+
+    await act(async () => {
+      await result.current.toggleScreenShare()
+    })
+
+    const localTransceiver = pc
+      .getTransceivers()
+      .find((transceiver) => transceiver.sender.track === screenTrack)
+    expect(localTransceiver).toBeDefined()
+    expect(localTransceiver).not.toBe(remoteTransceiver)
+    expect(localTransceiver?.direction).toBe("sendonly")
+    expect(remoteTransceiver.direction).toBe("recvonly")
+
+    const localTrackRequest = fetchMock.mock.calls
+      .filter(([input, init]) => {
+        if (!String(input).endsWith("/api/sfu/tracks")) return false
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          tracks?: Array<{ location?: string }>
+        }
+        return body.tracks?.[0]?.location === "local"
+      })
+      .at(-1)
+    expect(
+      JSON.parse(String(localTrackRequest?.[1]?.body ?? "{}")).tracks[0].mid
+    ).toBe(localTransceiver?.mid)
+    unmount()
+  })
+
+  it("rebuilds the media session after a local screen-share answer failure", async () => {
+    const { result, pc, unmount } = await connect()
+    localTrackResponseWithDescription = true
+    const screenTrack = new TestTrack("video")
+    getDisplayMedia.mockResolvedValue(new TestMediaStream([screenTrack]))
+    TestPeerConnection.remoteDescriptionFailures = 1
+
+    await act(async () => {
+      await result.current.toggleScreenShare()
+    })
+
+    await waitFor(() => expect(TestPeerConnection.instances).toHaveLength(2))
+    expect(pc.connectionState).toBe("closed")
+    expect(
+      TestPeerConnection.instances[1]
+        .getTransceivers()
+        .some((transceiver) => transceiver.sender.track === screenTrack)
+    ).toBe(true)
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSfuChatRoom } from "./useSfuChatRoom"
+import { buildRoomTimeline } from "../components/TextChatCard"
 import type { SfuRoomState, SfuTrack } from "../sfu/types"
 
 class TestTrack {
@@ -1084,6 +1085,12 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
       type: "file-start",
       afterSequence: 2,
     })
+    expect(
+      buildRoomTimeline(
+        result.current.messages,
+        result.current.attachments
+      ).map((item) => item.message?.messageId ?? item.attachment?.id)
+    ).toEqual(["text-1", "agent-attachment-2", fileStart.id])
     expect(
       result.current.attachments.map((attachment) => attachment.id)
     ).toEqual(["agent-attachment-2"])

--- a/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
@@ -142,6 +142,11 @@ describe("useSfuChatRoom SFU egress analytics", () => {
         })
       if (url.endsWith("/api/sfu/datachannels/new"))
         return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return jsonResponse({
+          sessionDescription: { type: "answer", sdp: "fake-local-answer" },
+          tracks: [{ mid: "0" }],
+        })
       return jsonResponse({})
     }) as unknown as typeof fetch
     vi.mocked(trackAnalyticsEvent).mockClear()

--- a/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.sfuEgress.test.tsx
@@ -48,6 +48,14 @@ class FakePeerConnection {
     this.transceivers.push({ sender: { track }, mid })
     return { track }
   }
+  addTransceiver(
+    track: FakeTrack,
+    _init: { direction?: "sendonly" | "recvonly" } = {}
+  ) {
+    const transceiver = { sender: { track }, mid: String(this.mids++) }
+    this.transceivers.push(transceiver)
+    return transceiver
+  }
   getTransceivers() {
     return this.transceivers
   }

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -44,6 +44,14 @@ class FakePeerConnection {
     this.transceivers.push({ sender: { track }, mid })
     return { track }
   }
+  addTransceiver(
+    track: FakeTrack,
+    _init: { direction?: "sendonly" | "recvonly" } = {}
+  ) {
+    const transceiver = { sender: { track }, mid: String(this.mids++) }
+    this.transceivers.push(transceiver)
+    return transceiver
+  }
   getTransceivers() {
     return this.transceivers
   }

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -83,6 +83,18 @@ function jsonResponse(body: unknown, status = 200) {
   } as Response)
 }
 
+function localTrackResponse(init?: RequestInit) {
+  const body = JSON.parse(String(init?.body ?? "{}")) as {
+    tracks?: Array<{ location?: string; mid?: string; trackName?: string }>
+  }
+  const track = body.tracks?.find((entry) => entry.location === "local")
+  if (!track) return null
+  return jsonResponse({
+    sessionDescription: { type: "answer", sdp: "fake-local-answer" },
+    tracks: [{ mid: track.mid ?? "0", trackName: track.trackName }],
+  })
+}
+
 describe("useSfuChatRoom — Turnstile boundary", () => {
   let fetchMock: ReturnType<typeof vi.fn>
   let getUserMedia: ReturnType<typeof vi.fn>
@@ -126,7 +138,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
       configurable: true,
     })
 
-    fetchMock = vi.fn((input: RequestInfo | URL) => {
+    fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString()
       if (url.endsWith("/api/sfu/session")) {
         return jsonResponse({
@@ -143,7 +155,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
         return jsonResponse({ dataChannels: [{ id: 1 }] })
       }
       if (url.endsWith("/api/sfu/tracks")) {
-        return jsonResponse({})
+        return localTrackResponse(init) ?? jsonResponse({})
       }
       return jsonResponse({})
     })
@@ -303,7 +315,7 @@ describe("useSfuChatRoom Live Transcript RoomState wiring (#177 PR3)", () => {
       },
       configurable: true,
     })
-    global.fetch = vi.fn((input: RequestInfo | URL) => {
+    global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       if (String(input).endsWith("/api/sfu/session"))
         return jsonResponse({
           participantId: "human-a",
@@ -313,6 +325,8 @@ describe("useSfuChatRoom Live Transcript RoomState wiring (#177 PR3)", () => {
         })
       if (String(input).endsWith("/api/sfu/datachannels/new"))
         return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (String(input).endsWith("/api/sfu/tracks"))
+        return localTrackResponse(init) ?? jsonResponse({})
       return jsonResponse({})
     }) as unknown as typeof fetch
   })
@@ -513,7 +527,7 @@ describe("useSfuChatRoom room attachments (#123)", () => {
       configurable: true,
     })
 
-    fetchMock = vi.fn((input: RequestInfo | URL) => {
+    fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString()
       if (url.endsWith("/api/sfu/session")) {
         return jsonResponse({
@@ -530,7 +544,7 @@ describe("useSfuChatRoom room attachments (#123)", () => {
         return jsonResponse({ dataChannels: [{ id: 1 }] })
       }
       if (url.endsWith("/api/sfu/tracks")) {
-        return jsonResponse({})
+        return localTrackResponse(init) ?? jsonResponse({})
       }
       if (url.endsWith("/api/room/attachments")) {
         return jsonResponse({
@@ -663,6 +677,7 @@ describe("useSfuChatRoom room attachments (#123)", () => {
             attempts += 1
             return jsonResponse(response)
           }
+          return localTrackResponse(init)
         }
         return jsonResponse({})
       }
@@ -899,6 +914,7 @@ describe("useSfuChatRoom room attachments (#123)", () => {
           const body = JSON.parse((init?.body as string | undefined) ?? "{}")
           if (body.tracks?.[0]?.location === "remote")
             return pendingRemoteTracks
+          return localTrackResponse(init)
         }
         return jsonResponse({})
       }
@@ -1010,7 +1026,8 @@ describe("useSfuChatRoom room attachments (#123)", () => {
           ) as {
             tracks?: Array<{ location?: string }>
           }
-          if (body.tracks?.[0]?.location !== "remote") return jsonResponse({})
+          if (body.tracks?.[0]?.location !== "remote")
+            return localTrackResponse(init) ?? jsonResponse({})
           trackAttempts += 1
           if (trackAttempts === 1)
             return Promise.reject(new Error("secret-sdp-fetch-failure"))
@@ -1250,7 +1267,8 @@ describe("useSfuChatRoom room attachments (#123)", () => {
             sessionId?: string
             tracks?: Array<{ location?: string }>
           }
-          if (body.tracks?.[0]?.location !== "remote") return jsonResponse({})
+          if (body.tracks?.[0]?.location !== "remote")
+            return localTrackResponse(init) ?? jsonResponse({})
           remoteTrackAttempts += 1
           remoteSubscriberSessionIds.push(body.sessionId ?? "")
           if (remoteTrackAttempts === 1)

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -552,6 +552,7 @@ export function useSfuChatRoom(
   const incomingFilesRef = useRef(new Map<string, IncomingFileTransfer>())
   const objectUrlsRef = useRef(new Set<string>())
   const roomMessagesRef = useRef<Message[]>([])
+  const attachmentsRef = useRef<RoomAttachmentProjection[]>([])
   const ephemeralMessagesRef = useRef<Message[]>([])
   const fileSendQueueRef = useRef(Promise.resolve())
   const dataChannelReadyRef = useRef(false)
@@ -1117,7 +1118,7 @@ export function useSfuChatRoom(
   }, [])
 
   const latestObservedRoomSequence = useCallback(() => {
-    return roomMessagesRef.current.reduce(
+    const latestMessageSequence = roomMessagesRef.current.reduce(
       (latest, message) =>
         typeof message.sequence === "number" &&
         Number.isSafeInteger(message.sequence) &&
@@ -1125,6 +1126,16 @@ export function useSfuChatRoom(
           ? Math.max(latest, message.sequence)
           : latest,
       0
+    )
+
+    return attachmentsRef.current.reduce(
+      (latest, attachment) =>
+        typeof attachment.sequence === "number" &&
+        Number.isSafeInteger(attachment.sequence) &&
+        attachment.sequence >= 0
+          ? Math.max(latest, attachment.sequence)
+          : latest,
+      latestMessageSequence
     )
   }, [])
 
@@ -2172,7 +2183,9 @@ export function useSfuChatRoom(
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
       roomStateRef.current = state
-      setAttachments(state.attachments ?? [])
+      const nextAttachments = state.attachments ?? []
+      attachmentsRef.current = nextAttachments
+      setAttachments(nextAttachments)
       const agentAudioTrackCount = state.participants.reduce(
         (count, participant) =>
           count +
@@ -2543,11 +2556,13 @@ export function useSfuChatRoom(
           roomMessageToMessage(message.message, localParticipantId)
         )
       } else if (message.type === "attachment" && message.attachment) {
-        setAttachments((current) =>
-          current.some((entry) => entry.id === message.attachment!.id)
-            ? current
-            : [...current, message.attachment!]
-        )
+        const attachment = message.attachment
+        const currentAttachments = attachmentsRef.current
+        if (!currentAttachments.some((entry) => entry.id === attachment.id)) {
+          const nextAttachments = [...currentAttachments, attachment]
+          attachmentsRef.current = nextAttachments
+          setAttachments(nextAttachments)
+        }
       } else if (message.type === "expired") {
         setError(
           "This room has closed after being empty for a while. Please open a new room."
@@ -2861,6 +2876,7 @@ export function useSfuChatRoom(
       for (const url of objectUrls) URL.revokeObjectURL(url)
       objectUrls.clear()
       roomMessagesRef.current = []
+      attachmentsRef.current = []
       ephemeralMessagesRef.current = []
       dataChannelReadyRef.current = false
       localTrackMids.clear()

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -203,6 +203,22 @@ function hasUsableSessionDescription(response: SfuApiResponse): boolean {
   )
 }
 
+function addLocalMediaTrack(
+  pc: RTCPeerConnection,
+  track: MediaStreamTrack,
+  stream: MediaStream
+): RTCRtpTransceiver {
+  // A PeerConnection can already contain recvonly video transceivers created
+  // by SFU subscriptions. addTrack() is allowed to reuse one of those
+  // transceivers, which changes its direction and can make Cloudflare's next
+  // answer invalid when a second participant starts sharing. Local
+  // publications always get their own stable sendonly m-line.
+  return pc.addTransceiver(track, {
+    direction: "sendonly",
+    streams: [stream],
+  })
+}
+
 function hasRemoteTrackError(response: SfuApiResponse): boolean {
   return Boolean(
     response.errorCode ||
@@ -2654,10 +2670,10 @@ export function useSfuChatRoom(
       }
 
       const pc = createPeerConnection()
-      pc.addTrack(audioTrack, new MediaStream([audioTrack]))
+      addLocalMediaTrack(pc, audioTrack, new MediaStream([audioTrack]))
       const screenTrack = localScreenTrackRef.current
       if (screenTrack && screenTrack.readyState === "live")
-        pc.addTrack(screenTrack, new MediaStream([screenTrack]))
+        addLocalMediaTrack(pc, screenTrack, new MediaStream([screenTrack]))
       rebuildParticipants()
 
       const body: Record<string, unknown> = {
@@ -2889,7 +2905,7 @@ export function useSfuChatRoom(
       if (!track) return
       localScreenTrackRef.current = track
       localScreenTrackNameRef.current = `screen-${session.participantId}`
-      pc.addTrack(track, display)
+      addLocalMediaTrack(pc, track, display)
       track.onended = () => {
         if (localScreenTrackRef.current === track) {
           void closePublishedTrack(localScreenTrackNameRef.current)
@@ -2908,6 +2924,17 @@ export function useSfuChatRoom(
       rebuildParticipants()
       await publishTrack(track, "video", localScreenTrackNameRef.current)
     } catch (err) {
+      if (localScreenTrackRef.current && !closingRef.current) {
+        sfuClientDiagnostic("local_track_publish_failed", {
+          track_kind: "video",
+          error_type: diagnosticErrorType(err),
+        })
+        // A local tracks/new answer failure can leave this PeerConnection's
+        // SDP state unusable. Rebuild the whole media session so the Room
+        // state is re-advertised from a fresh PeerConnection instead of
+        // asking the poisoned one to negotiate a second video m-line.
+        void mediaReconnectRef.current?.()
+      }
       setError(
         err instanceof Error ? err.message : "Screen sharing was not started"
       )

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1538,9 +1538,23 @@ export function useSfuChatRoom(
             sdp: offer.sdp,
           },
         })
-        if (response.sessionDescription) {
-          await pc.setRemoteDescription(response.sessionDescription)
-        }
+        if (
+          !hasUsableSessionDescription(response) ||
+          !response.sessionDescription
+        )
+          throw new Error("SFU publication answer unavailable")
+        await pc.setRemoteDescription(response.sessionDescription)
+        // Cloudflare admission is not Room publication. Only advertise the
+        // local track after this PeerConnection has accepted the answer; the
+        // Worker re-checks the exact current session before committing it.
+        await apiRequest("publish-confirm", {
+          room: roomName,
+          participantId: session.participantId,
+          token: session.participantToken,
+          sessionId: session.sessionId,
+          trackName,
+          kind,
+        })
         localTrackMidsRef.current.set(trackName, transceiver.mid)
       })
     },

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -265,6 +265,7 @@ describe("Origin policy is route-scoped, not global", () => {
     "agent-room-media",
     "tracks",
     "renegotiate",
+    "publish-confirm",
     "datachannels/establish",
   ]
   const missingOriginRejected = ["session"]
@@ -462,6 +463,23 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
       env
     )
     expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(actions.map((action) => action.action)).toEqual(["authorize"])
+
+    const confirm = await handleSfuRequest(
+      req("publish-confirm", {
+        body: JSON.stringify({
+          room: "room-1",
+          participantId: "human-1",
+          token: "tok-1",
+          sessionId: "sess-1",
+          trackName: "audio-1",
+          kind: "audio",
+        }),
+      }),
+      env
+    )
+    expect(confirm.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(actions).toContainEqual({
       action: "publish",

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -265,10 +265,9 @@ describe("Origin policy is route-scoped, not global", () => {
     "agent-room-media",
     "tracks",
     "renegotiate",
-    "publish-confirm",
     "datachannels/establish",
   ]
-  const missingOriginRejected = ["session"]
+  const missingOriginRejected = ["session", "publish-confirm"]
 
   for (const route of missingOriginAllowed) {
     it(`missing Origin is accepted on ${route} (non-browser Runtime route)`, async () => {
@@ -468,6 +467,7 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
 
     const confirm = await handleSfuRequest(
       req("publish-confirm", {
+        origin: "https://www.free4.chat",
         body: JSON.stringify({
           room: "room-1",
           participantId: "human-1",

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -441,7 +441,13 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
   })
 
   it("Human + local audio track => allowed", async () => {
-    const env = makeEnv({}, doResponderForKind("human"))
+    const actions: Array<Record<string, unknown>> = []
+    const env = makeEnv({}, (body) => {
+      actions.push(body)
+      if (body.action === "authorize")
+        return { status: 200, body: { ok: true, kind: "human" } }
+      return { status: 200, body: { ok: true } }
+    })
     const res = await handleSfuRequest(
       req("tracks", {
         body: JSON.stringify(
@@ -457,6 +463,13 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     )
     expect(res.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(actions).toContainEqual({
+      action: "publish",
+      participantId: "human-1",
+      token: "tok-1",
+      sessionId: "sess-1",
+      track: { trackName: "audio-1", kind: "audio" },
+    })
   })
 
   it("Human + local video track => allowed", async () => {
@@ -476,6 +489,38 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     )
     expect(res.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not advertise a Human local track when Cloudflare omits its answer or mid", async () => {
+    fetchMock = vi.fn(async () =>
+      Response.json({ tracks: [{ errorCode: "publication_failed" }] })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const actions: Array<Record<string, unknown>> = []
+    const env = makeEnv({}, (body) => {
+      actions.push(body)
+      if (body.action === "authorize")
+        return { status: 200, body: { ok: true, kind: "human" } }
+      return { status: 200, body: { ok: true } }
+    })
+
+    const res = await handleSfuRequest(
+      req("tracks", {
+        body: JSON.stringify(
+          humanTracksBody({
+            location: "local",
+            trackName: "video-1",
+            kind: "video",
+            mid: "1",
+          })
+        ),
+      }),
+      env
+    )
+
+    expect(res.status).toBe(502)
+    expect((await json(res)).error).toBe("sfu_publication_unverifiable")
+    expect(actions.map((action) => action.action)).toEqual(["authorize"])
   })
 
   it("Human remote response with an offer does not perform publisher diagnostics", async () => {

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -1,4 +1,4 @@
-import type { SfuSessionResponse, SfuTrack } from "./types"
+import type { SfuSessionResponse } from "./types"
 import { isAllowedOrigin } from "../common/origin"
 import { isRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
 import { compensateUnacceptedAgentMedia } from "../do/mediaEffects"
@@ -50,6 +50,7 @@ const MISSING_ORIGIN_ALLOWED_ROUTES = new Set([
   "agent-track-active",
   "tracks",
   "renegotiate",
+  "publish-confirm",
   // The resident, subscribe-only Meeting Notes Runtime has no browser Origin
   // but must establish its own WebRTC transport before it can pull Human
   // tracks. The route still performs the normal token/session/grant checks.
@@ -671,6 +672,50 @@ export async function handleSfuRequest(
     return json(diagnostic)
   }
 
+  // A successful Cloudflare tracks/new response is only an admission. A
+  // Human publication becomes Room-visible after the browser has applied the
+  // returned answer successfully. This is intentionally a separate request:
+  // initial microphone publication happens before the Room WebSocket is open.
+  if (route === "publish-confirm") {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const body = await readBody(request)
+    if (!body) return badRequest("invalid_json")
+    const room = typeof body.room === "string" ? body.room : ""
+    const participantId =
+      typeof body.participantId === "string" ? body.participantId : ""
+    const token = typeof body.token === "string" ? body.token : ""
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : ""
+    const trackName = typeof body.trackName === "string" ? body.trackName : ""
+    const kind = body.kind === "audio" || body.kind === "video" ? body.kind : ""
+    if (!room || !participantId || !token || !sessionId || !trackName || !kind)
+      return badRequest("missing_publication")
+
+    const authResponse = await authorize(
+      env,
+      room,
+      participantId,
+      token,
+      sessionId
+    )
+    if (!authResponse.ok) return authResponse
+    const { kind: participantKind } = (await authResponse.json()) as {
+      kind?: string
+    }
+    if (participantKind !== "human")
+      return json({ error: "human_publish_only" }, 403)
+
+    const publishResponse = await roomControl(env, room, {
+      action: "publish",
+      participantId,
+      token,
+      sessionId,
+      track: { trackName, kind },
+    })
+    if (!publishResponse.ok) return publishResponse
+    return json({ ok: true })
+  }
+
   if (route === "tracks" || route === "renegotiate") {
     if (request.method !== "POST" && request.method !== "PUT") {
       return json({ error: "method_not_allowed" }, 405)
@@ -840,24 +885,6 @@ export async function handleSfuRequest(
     }
 
     if (route === "tracks" && Array.isArray(body.tracks)) {
-      for (const track of body.tracks as Array<Record<string, unknown>>) {
-        if (track.location !== "local" || typeof track.trackName !== "string")
-          continue
-        // #83: an Agent's publication is booked through the grant-rechecking
-        // "agent-track-published" action below — never this Human track-list
-        // action, which rejects agents outright.
-        if (participantKind === "agent") continue
-        const trackKind: SfuTrack["kind"] =
-          track.kind === "video" ? "video" : "audio"
-        const publishResponse = await roomControl(env, room, {
-          action: "publish",
-          participantId,
-          token,
-          sessionId,
-          track: { trackName: track.trackName, kind: trackKind },
-        })
-        if (!publishResponse.ok) return publishResponse
-      }
       // Record the Cloudflare-assigned mid(s) for the Agent's newly
       // established *remote* (subscribe) tracks, so a future Meeting Notes
       // revocation can actually close them server-side (finding #3) instead

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -284,6 +284,37 @@ function usableSessionDescription(responseBody: string): boolean {
   return typeof description?.sdp === "string" && description.sdp.length > 0
 }
 
+function usableHumanPublication(
+  responseBody: string,
+  expectedTrackCount: number
+): boolean {
+  const response = parsedObject(responseBody)
+  const description =
+    response?.sessionDescription &&
+    typeof response.sessionDescription === "object"
+      ? (response.sessionDescription as Record<string, unknown>)
+      : undefined
+  if (
+    description?.type !== "answer" ||
+    typeof description.sdp !== "string" ||
+    description.sdp.length === 0
+  )
+    return false
+
+  const tracks = Array.isArray(response?.tracks) ? response.tracks : []
+  if (tracks.length < expectedTrackCount) return false
+  return tracks
+    .slice(0, expectedTrackCount)
+    .every(
+      (track) =>
+        track &&
+        typeof track === "object" &&
+        !("errorCode" in track) &&
+        typeof (track as Record<string, unknown>).mid === "string" &&
+        ((track as Record<string, unknown>).mid as string).length > 0
+    )
+}
+
 type PublisherTrackStatus = "active" | "inactive" | "waiting" | "unknown"
 
 function publisherTrackStatus(value: unknown): PublisherTrackStatus {
@@ -766,6 +797,18 @@ export async function handleSfuRequest(
     if (!upstream.ok)
       return new Response(responseBody, { status: upstream.status })
 
+    // A Human local publication is not safe to advertise from a bare 2xx:
+    // Cloudflare must have returned its answer and an assigned mid. Otherwise
+    // the Room can announce a track that this PeerConnection never actually
+    // published, leaving every subscriber to chase a dead publication.
+    if (
+      route === "tracks" &&
+      participantKind === "human" &&
+      localTracks.length > 0 &&
+      !usableHumanPublication(responseBody, localTracks.length)
+    )
+      return json({ error: "sfu_publication_unverifiable" }, 502)
+
     // Production-only diagnostic for the Human remote-subscribe path. A
     // successful tracks/new response should carry an SFU-generated offer;
     // when it does not, inspect the publisher session without changing the
@@ -806,12 +849,14 @@ export async function handleSfuRequest(
         if (participantKind === "agent") continue
         const trackKind: SfuTrack["kind"] =
           track.kind === "video" ? "video" : "audio"
-        await roomControl(env, room, {
+        const publishResponse = await roomControl(env, room, {
           action: "publish",
           participantId,
           token,
+          sessionId,
           track: { trackName: track.trackName, kind: trackKind },
         })
+        if (!publishResponse.ok) return publishResponse
       }
       // Record the Cloudflare-assigned mid(s) for the Agent's newly
       // established *remote* (subscribe) tracks, so a future Meeting Notes

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -50,7 +50,6 @@ const MISSING_ORIGIN_ALLOWED_ROUTES = new Set([
   "agent-track-active",
   "tracks",
   "renegotiate",
-  "publish-confirm",
   // The resident, subscribe-only Meeting Notes Runtime has no browser Origin
   // but must establish its own WebRTC transport before it can pull Human
   // tracks. The route still performs the normal token/session/grant checks.


### PR DESCRIPTION
## Summary

- Allocate every local audio/screen publication on a dedicated `sendonly` transceiver so a new screen share cannot reuse a remote video subscription m-line.
- Rebuild the media session after a local screen-share answer/negotiation failure, preserving the local screen track for fresh-session republish.
- Reject unverifiable Human local publications before broadcasting them into Room state, and bind publish bookkeeping to the current SFU session.
- Keep Human browser files at their `afterSequence` causal position when `TextChatCard` performs its final timeline sort.

## Production diagnosis

The production trace confirmed the deployed PR #251 Worker version and showed the failure after a second video publication: the browser rejected Cloudflare's answer for a video m-section (`mid=5`), followed by stale old-session requests. Refreshing created a clean PeerConnection and restored sharing. The failure pattern is consistent with `addTrack()` reusing a recvonly video transceiver created by remote SFU subscription.

The attachment issue had a separate deterministic UI cause: `useSfuChatRoom` already emitted `afterSequence`, but `TextChatCard` mapped sequence-less files to `Infinity` during its second sort, moving them below later Room messages.

## Verification

- `yarn vitest run ...` (focused: 117 tests passed)
- `yarn test` (62 files, 609 tests passed)
- `yarn type-check`
- `yarn eslint src`
- `yarn cf-build`
