### PR TITLE
fix(runtime): ignore replayed Room events after transport receipt

### DIFF
--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -840,9 +840,15 @@ func (r *ResidentRuntime) residentHeartbeatInterval() time.Duration {
 
 func (r *ResidentRuntime) advanceFromWait(result types.WaitResult) {
 	r.mu.Lock()
-	if result.Cursor > r.cursor {
-		r.cursor = result.Cursor
-	}
+	// The Room transport is at-least-once across reconnect, heartbeat, and
+	// catch-up boundaries. Keep its receipt cursor separate from
+	// deliveredThrough, which tracks only successful Harness consumption.
+	//
+	// Capture the boundary before processing this envelope. A server cursor may
+	// advance over self-originated or otherwise filtered events, so it (rather
+	// than the highest event accepted below) remains the receipt boundary for
+	// the next envelope.
+	receivedThrough := r.cursor
 	// #228: a successful long-poll proves the Room connection recovered.
 	// Only a WAIT-origin transient error is cleared — the exact class a
 	// successful wait proves resolved. Harness/turn/send failures recorded
@@ -856,9 +862,31 @@ func (r *ResidentRuntime) advanceFromWait(result types.WaitResult) {
 		r.roster = append([]types.ParticipantRosterEntry(nil), result.Participants...)
 	}
 	r.mu.Unlock()
+
+	// Deduplicate within the envelope as well as against the prior transport
+	// receipt boundary. This map is intentionally envelope-local: the monotonic
+	// Room cursor is the sole in-memory receipt boundary, not a second delivery
+	// ledger.
+	accepted := make(map[int64]struct{}, len(result.Events))
 	for _, event := range result.Events {
+		if event.Sequence <= receivedThrough {
+			continue
+		}
+		if _, duplicate := accepted[event.Sequence]; duplicate {
+			continue
+		}
+		accepted[event.Sequence] = struct{}{}
 		r.acceptEvent(event)
 	}
+
+	// Advance only after this envelope's events have been ingested. A
+	// heartbeat may observe the prior cursor while ingestion is in progress;
+	// that is safe because replayed events are idempotently ignored above.
+	r.mu.Lock()
+	if result.Cursor > r.cursor {
+		r.cursor = result.Cursor
+	}
+	r.mu.Unlock()
 }
 
 func (r *ResidentRuntime) acceptEvent(event types.RoomEvent) {

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -1183,6 +1183,174 @@ func TestRetainedHarnessDeliveryAcknowledgesOnlySuccessfulTurn(t *testing.T) {
 	}
 }
 
+func TestTransportReplayAfterSuccessfulHarnessAckIsIgnored(t *testing.T) {
+	client := &fakeClient{}
+	adapter := &fakeAdapter{name: "pi"}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "inst-replay-ack", RoomID: "room", Name: "Pi",
+		Client: client, Adapter: adapter,
+	})
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+
+	var captured []types.HarnessTurnInput
+	original := adapterRunTurnHook
+	adapterRunTurnHook = func(_ *fakeAdapter, input types.HarnessTurnInput) {
+		captured = append(captured, input)
+	}
+	defer func() { adapterRunTurnHook = original }()
+
+	addressed := roomEvent(7, true)
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{addressed}, Cursor: 7})
+	rt.drainTurns()
+	if got := rt.pendingAddressedSnapshot(); len(got) != 0 || rt.deliveredSeq() != 7 {
+		t.Fatalf("successful turn was not acknowledged: pending=%v delivered=%d", got, rt.deliveredSeq())
+	}
+
+	// A reconnect/catch-up replay of an already accepted transport event must
+	// not become a second Harness trigger after its first turn was acknowledged.
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{addressed}, Cursor: 7})
+	rt.drainTurns()
+
+	if got := rt.pendingAddressedSnapshot(); len(got) != 0 {
+		t.Fatalf("transport replay created a pending trigger: %v", got)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("transport replay reached the Harness: %#v", captured)
+	}
+	client.mu.Lock()
+	contextCalls := client.contextCalls
+	client.mu.Unlock()
+	if contextCalls != 0 {
+		t.Fatalf("transport replay attempted Room-context recovery: %d", contextCalls)
+	}
+	if status := rt.Status(); status.LastError != "" || status.State == StateReconnecting {
+		t.Fatalf("transport replay entered an error state: %+v", status)
+	}
+	if events := rt.bufferSince(0, 7); len(events) != 1 || events[0].Sequence != 7 {
+		t.Fatalf("transport replay duplicated EventBuffer state: %#v", events)
+	}
+}
+
+func TestTransportReplayPreservesUnacknowledgedHarnessTurn(t *testing.T) {
+	client := &fakeClient{}
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("ambiguous ACP failure")}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "inst-replay-pending", RoomID: "room", Name: "Pi",
+		Client: client, Adapter: adapter,
+	})
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+
+	var captured []types.HarnessTurnInput
+	original := adapterRunTurnHook
+	adapterRunTurnHook = func(_ *fakeAdapter, input types.HarnessTurnInput) {
+		captured = append(captured, input)
+	}
+	defer func() { adapterRunTurnHook = original }()
+
+	addressed := roomEvent(8, true)
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{addressed}, Cursor: 8})
+	rt.drainTurns()
+	if got := rt.pendingAddressedSnapshot(); len(got) != 1 || got[0] != 8 || rt.deliveredSeq() != 0 {
+		t.Fatalf("ambiguous turn state mismatch: pending=%v delivered=%d", got, rt.deliveredSeq())
+	}
+
+	// The retry remains the original pinned turn; a duplicate transport receipt
+	// cannot replace its snapshot or acknowledge it.
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{addressed}, Cursor: 8})
+	if got := rt.pendingAddressedSnapshot(); len(got) != 1 || got[0] != 8 || rt.deliveredSeq() != 0 {
+		t.Fatalf("transport replay changed pending retry state: pending=%v delivered=%d", got, rt.deliveredSeq())
+	}
+	rt.mu.Lock()
+	pending := rt.pendingContexts[8]
+	rt.mu.Unlock()
+	if len(pending.events) != 1 || pending.events[0].Sequence != 8 {
+		t.Fatalf("transport replay replaced the pinned context: %#v", pending)
+	}
+
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	rt.drainTurns()
+	if len(captured) != 2 || len(captured[1].Events) != 1 || captured[1].Events[0].Sequence != 8 {
+		t.Fatalf("retry did not receive the original event exactly once: %#v", captured)
+	}
+	if got := rt.pendingAddressedSnapshot(); len(got) != 0 || rt.deliveredSeq() != 8 {
+		t.Fatalf("successful retry did not acknowledge once: pending=%v delivered=%d", got, rt.deliveredSeq())
+	}
+}
+
+func TestUnaddressedTransportReplayDoesNotDuplicateLaterHarnessDelta(t *testing.T) {
+	client := &fakeClient{}
+	adapter := &fakeAdapter{name: "pi"}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "inst-replay-unaddressed", RoomID: "room", Name: "Pi",
+		Client: client, Adapter: adapter,
+	})
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+
+	var captured []types.HarnessTurnInput
+	original := adapterRunTurnHook
+	adapterRunTurnHook = func(_ *fakeAdapter, input types.HarnessTurnInput) {
+		captured = append(captured, input)
+	}
+	defer func() { adapterRunTurnHook = original }()
+
+	unaddressed := roomEvent(9, false)
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{unaddressed}, Cursor: 9})
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{unaddressed}, Cursor: 9})
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{roomEvent(10, true)}, Cursor: 10})
+	rt.drainTurns()
+
+	if len(captured) != 1 || len(captured[0].Events) != 2 ||
+		captured[0].Events[0].Sequence != 9 || captured[0].Events[1].Sequence != 10 {
+		t.Fatalf("unaddressed transport replay duplicated the Harness delta: %#v", captured)
+	}
+	if events := rt.bufferSince(0, 10); len(events) != 2 ||
+		events[0].Sequence != 9 || events[1].Sequence != 10 {
+		t.Fatalf("unaddressed transport replay duplicated EventBuffer state: %#v", events)
+	}
+}
+
+func TestOverlappingTransportEnvelopeAcceptsOnlyNewerSequences(t *testing.T) {
+	client := &fakeClient{}
+	adapter := &fakeAdapter{name: "pi"}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "inst-replay-overlap", RoomID: "room", Name: "Pi",
+		Client: client, Adapter: adapter,
+	})
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+
+	var captured []types.HarnessTurnInput
+	original := adapterRunTurnHook
+	adapterRunTurnHook = func(_ *fakeAdapter, input types.HarnessTurnInput) {
+		captured = append(captured, input)
+	}
+	defer func() { adapterRunTurnHook = original }()
+
+	// Cursor 12 proves receipt through an omitted self-originated event 12;
+	// later overlapping envelopes must still accept the new addressed 13.
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{roomEvent(11, false)}, Cursor: 12})
+	if got := rt.currentCursor(); got != 12 {
+		t.Fatalf("transport cursor did not advance across an omitted event: %d", got)
+	}
+	rt.advanceFromWait(types.WaitResult{Events: []types.RoomEvent{
+		roomEvent(11, false), roomEvent(13, true), roomEvent(13, true),
+	}, Cursor: 13})
+	rt.drainTurns()
+
+	if got := rt.currentCursor(); got != 13 {
+		t.Fatalf("transport cursor did not advance after overlap: %d", got)
+	}
+	if len(captured) != 1 || len(captured[0].Events) != 2 ||
+		captured[0].Events[0].Sequence != 11 || captured[0].Events[1].Sequence != 13 {
+		t.Fatalf("overlap did not preserve one old and one new event: %#v", captured)
+	}
+	if events := rt.bufferSince(0, 13); len(events) != 2 ||
+		events[0].Sequence != 11 || events[1].Sequence != 13 {
+		t.Fatalf("overlap duplicated buffered events: %#v", events)
+	}
+}
+
 func TestHarnessGenerationReplacementRebuildsBootstrapBeforePrompt(t *testing.T) {
 	client := &fakeClient{}
 	adapter := &fakeAdapter{name: "pi"}


### PR DESCRIPTION
## Summary

Refs #223

During production dogfood, a resident Agent successfully handled an addressed Room event at sequence `37`, then received an at-least-once transport replay of that same event. The Runtime attempted to deliver it again and failed with:

```text
lastError: room context for sequence 37 is unavailable
```

The Room's retained context still contained sequence `37`. The failure was therefore not context eviction: replayed transport input had been re-admitted as new pending Harness work after the original turn was acknowledged.

This PR adds receipt-side replay suppression in the shared `advanceFromWait` path used by both the legacy long-poll and resident event-stream consumers:

- Capture the pre-envelope Runtime `cursor` as the transport receipt boundary.
- Ignore an event whose sequence was already received, for addressed and unaddressed events alike.
- Ignore a duplicate sequence repeated within the same response envelope.
- Advance the cursor only after ingesting the envelope, retaining the server cursor even when it crossed self-originated or filtered events.

This intentionally does **not** use Harness acknowledgement state (`deliveredThrough`) for transport deduplication. A failed or ambiguous `RunTurn` remains pending with its original frozen context and is retried normally; only a repeated transport receipt is discarded.

No release/version changes, bootstrap activation, or delivery-state refactor are included.

## Regression coverage

- A replay after a successful Harness acknowledgement creates no pending turn, history recovery, reconnect, or second Harness run.
- A replay while the original Harness turn is unacknowledged preserves exactly one pending frozen turn and retries it once.
- An unaddressed replay is not duplicated in a later addressed turn's contextual delta.
- Overlapping response envelopes ignore old events while accepting only the newer sequence, including when the server cursor crossed a filtered/self event.

## Validation

```text
gofmt -l $(git ls-files '*.go')
go test ./...
go test ./... -count=1
go vet ./...
go build ./cmd/free4chat-agent
git diff --check
go test -race ./internal/runtime -count=1 -run 'TestTransportReplayAfterSuccessfulHarnessAckIsIgnored|TestTransportReplayPreservesUnacknowledgedHarnessTurn|TestUnaddressedTransportReplayDoesNotDuplicateLaterHarnessDelta|TestOverlappingTransportEnvelopeAcceptsOnlyNewerSequences'
```

All above passed.

An additional full `go test -race ./internal/runtime -count=1` exposes pre-existing races in test fakes/global test hooks and voice-output cleanup paths outside this change; no race trace points to the replay-receipt path or these regressions.
