### PR TITLE
chore(agent): prepare 0.5.21 release

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.20"
+var Version = "0.5.21"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary

Prepare the next native Free4Chat Agent Runtime release after #261.

This source-version phase changes only agent/internal/doctor/doctor.go:
- doctor.Version: 0.5.20 -> 0.5.21

Live bootstrap files are intentionally unchanged. app/public/agent.md and app/public/llms-full.txt remain on the last published release until the native agent-v0.5.21 Release is built, published, checksum-verified, and doctor-verified.

## Validation

- go test ./...
- go vet ./...
- go build ./cmd/free4chat-agent
- bash scripts/test-install-agent.sh (19/19)
- bash scripts/test-bootstrap-contract.sh
- git diff --check

Refs #223