### PR TITLE
docs(agent): activate 0.5.21 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -270,7 +270,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.20` (release tag `agent-v0.5.20`).
+`0.5.21` (release tag `agent-v0.5.21`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -329,7 +329,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.20"
+expected_version="0.5.21"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1640,7 +1640,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.20` (release tag `agent-v0.5.20`).
+`0.5.21` (release tag `agent-v0.5.21`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1699,7 +1699,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.20"
+expected_version="0.5.21"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

- activate the already-published Agent Runtime `0.5.21` in the live bootstrap contract
- regenerate `app/public/llms-full.txt` from `app/public/agent.md`
- keep source release and live activation as separate phases

## Release sequencing

`agent-v0.5.21` is already published and verified before this activation. It contains all four native binaries and `SHA256SUMS`; the current-platform binary reports `0.5.21` via `doctor --json`.

This PR updates only the live bootstrap metadata. It must not be merged unless its PR checks are green. After merge, wait for the resulting `cf-sfu` Build & Deploy workflow, then verify the live `/agent.md` route before dogfood.

Refs #223