### PR TITLE
fix(harness): preserve isolated Runtime root for local context reads

### DIFF
--- a/agent/internal/daemon/daemon_test.go
+++ b/agent/internal/daemon/daemon_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 var fakeAgentBinary string
+var free4chatAgentBinary string
 
 func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "free4chat-daemon-")
@@ -36,6 +37,11 @@ func TestMain(m *testing.M) {
 		panic("fakeagent build failed: " + string(out))
 	}
 	fakeAgentBinary = bin
+	free4chatAgentBinary = filepath.Join(dir, "free4chat-agent")
+	runtimeBuild := exec.Command("go", "build", "-o", free4chatAgentBinary, "../../cmd/free4chat-agent")
+	if out, err := runtimeBuild.CombinedOutput(); err != nil {
+		panic("free4chat-agent build failed: " + string(out))
+	}
 	code := m.Run()
 	_ = os.RemoveAll(dir)
 	os.Exit(code)
@@ -943,6 +949,139 @@ func serveResidentEventSocket(w http.ResponseWriter, r *http.Request, payload an
 	encoded, _ := json.Marshal(payload)
 	_ = conn.Write(context.Background(), websocket.MessageText, encoded)
 	return true
+}
+
+func TestCustomRuntimeRootReachesHarnessContextRead(t *testing.T) {
+	_, root := startDaemon(t)
+
+	// The fake ACP Harness invokes the CLI by name. Put the test-built CLI
+	// first on PATH so the child exercises the same local command path as a
+	// real Harness, while FREE4CHAT_AGENT_DIR points at this daemon's root.
+	t.Setenv("PATH", filepath.Dir(free4chatAgentBinary)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var mu sync.Mutex
+	var sentTexts []string
+	waitCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveResidentEventSocket(w, r, map[string]any{
+			"type": "events",
+			"events": []any{map[string]any{
+				"sequence": float64(1), "type": "text",
+				"participant": map[string]any{
+					"id": "human-1", "name": "History Human", "kind": "human",
+				},
+				"text": "live-trigger", "addressed": true,
+				"createdAt": float64(1700000000000),
+			}},
+			"cursor":    float64(1),
+			"expiresAt": float64(time.Now().Add(time.Hour).UnixMilli()),
+		}) {
+			return
+		}
+
+		var body struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		switch body.Method {
+		case "tools/list":
+			writeModernMCPTools(w)
+		case "tools/call":
+			switch body.Params.Name {
+			case "join_room":
+				writeJSONRPC(w, callToolResult(map[string]any{
+					"participantHandle": residentTestHandle("custom-root", "agent-1", "context-token"),
+					"participant":       map[string]any{"id": "agent-1"},
+					"cursor":            float64(0),
+					"expiresAt":         float64(time.Now().Add(time.Hour).UnixMilli()),
+				}))
+			case "read_room_context":
+				args := body.Params.Arguments
+				if args["beforeSequence"] != float64(2) || args["limit"] != float64(10) {
+					t.Errorf("context read bounds mismatch: %#v", args)
+				}
+				writeJSONRPC(w, callToolResult(map[string]any{
+					"events": []any{map[string]any{
+						"sequence": float64(1), "type": "text",
+						"participant": map[string]any{
+							"id": "human-1", "name": "History Human", "kind": "human",
+						},
+						"text": "custom-root-history", "addressed": false,
+						"createdAt": float64(1699999999000),
+					}},
+					"oldestSequence": float64(1), "newestSequence": float64(1),
+					"hasMoreBefore": false, "hasMoreAfter": false,
+					"liveTranscript": map[string]any{
+						"segments": []any{}, "oldestSequence": float64(0),
+						"newestSequence": float64(0), "hasMoreBefore": false, "hasMoreAfter": false,
+					},
+				}))
+			case "wait_for_events":
+				mu.Lock()
+				waitCalls++
+				mu.Unlock()
+				http.Error(w, "resident Runtime must use the event stream", http.StatusInternalServerError)
+			case "send_text":
+				text, _ := body.Params.Arguments["text"].(string)
+				mu.Lock()
+				sentTexts = append(sentTexts, text)
+				mu.Unlock()
+				writeJSONRPC(w, callToolResult(map[string]any{"sequence": float64(2)}))
+			default:
+				writeJSONRPC(w, callToolResult(map[string]any{}))
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("FREE4CHAT_MCP_URL", server.URL)
+
+	joined, err := SendIPC(&IpcRequest{
+		Op:           "join",
+		Room:         "custom-root",
+		Name:         "Context Reader",
+		AgentCommand: fakeAgentBinary,
+		AgentArgs:    []string{"--mode", "context_read"},
+	})
+	if err != nil {
+		t.Fatalf("daemon join failed: %v", err)
+	}
+	var statusView struct {
+		State      string `json:"state"`
+		InstanceID string `json:"instanceId"`
+	}
+	if err := json.Unmarshal(joined, &statusView); err != nil || statusView.State != "waiting" || statusView.InstanceID == "" {
+		t.Fatalf("join view mismatch: %s", joined)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		answered := len(sentTexts) > 0
+		mu.Unlock()
+		if answered {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	mu.Lock()
+	texts := append([]string(nil), sentTexts...)
+	waits := waitCalls
+	mu.Unlock()
+	if waits != 0 {
+		t.Fatalf("resident Runtime used public wait_for_events %d times", waits)
+	}
+	if len(texts) != 1 || !strings.Contains(texts[0], "custom-root-history") {
+		t.Fatalf("Harness context read did not return bounded Room history: %q", texts)
+	}
+	if _, err := os.Stat(filepath.Join(root, "workspaces", statusView.InstanceID)); err != nil {
+		t.Fatalf("resident workspace was not created under custom Runtime root: %v", err)
+	}
 }
 
 func residentTestHandle(roomID, participantID, participantToken string) string {

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -424,6 +424,8 @@ func TestBuildHarnessEnvironmentIsAllowListed(t *testing.T) {
 	environment := BuildHarnessEnvironment(codex, map[string]string{
 		"PATH":                  "/safe/bin",
 		"HOME":                  "/home/test",
+		"FREE4CHAT_AGENT_DIR":   "/custom/runtime-root",
+		"FREE4CHAT_UNRELATED":   "must-not-pass",
 		"OPENAI_API_KEY":        "provider-secret",
 		"AWS_SECRET_ACCESS_KEY": "must-not-pass",
 		"GH_TOKEN":              "must-not-pass",
@@ -437,16 +439,40 @@ func TestBuildHarnessEnvironmentIsAllowListed(t *testing.T) {
 	if environment["OPENAI_API_KEY"] != "provider-secret" {
 		t.Fatal("provider credentials must survive the filter")
 	}
+	if environment["FREE4CHAT_AGENT_DIR"] != "/custom/runtime-root" {
+		t.Fatalf("explicit Runtime root must survive the filter: %v", environment)
+	}
 	for _, forbidden := range []string{"AWS_SECRET_ACCESS_KEY", "GH_TOKEN", "GITHUB_TOKEN"} {
 		if _, present := environment[forbidden]; present {
 			t.Fatalf("%s must not leak into the Harness environment", forbidden)
 		}
+	}
+	if _, present := environment["FREE4CHAT_UNRELATED"]; present {
+		t.Fatal("unrelated FREE4CHAT_* variables must not leak into the Harness environment")
 	}
 	if _, present := environment["CODEX_CONFIG"]; present {
 		t.Fatal("ambient CODEX_CONFIG must be dropped")
 	}
 	if environment["INITIAL_AGENT_MODE"] != "read-only" {
 		t.Fatalf("trusted launcher override lost: %v", environment["INITIAL_AGENT_MODE"])
+	}
+}
+
+func TestACPSubprocessReceivesExplicitRuntimeRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "runtime-root")
+	t.Setenv("FREE4CHAT_AGENT_DIR", root)
+	adapter, _ := newTestAdapter(t, scriptLauncher("env", nil), AdapterOptions{})
+	defer adapter.Close()
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("runtime-root"), adapter.SessionGeneration())
+	if err != nil {
+		t.Fatalf("turn failed: %v", err)
+	}
+	if result.Text != root {
+		t.Fatalf("Harness did not receive FREE4CHAT_AGENT_DIR: got %q want %q", result.Text, root)
 	}
 }
 

--- a/agent/internal/harness/env.go
+++ b/agent/internal/harness/env.go
@@ -24,6 +24,7 @@ func (e *UnknownLauncherError) Error() string {
 // explicit launcher override).
 var safeEnvironmentKeys = []string{
 	"PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "TERM", "NO_COLOR",
+	"FREE4CHAT_AGENT_DIR",
 	"OPENAI_API_KEY", "OPENAI_BASE_URL",
 	"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL",
 	"GOOGLE_API_KEY", "GEMINI_API_KEY",

--- a/agent/internal/harness/testdata/fakeagent/main.go
+++ b/agent/internal/harness/testdata/fakeagent/main.go
@@ -4,6 +4,8 @@
 // Modes are selected through FAKE_MODE:
 //
 //	normal         reply incrementally to every prompt
+//	env            reply with the Harness-visible FREE4CHAT_AGENT_DIR
+//	context_read   invoke the local CLI's bounded Room context read
 //	permission     answer a targeted turn after an auto-cancelled permission ask
 //	cancel         hold the requested turn until session/cancel arrives
 //	exit           die shortly after the first prompt completes
@@ -20,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strconv"
 	"syscall"
@@ -123,7 +126,14 @@ func main() {
 		os.Exit(1)
 	}
 	tracePath = os.Getenv("FAKE_TRACE")
-	a := &agent{mode: os.Getenv("FAKE_MODE")}
+	mode := os.Getenv("FAKE_MODE")
+	for index := 0; index+1 < len(os.Args); index++ {
+		if os.Args[index] == "--mode" {
+			mode = os.Args[index+1]
+			break
+		}
+	}
+	a := &agent{mode: mode}
 	sessionID := ""
 	// A FIRST-life stuck process must also survive stdin EOF (the adapter
 	// closes the pipe before escalating): only SIGKILL may end it, which is
@@ -212,6 +222,17 @@ func main() {
 		case message.Method == "session/prompt":
 			prompt := promptText(message.Params)
 			switch a.mode {
+			case "env":
+				updateChunk(sessionID, os.Getenv("FREE4CHAT_AGENT_DIR"))
+				reply(message.ID, map[string]any{"stopReason": "end_turn"})
+			case "context_read":
+				output, err := exec.Command("free4chat-agent", "context", "read", "--before-sequence", "2", "--limit", "10").CombinedOutput()
+				if err != nil {
+					updateChunk(sessionID, "context-read-error: "+string(output))
+				} else {
+					updateChunk(sessionID, string(output))
+				}
+				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "permission":
 				if len(prompt) > 0 && contains(prompt, "permission-test") {
 					// Agent -> client requests carry an explicit id so the


### PR DESCRIPTION
## Summary

Production dogfood for #223 exposed one remaining supported sandbox/custom-root issue. A Runtime started with FREE4CHAT_AGENT_DIR=/custom/root could operate normally, but its retained Harness subprocess did not inherit that explicit root. When Pi autonomously ran free4chat-agent context read, the CLI looked at the default Runtime root and could not resolve the active participant or bounded Room history.

This is a narrow environment propagation bug, not a Room-context architecture change. The default Runtime path was healthy; only the supported custom-root path was lost at the ACP subprocess boundary.

This PR:
- adds only FREE4CHAT_AGENT_DIR to the explicit Harness-safe environment allow-list;
- keeps arbitrary FREE4CHAT_* variables filtered;
- leaves doctor/probe filtering unchanged;
- does not pass participantHandle, tokens, cursors, credentials, or daemon-private state to the Harness;
- adds allow-list, ACP subprocess, and custom-root daemon/CLI/MCP regression coverage.

## Validation

- gofmt check
- go test ./...
- go test ./... -count=1
- go vet ./...
- go build ./cmd/free4chat-agent
- git diff --check

No Agent version bump or release work is included. No Runtime delivery-state refactor is included.

Refs #223