### PR TITLE
docs(agent): activate 0.5.20 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -270,7 +270,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.19` (release tag `agent-v0.5.19`).
+`0.5.20` (release tag `agent-v0.5.20`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -329,7 +329,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.19"
+expected_version="0.5.20"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1640,7 +1640,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.19` (release tag `agent-v0.5.19`).
+`0.5.20` (release tag `agent-v0.5.20`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1699,7 +1699,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.19"
+expected_version="0.5.20"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

Refs #223

Activates the already-published Agent Runtime `0.5.20` in the live bootstrap source:

- `app/public/agent.md` now names `agent-v0.5.20` and pins `expected_version="0.5.20"`.
- `app/public/llms-full.txt` was regenerated from `agent.md` and contains the same two changes.

This is phase 3 of the deliberate release sequence:

```text
source-version PR #259 (merged)
→ agent-v0.5.20 native GitHub Release (published and verified)
→ this bootstrap activation PR
```

Before this PR, the native Release was verified with all four platform assets and `SHA256SUMS`; the downloaded `darwin-arm64` binary reported `doctor --json` version `0.5.20`. Production bootstrap has remained safely pinned to `0.5.19` until that verification completed.

After this PR's CI is green, merge it. The resulting `cf-sfu` push—not PR CI—will deploy the bootstrap. Wait for that deployment to succeed before treating `0.5.20` as live, then verify deployed `/agent.md` and dogfood #223.

## Validation

```text
cd agent && bash scripts/test-bootstrap-contract.sh
cd app && yarn docs:generate
cd app && yarn docs:check
cd app && yarn test                  # 613 passed
cd app && yarn type-check
cd app && yarn eslint src --no-fix
cd app && yarn prettier --check .
cd app && yarn cf-build
git diff --check
```

All commands passed. The first sandboxed `cf-build` was blocked only from binding a local loopback listener; the required non-sandboxed rerun completed successfully.
