### PR TITLE
chore(agent): prepare 0.5.20 release

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.19"
+var Version = "0.5.20"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary

Refs #223

Prepares the next Agent Runtime source version, `0.5.20`, containing the merged #257 transport-replay correctness fix.

This is deliberately **phase 1 of 3** of the Agent Runtime release process:

```text
source-version PR → verified native GitHub Release → live bootstrap activation PR
```

The only source change is `doctor.Version` from `0.5.19` to `0.5.20`.

It intentionally does not update `app/public/agent.md` or generated `app/public/llms-full.txt`; production bootstrap remains pinned to the already-published `0.5.19` release until `agent-v0.5.20` native assets and `SHA256SUMS` are published and verified.

After this PR is green and merged, the release procedure is:

1. Tag its merge SHA as `agent-v0.5.20`.
2. Wait for the four native assets, `SHA256SUMS`, and GitHub Release; verify the current-platform asset reports `0.5.20`.
3. Open a separate activation PR for `agent.md` and regenerated `llms-full.txt`, then deploy, verify the live bootstrap, and dogfood #223.

## Validation

```text
cd agent
go test ./...
go vet ./...
go build ./cmd/free4chat-agent
bash scripts/test-install-agent.sh
bash scripts/test-bootstrap-contract.sh
git diff --check
./free4chat-agent doctor --json  # version 0.5.20
```

All commands passed. The installer contract uses mocked downloads and temporary directories; no installed local Runtime was modified.
