### PR TITLE
docs: align public and developer docs with current Room behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,23 @@ All `/api/sfu/*` requests require an `Origin` of `https://free4.chat` or `https:
 4. The browser publishes microphone and optional screen-share tracks.
 5. `RoomSession` broadcasts metadata; remote track subscriptions are authorized against the room state before being forwarded to Cloudflare.
 
+### Human local media publication invariants
+
+Dynamic Human audio and screen publication must use a dedicated local
+`sendonly` transceiver. Do not simplify this to `pc.addTrack(...)`: WebRTC may
+reuse an eligible remote `recvonly` transceiver and its m-line, which can make
+the next multi-publication SDP answer invalid. Local publication ownership and
+remote subscription ownership must remain separate.
+
+The publication becomes Room-visible only after the browser has accepted the
+SFU answer: create the dedicated transceiver, `createOffer`/
+`setLocalDescription`, call Cloudflare `tracks/new`, apply the returned answer
+with `setRemoteDescription`, then call `/publish-confirm`. That confirmation
+must validate the exact current `sessionId` before committing `trackPublished`
+to Room state. A Cloudflare 2xx, answer, or MID alone is not enough; if answer
+application fails, do not expose a phantom Room track, and recover by
+replacing the media session/PeerConnection when needed.
+
 The SFU App ID is a deployment variable. `SFU_APP_SECRET` and `TURNSTILE_SECRET_KEY` are Worker secrets and must never be committed or sent to the browser.
 
 ## Agent room protocol
@@ -107,6 +124,16 @@ The legacy Meeting Notes grant remains implemented for compatibility but is not 
 - Chunks are 32 KB with buffered-amount backpressure.
 - Browser transfers are reconstructed as `Blob` object URLs and are never written to R2, KV, or DO storage. Bounded Agent-readable image copies and explicit Room attachments are separate Room-state paths described above.
 - Object URLs and channels must be closed and revoked during room cleanup.
+
+### Human browser file timeline
+
+Human browser DataChannel files are ephemeral local timeline items. Their
+causal position is anchored by `afterSequence`, captured at actual transfer
+start from the latest canonical Room sequence observed by the sender; that
+sequence includes both Room messages and Agent Room attachments. The final
+timeline merge must preserve this anchor, including in `TextChatCard`. Never
+sort these items by browser wall-clock timestamps or fix only the send hook
+while reordering them incorrectly during final rendering.
 
 ## Analytics
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,21 @@ The text-only Agent protocol does not require OAuth, an account, or another secr
 
 ## Resident Agent Runtime (Go, canonical)
 
-The MCP endpoint is a stateless Room API. It is not a resident lifecycle owner. For a local Agent that should remain present across many Harness turns, the human-facing path is a copied Invite Agent prompt. The Agent fetches `agent.md`, identifies its own Harness, and bootstraps the self-contained native binary from the official GitHub Releases, then runs:
+The MCP endpoint is a stateless Room API. It is not a resident lifecycle
+owner. There are two first-class entry surfaces into the same Room:
+
+- **Browser-assisted:** a Human opens a Room and uses **Invite Agent**. The
+  copied prompt lets the Agent fetch `agent.md`, identify its Harness, and
+  bootstrap the self-contained native binary from the official GitHub
+  Releases.
+- **Developer-native terminal:** a developer starts the same local Runtime
+  directly with `free4chat-agent room create --agent ...` or
+  `free4chat-agent room join <room-id> --agent ...`. This path is
+  browser-optional and is intended for independently running Agents on
+  separate machines.
+
+For either path, a local Agent that should remain present across many Harness
+turns runs:
 
 ```bash
 free4chat-agent join --room <room-id> --agent <harness> --name <name>

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,10 +42,27 @@ owner. There are two first-class entry surfaces into the same Room:
   browser-optional and is intended for independently running Agents on
   separate machines.
 
-For either path, a local Agent that should remain present across many Harness
-turns runs:
+The browser-assisted Invite Agent flow joins an already existing Room through
+the stable low-level join command:
 
 ```bash
+free4chat-agent join --room <room-id> --agent <harness> --name <name>
+```
+
+The developer-native terminal path starts the same resident Runtime directly;
+it either creates a fresh Room and joins it as the first participant or joins
+an existing Room:
+
+```bash
+free4chat-agent room create --agent <harness> --name <name>
+free4chat-agent room join <room-id> --agent <harness> --name <name>
+```
+
+The stable low-level machine commands remain available for scripts and
+automation:
+
+```bash
+free4chat-agent create --agent <harness> --name <name>
 free4chat-agent join --room <room-id> --agent <harness> --name <name>
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ permissions / private memory / durable state
 - ⏱️ Rooms close automatically once everyone has left
 - 🛡️ Cloudflare Turnstile bot protection
 
-## Developer-native Agent Rooms
+## Agent entry paths
+
+Free4Chat has two first-class entry surfaces into the same temporary Room:
+
+- **Browser-assisted:** open a Room and use **Invite Agent** to give an Agent
+  a room-scoped prompt that bootstraps the local Runtime.
+- **Developer-native terminal:** use `free4chat-agent room create` or
+  `free4chat-agent room join` directly. This path is browser-optional and is
+  useful when Agents already run on independent machines.
+
+### Developer-native Agent Rooms
 
 The browser is optional when developers want to bring independently running
 Agents together for text and artifact collaboration:
@@ -69,7 +79,7 @@ contract.
 - [**Multi-Agent collaboration**](https://www.free4.chat/multi-agent-collaboration) — why independently running Agents may need a temporary shared Room instead of another permanent workspace or central orchestrator.
 - [**Collaboration patterns**](https://www.free4.chat/docs/patterns/collaboration-patterns) — exploratory examples of Rooms connecting participants with different machines, operators, tools, and trust boundaries.
 - [**Bring your own Agent**](https://www.free4.chat/ai-agent-room) — current Human ↔ Agent and Agent ↔ Agent capabilities, the local Go Runtime, and the Harness boundary.
-- [**MCP Room API**](https://www.free4.chat/developers/mcp) — the sixteen-tool developer-facing protocol for room lifecycle, capability discovery, collaboration, and ephemeral artifacts.
+- [**MCP Room API**](https://www.free4.chat/docs/reference/mcp) — the sixteen-tool developer-facing protocol for room lifecycle, capability discovery, collaboration, and ephemeral artifacts.
 - [**Four evolutions of a WebRTC chat room**](https://www.bmpi.dev/dev/free4chat/) — the longer architecture and product story, from Pion and RealtimeKit to Realtime SFU and Human + Agent collaboration.
 
 ## Privacy
@@ -104,11 +114,13 @@ sharing flow through Cloudflare's media plane, while ordinary Human file
 transfer stays in browser-to-browser DataChannels. Text-only Agents can join
 through the stateless [`/mcp`](https://www.free4.chat/mcp) endpoint, observe
 sanitized Room context, receive explicit addressing metadata, and read bounded
-ephemeral artifacts through `read_attachment`. For resident participation, the
-Invite Agent prompt bootstraps the official self-contained native **Go Agent
-Runtime** (`free4chat-agent`, published as versioned binaries plus SHA256SUMS
-on GitHub Releases — no Node, npm, or Go toolchain required), which owns the
-participant lease and wakes one retained ACP session across many Harness turns.
+ephemeral artifacts through `read_attachment`. For browser-assisted resident
+participation, the Invite Agent prompt bootstraps the official self-contained
+native **Go Agent Runtime** (`free4chat-agent`, published as versioned binaries
+plus SHA256SUMS on GitHub Releases — no Node, npm, or Go toolchain required).
+The same Runtime can also be started directly with the terminal `room create`
+and `room join` commands; both paths own the participant lease and use the
+same Room model, waking one retained ACP session across Harness turns.
 The runtime uses the same adapter for Hermes, OpenCode, Codex, Claude, Pi,
 DeepSeek Harness preview, and custom ACP agents; Pion runs in-process, and
 Doubao STT powers Room-wide Live Transcript while TTS powers audible Agent
@@ -133,10 +145,10 @@ protocol.
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Frontend | Next.js 15, Tailwind CSS                                                                                                                       |
 | API      | Next.js API routes deployed as Cloudflare Worker via `@opennextjs/cloudflare`                                                                  |
-| Storage  | Cloudflare KV (room metadata, rate limiting) + per-room Durable Object state                                                                   |
+| Storage  | Per-room `RoomSession` Durable Object state + Cloudflare KV for bounded rate limiting/admission support                                        |
 | Media    | Cloudflare Realtime SFU (WebRTC, audio, data channels, screen sharing)                                                                         |
 | Agents   | Stateless MCP v2 Room API + optional local Go Agent Runtime (self-contained binary, in-process Pion, one ACP v1 adapter and launcher registry) |
-| Security | Cloudflare Turnstile (full-page bot challenge) + origin whitelist + KV rate limiting                                                           |
+| Security | Cloudflare Turnstile (just-in-time, action-scoped Human SFU admission) + origin whitelist + KV rate limiting                                   |
 
 ## Stack History
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -115,16 +115,18 @@ content goes with it.
 
 ## Bringing an Agent in (optional)
 
-Agents join from wherever they already run - a laptop, a Mac mini, a VPS, a
-container - not from the browser. Two paths exist:
+Use **Invite Agent** in the Room. It gives an Agent a copied room-scoped
+prompt that bootstraps the official local Runtime and joins your Room. See
+[Agent Room quick start](agent-room).
 
-- Give an Agent a copied Invite prompt; it bootstraps the official local
-  Runtime itself and joins your Room. See
-  [Agent Room quick start](agent-room).
-- Connect your own already-running local Runtime through the Room's
-  **Live Transcript** control (it offers a setup command when no
-  transcription Runtime is connected). See
-  [Live Transcript](/docs/guides/live-transcript).
+## Using an already-running local Runtime for Room features (optional)
+
+If a Free4Chat Runtime is already running on your computer, use the Room's
+**Live Transcript** control and its **Copy connection command** setup flow.
+This associates the local Runtime Host for Room features such as local
+transcription support. It is not an Agent invitation and does not bring a new
+Agent participant into the Room. See
+[Live Transcript](/docs/guides/live-transcript).
 
 There is no centralized Agent hosting on the Free4Chat side: Agents run on
 your machines with your tools and credentials.
@@ -148,17 +150,19 @@ Source: docs/en/getting-started/agent-room.md
 
 # Agent Room quick start
 
-Developers can bring independently running Agents together in a temporary
-Room without opening the browser. The browser remains the richer Human
-surface for voice, Live Transcript controls, and visual attachments, but it
-is optional for text and artifact collaboration.
+This is the developer-native counterpart to the browser-assisted **Invite
+Agent** flow. Developers can bring independently running Agents together in a
+temporary Room without opening the browser. The browser remains the richer
+Human surface for voice, Live Transcript controls, and visual attachments,
+but it is optional for text and artifact collaboration.
 
 ## Prerequisites
 
 The official, self-contained `free4chat-agent` Runtime binary. See
 [/agent.md](/agent.md) for the canonical bootstrap contract: exact-version
 verification, the checksum-verifying installer, and the join command
-boundaries. The binary needs no Node, npm, Go toolchain, or separately
+boundaries. Current native releases target macOS and Linux; Windows support is
+deferred. The binary needs no Node, npm, Go toolchain, or separately
 provisioned media engine; Pion runs in-process.
 
 ## Create and join

--- a/docs/en/getting-started/agent-room.md
+++ b/docs/en/getting-started/agent-room.md
@@ -1,16 +1,18 @@
 # Agent Room quick start
 
-Developers can bring independently running Agents together in a temporary
-Room without opening the browser. The browser remains the richer Human
-surface for voice, Live Transcript controls, and visual attachments, but it
-is optional for text and artifact collaboration.
+This is the developer-native counterpart to the browser-assisted **Invite
+Agent** flow. Developers can bring independently running Agents together in a
+temporary Room without opening the browser. The browser remains the richer
+Human surface for voice, Live Transcript controls, and visual attachments,
+but it is optional for text and artifact collaboration.
 
 ## Prerequisites
 
 The official, self-contained `free4chat-agent` Runtime binary. See
 [/agent.md](/agent.md) for the canonical bootstrap contract: exact-version
 verification, the checksum-verifying installer, and the join command
-boundaries. The binary needs no Node, npm, Go toolchain, or separately
+boundaries. Current native releases target macOS and Linux; Windows support is
+deferred. The binary needs no Node, npm, Go toolchain, or separately
 provisioned media engine; Pion runs in-process.
 
 ## Create and join

--- a/docs/en/getting-started/browser-room.md
+++ b/docs/en/getting-started/browser-room.md
@@ -22,16 +22,18 @@ content goes with it.
 
 ## Bringing an Agent in (optional)
 
-Agents join from wherever they already run - a laptop, a Mac mini, a VPS, a
-container - not from the browser. Two paths exist:
+Use **Invite Agent** in the Room. It gives an Agent a copied room-scoped
+prompt that bootstraps the official local Runtime and joins your Room. See
+[Agent Room quick start](agent-room).
 
-- Give an Agent a copied Invite prompt; it bootstraps the official local
-  Runtime itself and joins your Room. See
-  [Agent Room quick start](agent-room).
-- Connect your own already-running local Runtime through the Room's
-  **Live Transcript** control (it offers a setup command when no
-  transcription Runtime is connected). See
-  [Live Transcript](/docs/guides/live-transcript).
+## Using an already-running local Runtime for Room features (optional)
+
+If a Free4Chat Runtime is already running on your computer, use the Room's
+**Live Transcript** control and its **Copy connection command** setup flow.
+This associates the local Runtime Host for Room features such as local
+transcription support. It is not an Agent invitation and does not bring a new
+Agent participant into the Room. See
+[Live Transcript](/docs/guides/live-transcript).
 
 There is no centralized Agent hosting on the Free4Chat side: Agents run on
 your machines with your tools and credentials.


### PR DESCRIPTION
## Summary

- Correct README architecture/security wording: `RoomSession` owns canonical Room state, KV is bounded rate-limit/admission support, and Turnstile is just-in-time Human SFU admission.
- Point the README MCP documentation link at the canonical `/docs/reference/mcp` URL.
- Document both browser-assisted Invite Agent and browser-optional terminal Runtime entry paths, while preserving the stable low-level CLI commands.
- Separate Live Transcript Runtime Host connection/setup from inviting an Agent into a Room.
- Add the PR #252 developer invariants for dedicated local `sendonly` media transceivers, post-SDP `publish-confirm`, and causal DataChannel file ordering.
- Refresh `app/public/llms-full.txt` with the canonical docs generator.

## Scope

- No product behavior or protocol changes.
- No issue #223 future Runtime/Harness semantics were documented.
- Generated docs were refreshed by `yarn docs:generate`; no generated file was edited manually.
- RealtimeKit remains historical only.

## Validation

- `cd app && yarn docs:check`
- `cd app && yarn type-check`
- `cd app && yarn lint`
- `cd app && yarn test --run` (62 files, 611 tests passed)
