### PR TITLE
chore(agent): prepare 0.5.19 release

### DIFF
--- a/.agent/skills/free4chat-agent-release/SKILL.md
+++ b/.agent/skills/free4chat-agent-release/SKILL.md
@@ -5,83 +5,89 @@ description: Prepare, publish, activate, and dogfood a Free4Chat Go Agent Runtim
 
 # Free4Chat Agent Runtime release
 
-A release is three deliberate phases, not merely an `agent-v*` tag:
+A Runtime release is not merely an `agent-v*` tag. Its complete source contract
+is:
 
 ```text
-source-version PR → matching GitHub Release → live bootstrap activation PR
+doctor.Version + app/public/agent.md bootstrap pins + generated llms-full.txt
+→ merged cf-sfu commit + matching native GitHub Release + deployed route
 ```
 
-The source and the public bootstrap may intentionally be staged separately.
-Never make a fresh Invite request a version whose Release assets are not yet
-published.
+`app/public/agent.md` is the repository source for `/agent.md`; treat it as
+the versioned source file, not as a separate release phase.
 
-## 1. Prepare the source-version PR
+## Change the complete source set
 
-1. Inspect the current `agent/internal/doctor/doctor.go` version, existing
-   `agent-v*` tags, and GitHub Releases. Choose a new semantic version that
-   does not reuse a tag.
-2. Update `doctor.Version`. Search for version-bearing references with `rg`;
-   update source-level release or installer tests only when their expectations
-   are actually version-specific. Do not mechanically rewrite historical docs.
-3. Read `.github/workflows/agent-release.yml` and `agent/scripts/release.sh`.
-   The pushed tag must exactly equal `doctor.Version`; CI builds four native
-   targets, verifies their reported version, and publishes SHA256SUMS.
-4. Before requesting/performing merge, run from `agent/`:
-
-   ```bash
-   go test ./...
-   go vet ./...
-   go build ./cmd/free4chat-agent
-   bash scripts/test-install-agent.sh
-   bash scripts/test-bootstrap-contract.sh
-   ```
-
-   Also run `git diff --check` and inspect the full PR diff. Keep this PR
-   focused on release preparation; do not push the release tag before merge.
-
-## 2. Publish the matching native release
-
-After the source-version PR is green and merged, fetch `origin/cf-sfu` and
-verify the merged commit still declares the intended `doctor.Version`. Confirm
-both the Git tag and GitHub Release do not already exist, then create an
-annotated `agent-v<doctor.Version>` tag at that exact merged commit and push
-only that tag.
-
-Monitor the Agent Release workflow to completion. Require all four named
-native binaries, `SHA256SUMS`, and the GitHub Release. Verify a current-platform
-release binary reports the tagged version through `doctor --json` before
-activating public bootstrap documentation.
-
-Tags, releases, merges, and deployments are external mutations: obtain or use
-explicit user authorization for each requested step.
-
-## 3. Activate live bootstrap documentation
-
-Only after the matching GitHub Release is available, make a focused activation
-PR that updates both expected-version occurrences in `app/public/agent.md`:
-
-- the human-readable version/tag line;
-- `expected_version` in the installer command.
-
-Run `yarn docs:generate` in `app/`; commit the resulting
-`app/public/llms-full.txt` update, and verify no unrelated generated output
-changed. Then run:
+Before changing a version, find the old literal in tracked source:
 
 ```bash
-cd agent && bash scripts/test-bootstrap-contract.sh
-cd app && yarn docs:check && yarn test && yarn type-check
-cd app && yarn eslint src --no-fix && yarn prettier --check . && yarn cf-build
+rg -n "<old-version>|agent-v<old-version>" . \
+  --glob '!app/node_modules/**' --glob '!app/.next/**' --glob '!app/.open-next/**'
 ```
 
-Merge the activation PR only with the normal `cf-sfu` deployment green. This
-ensures a fresh Invite sees a published installer version, not just source
-code that happens to name a future release.
+Inspect existing `agent-v*` tags and GitHub Releases before choosing a new
+semantic version; never reuse a tag.
 
-## Production dogfood
+## Prepare one complete release PR
 
-Record only safe evidence: merged SHA, deployed bootstrap version, release
-asset/checksum name, and `doctor --json` version. In a fresh disposable Room,
-verify that installer selection, installed binary, and resident daemon all use
-the exact activated version before testing resident participation. Ask the user
-only if a native keychain/keystore approval actually blocks installation; never
-request or print credentials, handles, tokens, audio, or transcript content.
+For a normal Runtime release, update every current version carrier together:
+
+1. `agent/internal/doctor/doctor.go`: `doctor.Version`.
+2. `app/public/agent.md`: both the human-readable release tag/version and the
+   `expected_version` installer pin.
+3. Run `yarn docs:generate` from `app/` and commit the corresponding
+   `app/public/llms-full.txt` update. Inspect generator output; do not include
+   unrelated generated changes.
+4. Search the old literal again. Update source-level release or installer tests
+   only when they contain a genuine version-specific expectation; do not
+   mechanically rewrite historical documentation.
+
+Read `.github/workflows/agent-release.yml` and `agent/scripts/release.sh`.
+The eventual tag must exactly equal `doctor.Version`; CI builds four native
+targets, checks their reported version, emits `SHA256SUMS`, and publishes the
+GitHub Release.
+
+Before merge, run:
+
+```bash
+cd agent
+go test ./...
+go vet ./...
+go build ./cmd/free4chat-agent
+bash scripts/test-install-agent.sh
+bash scripts/test-bootstrap-contract.sh
+
+cd ../app
+yarn docs:check
+yarn test
+yarn type-check
+yarn eslint src --no-fix
+yarn prettier --check .
+yarn cf-build
+```
+
+Also run `git diff --check` and inspect the complete PR diff. Do not push the
+release tag before this PR is green and merged.
+
+## Publish, deploy, then prove it
+
+After merge, fetch `origin/cf-sfu` and verify that exact merged commit declares
+the intended `doctor.Version` and bootstrap pins. Confirm the tag and release
+do not already exist, create an annotated `agent-v<doctor.Version>` tag at that
+commit, and push only that tag.
+
+Wait for the Agent Release workflow: all four native assets and `SHA256SUMS`
+must be attached to the GitHub Release, and a current-platform binary's
+`doctor --json` must report the released version. Also wait for the `cf-sfu`
+deployment generated by the merged PR, then verify the deployed `/agent.md`
+serves the version, tag, and installer pin from the merged source file.
+
+For production dogfood, create a fresh disposable Room and verify installer
+selection, installed binary, and resident daemon all use that exact version
+before testing resident participation. Record only safe evidence: SHAs,
+versions, release asset/checksum names, and status codes. Ask the user only if
+a native keychain/keystore approval actually blocks setup; never request or
+print credentials, handles, tokens, audio, or transcript content.
+
+Tags, releases, merges, deployments, and local installation are external
+mutations. Obtain or use explicit user authorization for each requested step.

--- a/.agent/skills/free4chat-agent-release/SKILL.md
+++ b/.agent/skills/free4chat-agent-release/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: free4chat-agent-release
+description: Prepare, publish, activate, and dogfood a Free4Chat Go Agent Runtime release. Use for a new free4chat-agent version; not for an ordinary Worker-only deployment.
+---
+
+# Free4Chat Agent Runtime release
+
+A release is three deliberate phases, not merely an `agent-v*` tag:
+
+```text
+source-version PR → matching GitHub Release → live bootstrap activation PR
+```
+
+The source and the public bootstrap may intentionally be staged separately.
+Never make a fresh Invite request a version whose Release assets are not yet
+published.
+
+## 1. Prepare the source-version PR
+
+1. Inspect the current `agent/internal/doctor/doctor.go` version, existing
+   `agent-v*` tags, and GitHub Releases. Choose a new semantic version that
+   does not reuse a tag.
+2. Update `doctor.Version`. Search for version-bearing references with `rg`;
+   update source-level release or installer tests only when their expectations
+   are actually version-specific. Do not mechanically rewrite historical docs.
+3. Read `.github/workflows/agent-release.yml` and `agent/scripts/release.sh`.
+   The pushed tag must exactly equal `doctor.Version`; CI builds four native
+   targets, verifies their reported version, and publishes SHA256SUMS.
+4. Before requesting/performing merge, run from `agent/`:
+
+   ```bash
+   go test ./...
+   go vet ./...
+   go build ./cmd/free4chat-agent
+   bash scripts/test-install-agent.sh
+   bash scripts/test-bootstrap-contract.sh
+   ```
+
+   Also run `git diff --check` and inspect the full PR diff. Keep this PR
+   focused on release preparation; do not push the release tag before merge.
+
+## 2. Publish the matching native release
+
+After the source-version PR is green and merged, fetch `origin/cf-sfu` and
+verify the merged commit still declares the intended `doctor.Version`. Confirm
+both the Git tag and GitHub Release do not already exist, then create an
+annotated `agent-v<doctor.Version>` tag at that exact merged commit and push
+only that tag.
+
+Monitor the Agent Release workflow to completion. Require all four named
+native binaries, `SHA256SUMS`, and the GitHub Release. Verify a current-platform
+release binary reports the tagged version through `doctor --json` before
+activating public bootstrap documentation.
+
+Tags, releases, merges, and deployments are external mutations: obtain or use
+explicit user authorization for each requested step.
+
+## 3. Activate live bootstrap documentation
+
+Only after the matching GitHub Release is available, make a focused activation
+PR that updates both expected-version occurrences in `app/public/agent.md`:
+
+- the human-readable version/tag line;
+- `expected_version` in the installer command.
+
+Run `yarn docs:generate` in `app/`; commit the resulting
+`app/public/llms-full.txt` update, and verify no unrelated generated output
+changed. Then run:
+
+```bash
+cd agent && bash scripts/test-bootstrap-contract.sh
+cd app && yarn docs:check && yarn test && yarn type-check
+cd app && yarn eslint src --no-fix && yarn prettier --check . && yarn cf-build
+```
+
+Merge the activation PR only with the normal `cf-sfu` deployment green. This
+ensures a fresh Invite sees a published installer version, not just source
+code that happens to name a future release.
+
+## Production dogfood
+
+Record only safe evidence: merged SHA, deployed bootstrap version, release
+asset/checksum name, and `doctor --json` version. In a fresh disposable Room,
+verify that installer selection, installed binary, and resident daemon all use
+the exact activated version before testing resident participation. Ask the user
+only if a native keychain/keystore approval actually blocks installation; never
+request or print credentials, handles, tokens, audio, or transcript content.

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.18"
+var Version = "0.5.19"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -270,7 +270,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.18` (release tag `agent-v0.5.18`).
+`0.5.19` (release tag `agent-v0.5.19`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -329,7 +329,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.18"
+expected_version="0.5.19"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1640,7 +1640,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.18` (release tag `agent-v0.5.18`).
+`0.5.19` (release tag `agent-v0.5.19`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1699,7 +1699,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.18"
+expected_version="0.5.19"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

- prepares the canonical Go Runtime 0.5.19 after #253
- updates `doctor.Version`, both source pins in `app/public/agent.md`, and regenerated `app/public/llms-full.txt` in one PR
- adds the repository-local release skill, which requires an old-version search, full source contract update, release asset verification, deployed-route verification, and disposable-room dogfood

The old 0.5.18 literal and tag are zero hits in current source.

## Validation

- `cd agent && go test ./... && go vet ./... && go build ./cmd/free4chat-agent && bash scripts/test-install-agent.sh && bash scripts/test-bootstrap-contract.sh`
- `cd app && yarn docs:check && yarn test && yarn type-check && yarn eslint src --no-fix && yarn prettier --check . && yarn cf-build`
- `git diff --check`