### PR TITLE
[codex] refresh Room participant presence UI

### DIFF
--- a/app/src/components/AudioVisualizer.test.tsx
+++ b/app/src/components/AudioVisualizer.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import AudioVisualizer from "./AudioVisualizer"
+
+describe("AudioVisualizer", () => {
+  it("renders an idle signal without a MediaStream", () => {
+    const { container, getByLabelText } = render(
+      <AudioVisualizer name="Hermes" />
+    )
+    const signal = getByLabelText("Idle")
+    expect(signal).toHaveAttribute("data-speaking", "false")
+    expect(signal).toHaveAttribute("data-audio-level", "0.00")
+    expect(container.querySelector("canvas")).toBeNull()
+  })
+
+  it("renders the same local signal grammar for muted participants", () => {
+    const { getByLabelText } = render(
+      <AudioVisualizer name="Pi" muteState audio={null} />
+    )
+    expect(getByLabelText("Idle")).toHaveAttribute("data-audio-level", "0.00")
+  })
+})

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -1,81 +1,124 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
+import type { CSSProperties } from "react"
 
-import { nameToColor, strToRGB } from "../common/utils"
+import { participantAccent } from "./ParticipantAvatar"
 
 interface Audio {
-  audio: MediaStream
+  audio?: MediaStream | null
   name: string
-  muteState: boolean | false
+  muteState?: boolean | false
 }
 
-export default function AudioVisualizer(props: Audio) {
-  const analyserCanvas = useRef(null)
-  useEffect(() => {
-    const color = nameToColor(props.name)
-    if (!props.audio || props.audio.getAudioTracks().length === 0) return
-    const audioCtx = new AudioContext()
-    void audioCtx.resume().catch(() => undefined)
-    const analyser = audioCtx.createAnalyser()
-    const audioSrc = audioCtx.createMediaStreamSource(props.audio)
-    audioSrc.connect(analyser)
-    analyser.fftSize = 256
-    const bufferLength = analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    analyser.getByteTimeDomainData(dataArray)
-
-    const canvas = analyserCanvas.current
-    const canvasCtx = canvas.getContext("2d")
-
-    const g = color[1]
-    const b = color[2]
-
-    let animationFrame = 0
-    const draw = () => {
-      const WIDTH = canvas.width
-      const HEIGHT = canvas.height
-
-      animationFrame = requestAnimationFrame(draw)
-      analyser.getByteFrequencyData(dataArray)
-
-      // clear canvas for next drawing
-      canvasCtx.fillStyle = strToRGB(props.name)
-      canvasCtx.fillRect(0, 0, WIDTH, HEIGHT)
-
-      const barWidth = 4
-      let barHeight: number
-      let x = 0
-
-      for (let i = 0; i < bufferLength; i++) {
-        barHeight = dataArray[i] / 2
-
-        // const r = Math.floor(barHeight + 64)
-        // if (g % 3 === 0) {
-        //   canvasCtx.fillStyle = `rgb(${r},${g},${b})`
-        // } else if (g % 3 === 1) {
-        //   canvasCtx.fillStyle = `rgb(${g},${r},${b})`
-        // } else {
-        //   canvasCtx.fillStyle = `rgb(${g},${b},${r})`
-        // }
-        canvasCtx.fillStyle = `rgb(255,255,255)`
-
-        canvasCtx.fillRect(x, 40 - barHeight / 2, barWidth, barHeight)
-
-        x += barWidth + 2
+function getAudioContextConstructor() {
+  if (typeof window === "undefined") return null
+  return (
+    window.AudioContext ??
+    (
+      window as Window & {
+        webkitAudioContext?: typeof AudioContext
       }
+    ).webkitAudioContext ??
+    null
+  )
+}
+
+/**
+ * Read a local MediaStream's level for presentation only. The Room protocol
+ * remains text/state based: no audio level leaves this browser.
+ */
+export function useAudioLevel(audio?: MediaStream | null, muted = false) {
+  const [level, setLevel] = useState(0)
+  const mutedRef = useRef(muted)
+
+  useEffect(() => {
+    mutedRef.current = muted
+  }, [muted])
+
+  useEffect(() => {
+    const AudioContextConstructor = getAudioContextConstructor()
+    if (
+      !audio ||
+      audio.getAudioTracks().length === 0 ||
+      !AudioContextConstructor
+    ) {
+      setLevel(0)
+      return
     }
-    draw()
+
+    let audioContext: AudioContext
+    let analyser: AnalyserNode
+    let source: MediaStreamAudioSourceNode
+    try {
+      audioContext = new AudioContextConstructor()
+      analyser = audioContext.createAnalyser()
+      analyser.fftSize = 256
+      source = audioContext.createMediaStreamSource(audio)
+    } catch {
+      setLevel(0)
+      return
+    }
+
+    const data = new Uint8Array(analyser.fftSize)
+    let animationFrame = 0
+    let smoothedLevel = 0
+
+    source.connect(analyser)
+    void audioContext.resume().catch(() => undefined)
+
+    const sample = () => {
+      analyser.getByteTimeDomainData(data)
+      let sum = 0
+      for (const value of data) {
+        const normalized = (value - 128) / 128
+        sum += normalized * normalized
+      }
+      const rms = Math.sqrt(sum / data.length)
+      const target = mutedRef.current ? 0 : Math.min(1, rms * 3.2)
+      smoothedLevel +=
+        (target - smoothedLevel) * (target > smoothedLevel ? 0.35 : 0.14)
+      setLevel(smoothedLevel < 0.015 ? 0 : smoothedLevel)
+      animationFrame = requestAnimationFrame(sample)
+    }
+
+    sample()
 
     return () => {
       cancelAnimationFrame(animationFrame)
-      audioSrc.disconnect()
+      source.disconnect()
       analyser.disconnect()
-      void audioCtx.close().catch(() => undefined)
+      void audioContext.close().catch(() => undefined)
     }
-  }, [props.audio, props.name])
+  }, [audio])
+
+  return muted ? 0 : level
+}
+
+export default function AudioVisualizer({ audio, name, muteState }: Audio) {
+  const level = useAudioLevel(audio, Boolean(muteState))
+  const accent = participantAccent(name)
+  const isSpeaking = level >= 0.08
+  const isStrong = level >= 0.32
 
   return (
-    <div className="visualizer mx-auto mt-4">
-      <canvas ref={analyserCanvas} className="h-12 w-4/5"></canvas>
+    <div
+      className="participant-signal"
+      data-audio-level={level.toFixed(2)}
+      data-speaking={isSpeaking ? "true" : "false"}
+      aria-label={isSpeaking ? "Speaking" : "Idle"}
+      style={
+        {
+          "--participant-accent": accent,
+          "--audio-level": level,
+        } as CSSProperties
+      }
+    >
+      <span
+        className={`participant-signal__ring participant-signal__ring--outer ${
+          isStrong ? "is-strong" : ""
+        }`}
+      />
+      <span className="participant-signal__ring participant-signal__ring--inner" />
+      <span className="participant-signal__dot" />
     </div>
   )
 }

--- a/app/src/components/ParticipantAvatar.test.tsx
+++ b/app/src/components/ParticipantAvatar.test.tsx
@@ -1,7 +1,10 @@
 import { render } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import ParticipantAvatar, { participantAccent } from "./ParticipantAvatar"
+import ParticipantAvatar, {
+  participantAccent,
+  participantVariant,
+} from "./ParticipantAvatar"
 
 describe("ParticipantAvatar", () => {
   it("uses a deterministic local accent and shared avatar grammar", () => {
@@ -22,6 +25,14 @@ describe("ParticipantAvatar", () => {
     expect(avatars[1]).toHaveStyle({
       "--participant-accent": participantAccent("Hermes"),
     })
+    expect(avatars[0]).toHaveAttribute(
+      "data-avatar-variant",
+      participantVariant("Hermes")
+    )
+    expect(avatars[1]).toHaveAttribute(
+      "data-avatar-variant",
+      participantVariant("Hermes")
+    )
     expect(container.querySelectorAll("img")).toHaveLength(0)
   })
 

--- a/app/src/components/ParticipantAvatar.test.tsx
+++ b/app/src/components/ParticipantAvatar.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import ParticipantAvatar, { participantAccent } from "./ParticipantAvatar"
+
+describe("ParticipantAvatar", () => {
+  it("uses a deterministic local accent and shared avatar grammar", () => {
+    const { container, getAllByTestId } = render(
+      <>
+        <ParticipantAvatar name="Hermes" kind="agent" />
+        <ParticipantAvatar name="Hermes" kind="human" />
+      </>
+    )
+
+    const avatars = getAllByTestId("participant-avatar")
+    expect(avatars).toHaveLength(2)
+    expect(avatars[0]).toHaveClass("participant-avatar")
+    expect(avatars[1]).toHaveClass("participant-avatar")
+    expect(avatars[0]).toHaveStyle({
+      "--participant-accent": participantAccent("Hermes"),
+    })
+    expect(avatars[1]).toHaveStyle({
+      "--participant-accent": participantAccent("Hermes"),
+    })
+    expect(container.querySelectorAll("img")).toHaveLength(0)
+  })
+
+  it("supports a compact node without a network avatar dependency", () => {
+    const { getByTestId } = render(
+      <ParticipantAvatar name="Pi" kind="agent" size="compact" />
+    )
+    expect(getByTestId("participant-avatar")).toHaveClass(
+      "participant-avatar--compact"
+    )
+    expect(getByTestId("participant-avatar").querySelector("svg")).toBeTruthy()
+  })
+})

--- a/app/src/components/ParticipantAvatar.test.tsx
+++ b/app/src/components/ParticipantAvatar.test.tsx
@@ -44,5 +44,15 @@ describe("ParticipantAvatar", () => {
       "participant-avatar--compact"
     )
     expect(getByTestId("participant-avatar").querySelector("svg")).toBeTruthy()
+    expect(
+      getByTestId("participant-avatar").querySelector(
+        ".participant-avatar__orbit"
+      )
+    ).toBeNull()
+    expect(
+      getByTestId("participant-avatar").querySelector(
+        ".participant-avatar__kind"
+      )
+    ).toBeNull()
   })
 })

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react"
 import type { CSSProperties } from "react"
 
 import type { UserInfo } from "../common/types"
@@ -16,6 +17,21 @@ const PARTICIPANT_ACCENTS = [
   "#f9a8d4", // rose
 ]
 
+export type ParticipantAvatarVariant =
+  | "planet"
+  | "ringed-planet"
+  | "moon"
+  | "crystal"
+  | "energy-orb"
+
+const PARTICIPANT_AVATAR_VARIANTS: ParticipantAvatarVariant[] = [
+  "planet",
+  "ringed-planet",
+  "moon",
+  "crystal",
+  "energy-orb",
+]
+
 function hashName(name: string) {
   let hash = 0
   for (let index = 0; index < name.length; index += 1) {
@@ -26,6 +42,132 @@ function hashName(name: string) {
 
 export function participantAccent(name: string) {
   return PARTICIPANT_ACCENTS[hashName(name) % PARTICIPANT_ACCENTS.length]
+}
+
+export function participantVariant(name: string) {
+  return PARTICIPANT_AVATAR_VARIANTS[
+    hashName(`${name}:avatar`) % PARTICIPANT_AVATAR_VARIANTS.length
+  ]
+}
+
+function participantSurface(
+  variant: ParticipantAvatarVariant,
+  accent: string,
+  gradientId: string
+) {
+  const gradient = `url(#${gradientId})`
+
+  switch (variant) {
+    case "ringed-planet":
+      return (
+        <>
+          <circle cx="36" cy="36" r="24" fill={gradient} />
+          <ellipse
+            cx="36"
+            cy="39"
+            rx="31"
+            ry="9"
+            stroke="#fff"
+            strokeOpacity=".48"
+            strokeWidth="2.2"
+            transform="rotate(-14 36 39)"
+          />
+          <path
+            d="M16 40c10-5 22-5 38 1"
+            stroke="#020617"
+            strokeLinecap="round"
+            strokeOpacity=".42"
+            strokeWidth="3"
+          />
+          <circle cx="25" cy="26" r="3" fill="#fff" fillOpacity=".64" />
+        </>
+      )
+    case "moon":
+      return (
+        <>
+          <circle cx="36" cy="36" r="24" fill="#dbeafe" fillOpacity=".26" />
+          <path
+            d="M48 16c-8 4-13 12-13 21 0 10 6 18 15 22-4 2-9 3-14 1-14-4-22-18-18-32 3-11 13-19 25-19 2 0 4 0 5 1Z"
+            fill={accent}
+            fillOpacity=".82"
+          />
+          <circle cx="28" cy="29" r="4" fill="#020617" fillOpacity=".2" />
+          <circle cx="43" cy="45" r="3" fill="#020617" fillOpacity=".24" />
+          <circle cx="24" cy="45" r="2" fill="#fff" fillOpacity=".35" />
+        </>
+      )
+    case "crystal":
+      return (
+        <>
+          <path
+            d="m36 10 17 15-6 30H25l-6-30 17-15Z"
+            fill={gradient}
+            stroke="#fff"
+            strokeOpacity=".38"
+            strokeWidth="1"
+          />
+          <path
+            d="m36 10 2 45M19 25l19 11 15-11M25 55l13-19 9 19"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeOpacity=".34"
+            strokeWidth="1"
+          />
+          <path d="m36 13 2 33-13-21 11-12Z" fill="#fff" fillOpacity=".3" />
+        </>
+      )
+    case "energy-orb":
+      return (
+        <>
+          <circle cx="36" cy="36" r="24" fill={gradient} />
+          <circle
+            cx="36"
+            cy="36"
+            r="14"
+            stroke="#fff"
+            strokeOpacity=".45"
+            strokeWidth="1.3"
+          />
+          <circle cx="36" cy="36" r="4" fill="#fff" fillOpacity=".82" />
+          <path
+            d="M16 32c8-8 18-11 32-6M23 51c9 3 18 1 27-6"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeOpacity=".3"
+            strokeWidth="1.5"
+          />
+        </>
+      )
+    case "planet":
+    default:
+      return (
+        <>
+          <circle cx="36" cy="36" r="25" fill={gradient} />
+          <path
+            d="M12 42c11-7 25-8 42-2 3 1 6 3 8 5-7 11-19 17-32 15-9-1-15-7-18-18Z"
+            fill="#020617"
+            fillOpacity=".28"
+          />
+          <path
+            d="M14 39c9-6 21-8 36-3 4 1 7 3 9 5"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeOpacity=".34"
+            strokeWidth="2"
+          />
+          <path
+            d="M23 20c-3 6-3 13 0 20 3 7 9 12 17 14"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeOpacity=".24"
+            strokeWidth="1.5"
+          />
+          <circle cx="24" cy="25" r="3" fill="#fff" fillOpacity=".72" />
+          <circle cx="50" cy="47" r="2" fill="#fff" fillOpacity=".45" />
+        </>
+      )
+  }
 }
 
 function participantGlyph(kind: UserInfo["kind"]) {
@@ -70,14 +212,18 @@ export default function ParticipantAvatar({
   size = "full",
   muted = false,
   speaking = false,
+  className,
 }: {
   name: string
   kind: UserInfo["kind"]
   size?: ParticipantAvatarSize
   muted?: boolean
   speaking?: boolean
+  className?: string
 }) {
   const accent = participantAccent(name)
+  const variant = participantVariant(name)
+  const gradientId = `participant-avatar-${useId().replace(/:/g, "")}`
   const style = {
     "--participant-accent": accent,
   } as CSSProperties
@@ -86,7 +232,8 @@ export default function ParticipantAvatar({
   return (
     <div
       data-testid="participant-avatar"
-      className={`participant-avatar ${sizeClass}`}
+      data-avatar-variant={variant}
+      className={`participant-avatar ${sizeClass} ${className ?? ""}`.trim()}
       style={style}
     >
       <div
@@ -95,29 +242,14 @@ export default function ParticipantAvatar({
       >
         <svg viewBox="0 0 72 72" fill="none">
           <defs>
-            <radialGradient id={`orb-${hashName(name)}`} cx="30%" cy="25%">
+            <radialGradient id={gradientId} cx="30%" cy="25%">
               <stop offset="0" stopColor="#fff" stopOpacity=".95" />
               <stop offset=".22" stopColor={accent} stopOpacity=".95" />
-              <stop offset="1" stopColor={accent} stopOpacity=".16" />
+              <stop offset=".72" stopColor={accent} stopOpacity=".76" />
+              <stop offset="1" stopColor={accent} stopOpacity=".3" />
             </radialGradient>
           </defs>
-          <circle cx="36" cy="36" r="25" fill={`url(#orb-${hashName(name)})`} />
-          <path
-            d="M14 39c9-6 21-8 36-3 4 1 7 3 9 5"
-            stroke="#fff"
-            strokeLinecap="round"
-            strokeOpacity=".28"
-            strokeWidth="2"
-          />
-          <path
-            d="M23 20c-3 6-3 13 0 20 3 7 9 12 17 14"
-            stroke="#fff"
-            strokeLinecap="round"
-            strokeOpacity=".22"
-            strokeWidth="1.5"
-          />
-          <circle cx="24" cy="25" r="3" fill="#fff" fillOpacity=".72" />
-          <circle cx="50" cy="47" r="2" fill="#fff" fillOpacity=".45" />
+          {participantSurface(variant, accent, gradientId)}
         </svg>
       </div>
       <span className="participant-avatar__orbit participant-avatar__orbit--one" />

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -1,0 +1,137 @@
+import type { CSSProperties } from "react"
+
+import type { UserInfo } from "../common/types"
+
+export type ParticipantAvatarSize = "compact" | "full"
+
+// A small, fixed palette keeps the Room's accents legible while making the
+// same participant/name render the same way on every client. The palette is
+// intentionally shared by Humans and Agents; kind is shown by the badge, not
+// by a separate avatar system.
+const PARTICIPANT_ACCENTS = [
+  "#67e8f9", // cyan
+  "#c4b5fd", // violet
+  "#fcd34d", // amber
+  "#bef264", // lime
+  "#f9a8d4", // rose
+]
+
+function hashName(name: string) {
+  let hash = 0
+  for (let index = 0; index < name.length; index += 1) {
+    hash = (hash * 31 + name.charCodeAt(index)) >>> 0
+  }
+  return hash
+}
+
+export function participantAccent(name: string) {
+  return PARTICIPANT_ACCENTS[hashName(name) % PARTICIPANT_ACCENTS.length]
+}
+
+function participantGlyph(kind: UserInfo["kind"]) {
+  if (kind === "agent") {
+    return (
+      <svg aria-hidden="true" viewBox="0 0 16 16" fill="none">
+        <path
+          d="M8 2.5v2m-3.5 8h7M4.5 9.25a3.5 3.5 0 1 1 7 0v1.25h-7V9.25Z"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.3"
+        />
+        <circle cx="6.75" cy="8.7" r=".65" fill="currentColor" />
+        <circle cx="9.25" cy="8.7" r=".65" fill="currentColor" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" fill="none">
+      <circle
+        cx="8"
+        cy="5.25"
+        r="2.25"
+        stroke="currentColor"
+        strokeWidth="1.3"
+      />
+      <path
+        d="M3.75 13.25c.45-2.05 1.83-3.1 4.25-3.1s3.8 1.05 4.25 3.1"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.3"
+      />
+    </svg>
+  )
+}
+
+export default function ParticipantAvatar({
+  name,
+  kind,
+  size = "full",
+  muted = false,
+  speaking = false,
+}: {
+  name: string
+  kind: UserInfo["kind"]
+  size?: ParticipantAvatarSize
+  muted?: boolean
+  speaking?: boolean
+}) {
+  const accent = participantAccent(name)
+  const style = {
+    "--participant-accent": accent,
+  } as CSSProperties
+  const sizeClass = size === "compact" ? "participant-avatar--compact" : ""
+
+  return (
+    <div
+      data-testid="participant-avatar"
+      className={`participant-avatar ${sizeClass}`}
+      style={style}
+    >
+      <div
+        className={`participant-avatar__orb ${speaking ? "is-speaking" : ""}`}
+        aria-hidden="true"
+      >
+        <svg viewBox="0 0 72 72" fill="none">
+          <defs>
+            <radialGradient id={`orb-${hashName(name)}`} cx="30%" cy="25%">
+              <stop offset="0" stopColor="#fff" stopOpacity=".95" />
+              <stop offset=".22" stopColor={accent} stopOpacity=".95" />
+              <stop offset="1" stopColor={accent} stopOpacity=".16" />
+            </radialGradient>
+          </defs>
+          <circle cx="36" cy="36" r="25" fill={`url(#orb-${hashName(name)})`} />
+          <path
+            d="M14 39c9-6 21-8 36-3 4 1 7 3 9 5"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeOpacity=".28"
+            strokeWidth="2"
+          />
+          <path
+            d="M23 20c-3 6-3 13 0 20 3 7 9 12 17 14"
+            stroke="#fff"
+            strokeLinecap="round"
+            strokeOpacity=".22"
+            strokeWidth="1.5"
+          />
+          <circle cx="24" cy="25" r="3" fill="#fff" fillOpacity=".72" />
+          <circle cx="50" cy="47" r="2" fill="#fff" fillOpacity=".45" />
+        </svg>
+      </div>
+      <span className="participant-avatar__orbit participant-avatar__orbit--one" />
+      <span className="participant-avatar__orbit participant-avatar__orbit--two" />
+      <span
+        className={`participant-avatar__status ${muted ? "is-muted" : ""}`}
+        aria-hidden="true"
+      />
+      <span
+        className="participant-avatar__kind"
+        title={kind === "agent" ? "Agent" : "Human"}
+      >
+        {participantGlyph(kind)}
+      </span>
+    </div>
+  )
+}

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -64,57 +64,47 @@ function participantSurface(
           <circle cx="36" cy="36" r="24" fill={gradient} />
           <ellipse
             cx="36"
-            cy="39"
-            rx="31"
-            ry="9"
+            cy="38"
+            rx="30"
+            ry="7"
             stroke="#fff"
-            strokeOpacity=".48"
-            strokeWidth="2.2"
-            transform="rotate(-14 36 39)"
+            strokeOpacity=".58"
+            strokeWidth="2"
+            transform="rotate(-12 36 38)"
           />
-          <path
-            d="M16 40c10-5 22-5 38 1"
-            stroke="#020617"
-            strokeLinecap="round"
-            strokeOpacity=".42"
-            strokeWidth="3"
-          />
-          <circle cx="25" cy="26" r="3" fill="#fff" fillOpacity=".64" />
+          <circle cx="27" cy="27" r="3" fill="#fff" fillOpacity=".64" />
         </>
       )
     case "moon":
       return (
         <>
-          <circle cx="36" cy="36" r="24" fill="#dbeafe" fillOpacity=".26" />
+          <circle cx="36" cy="36" r="24" fill={gradient} />
           <path
-            d="M48 16c-8 4-13 12-13 21 0 10 6 18 15 22-4 2-9 3-14 1-14-4-22-18-18-32 3-11 13-19 25-19 2 0 4 0 5 1Z"
-            fill={accent}
-            fillOpacity=".82"
+            d="M48 14c-8 5-13 13-13 23 0 9 5 17 13 21-4 2-9 2-14 0-12-5-18-18-14-30 4-11 14-18 26-18h2Z"
+            fill="#020617"
+            fillOpacity=".52"
           />
-          <circle cx="28" cy="29" r="4" fill="#020617" fillOpacity=".2" />
-          <circle cx="43" cy="45" r="3" fill="#020617" fillOpacity=".24" />
-          <circle cx="24" cy="45" r="2" fill="#fff" fillOpacity=".35" />
+          <circle cx="27" cy="28" r="2.5" fill="#fff" fillOpacity=".55" />
         </>
       )
     case "crystal":
       return (
         <>
           <path
-            d="m36 10 17 15-6 30H25l-6-30 17-15Z"
+            d="m36 11 15 15-5 29H26l-5-29 15-15Z"
             fill={gradient}
             stroke="#fff"
-            strokeOpacity=".38"
+            strokeOpacity=".5"
             strokeWidth="1"
           />
           <path
-            d="m36 10 2 45M19 25l19 11 15-11M25 55l13-19 9 19"
+            d="m36 12 1 42M21 26l16 10 14-10"
             stroke="#fff"
             strokeLinecap="round"
             strokeLinejoin="round"
-            strokeOpacity=".34"
+            strokeOpacity=".38"
             strokeWidth="1"
           />
-          <path d="m36 13 2 33-13-21 11-12Z" fill="#fff" fillOpacity=".3" />
         </>
       )
     case "energy-orb":
@@ -124,19 +114,12 @@ function participantSurface(
           <circle
             cx="36"
             cy="36"
-            r="14"
+            r="12"
             stroke="#fff"
-            strokeOpacity=".45"
-            strokeWidth="1.3"
-          />
-          <circle cx="36" cy="36" r="4" fill="#fff" fillOpacity=".82" />
-          <path
-            d="M16 32c8-8 18-11 32-6M23 51c9 3 18 1 27-6"
-            stroke="#fff"
-            strokeLinecap="round"
-            strokeOpacity=".3"
+            strokeOpacity=".5"
             strokeWidth="1.5"
           />
+          <circle cx="36" cy="36" r="4" fill="#fff" fillOpacity=".82" />
         </>
       )
     case "planet":
@@ -145,65 +128,21 @@ function participantSurface(
         <>
           <circle cx="36" cy="36" r="25" fill={gradient} />
           <path
-            d="M12 42c11-7 25-8 42-2 3 1 6 3 8 5-7 11-19 17-32 15-9-1-15-7-18-18Z"
+            d="M12 43c12-6 25-7 43-1 3 1 5 2 7 4-7 10-18 16-30 15-10-1-17-7-20-18Z"
             fill="#020617"
             fillOpacity=".28"
           />
           <path
-            d="M14 39c9-6 21-8 36-3 4 1 7 3 9 5"
+            d="M15 39c11-5 23-6 37-2"
             stroke="#fff"
             strokeLinecap="round"
-            strokeOpacity=".34"
-            strokeWidth="2"
+            strokeOpacity=".42"
+            strokeWidth="1.8"
           />
-          <path
-            d="M23 20c-3 6-3 13 0 20 3 7 9 12 17 14"
-            stroke="#fff"
-            strokeLinecap="round"
-            strokeOpacity=".24"
-            strokeWidth="1.5"
-          />
-          <circle cx="24" cy="25" r="3" fill="#fff" fillOpacity=".72" />
-          <circle cx="50" cy="47" r="2" fill="#fff" fillOpacity=".45" />
+          <circle cx="25" cy="25" r="3" fill="#fff" fillOpacity=".72" />
         </>
       )
   }
-}
-
-function participantGlyph(kind: UserInfo["kind"]) {
-  if (kind === "agent") {
-    return (
-      <svg aria-hidden="true" viewBox="0 0 16 16" fill="none">
-        <path
-          d="M8 2.5v2m-3.5 8h7M4.5 9.25a3.5 3.5 0 1 1 7 0v1.25h-7V9.25Z"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.3"
-        />
-        <circle cx="6.75" cy="8.7" r=".65" fill="currentColor" />
-        <circle cx="9.25" cy="8.7" r=".65" fill="currentColor" />
-      </svg>
-    )
-  }
-
-  return (
-    <svg aria-hidden="true" viewBox="0 0 16 16" fill="none">
-      <circle
-        cx="8"
-        cy="5.25"
-        r="2.25"
-        stroke="currentColor"
-        strokeWidth="1.3"
-      />
-      <path
-        d="M3.75 13.25c.45-2.05 1.83-3.1 4.25-3.1s3.8 1.05 4.25 3.1"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.3"
-      />
-    </svg>
-  )
 }
 
 export default function ParticipantAvatar({
@@ -233,6 +172,8 @@ export default function ParticipantAvatar({
     <div
       data-testid="participant-avatar"
       data-avatar-variant={variant}
+      data-participant-kind={kind}
+      data-muted={muted ? "true" : "false"}
       className={`participant-avatar ${sizeClass} ${className ?? ""}`.trim()}
       style={style}
     >
@@ -243,27 +184,14 @@ export default function ParticipantAvatar({
         <svg viewBox="0 0 72 72" fill="none">
           <defs>
             <radialGradient id={gradientId} cx="30%" cy="25%">
-              <stop offset="0" stopColor="#fff" stopOpacity=".95" />
-              <stop offset=".22" stopColor={accent} stopOpacity=".95" />
-              <stop offset=".72" stopColor={accent} stopOpacity=".76" />
-              <stop offset="1" stopColor={accent} stopOpacity=".3" />
+              <stop offset="0" stopColor="#fff" stopOpacity=".8" />
+              <stop offset=".3" stopColor={accent} stopOpacity=".95" />
+              <stop offset="1" stopColor={accent} stopOpacity=".6" />
             </radialGradient>
           </defs>
           {participantSurface(variant, accent, gradientId)}
         </svg>
       </div>
-      <span className="participant-avatar__orbit participant-avatar__orbit--one" />
-      <span className="participant-avatar__orbit participant-avatar__orbit--two" />
-      <span
-        className={`participant-avatar__status ${muted ? "is-muted" : ""}`}
-        aria-hidden="true"
-      />
-      <span
-        className="participant-avatar__kind"
-        title={kind === "agent" ? "Agent" : "Human"}
-      >
-        {participantGlyph(kind)}
-      </span>
     </div>
   )
 }

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -44,7 +44,7 @@ function ScreenShareViewer({
   }
 
   return (
-    <div className="relative min-h-0 flex-1 bg-black">
+    <div className="room-share-viewer relative min-h-0 flex-1 bg-black">
       <video
         ref={videoRef}
         autoPlay
@@ -52,11 +52,12 @@ function ScreenShareViewer({
         muted
         className="h-full w-full object-contain"
       />
-      <div className="absolute bottom-2 left-2 rounded bg-black/60 px-2 py-0.5 text-xs text-white">
-        {name}
+      <div className="room-share-viewer__label absolute bottom-2 left-2 rounded px-2 py-0.5 text-xs text-white">
+        <span className="mr-1 text-cyan-300">●</span>
+        {name} is sharing
       </div>
       <button
-        className="absolute bottom-2 right-2 rounded bg-black/60 p-1 text-white hover:bg-black/80"
+        className="room-share-viewer__fullscreen absolute bottom-2 right-2 rounded p-1 text-white"
         onClick={enterFullscreen}
         title="Fullscreen"
       >
@@ -476,7 +477,7 @@ export default function RoomContent({
   }
 
   return (
-    <main className="flex h-screen flex-col overflow-hidden bg-gray-900 text-white">
+    <main className="room-shell flex h-screen flex-col overflow-hidden text-white">
       {connectionStatus === "reconnecting" && (
         <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60">
           <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-gray-700 border-t-yellow-400" />
@@ -484,21 +485,25 @@ export default function RoomContent({
         </div>
       )}
 
-      <header className="flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center">
+      <header className="room-header flex flex-none flex-col gap-2 border-b px-4 py-3 lg:flex-row lg:items-center">
         <div
           data-testid="room-header-identity"
           className="flex min-w-0 items-center gap-2"
         >
-          <h1 className="min-w-0 flex-1 truncate text-lg font-medium lg:flex-none">
+          <h1 className="min-w-0 flex-1 truncate font-mono text-lg font-medium tracking-wide text-cyan-100 lg:flex-none">
             #{roomName}
           </h1>
+          <span className="hidden font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500 sm:inline">
+            temporary room · {participants.length} peer
+            {participants.length === 1 ? "" : "s"} online
+          </span>
           <button
             type="button"
             onClick={() => {
               leaveRoom()
               router.push("/")
             }}
-            className="shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:hidden"
+            className="shrink-0 rounded-md border border-rose-800/80 bg-rose-950/30 px-3 py-1 text-xs text-rose-200 hover:border-rose-500/80 hover:bg-rose-950/60 lg:hidden"
           >
             Leave
           </button>
@@ -511,7 +516,7 @@ export default function RoomContent({
             <button
               type="button"
               onClick={copyRoomLink}
-              className="flex min-w-0 items-center justify-center gap-1 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-300 hover:bg-gray-700"
+              className="flex min-w-0 items-center justify-center gap-1 rounded-md border border-slate-700/80 bg-slate-900/70 px-2 py-1 text-xs text-slate-300 hover:border-cyan-700/70 hover:bg-slate-800"
               title="Copy room link"
             >
               <svg
@@ -559,7 +564,7 @@ export default function RoomContent({
               leaveRoom()
               router.push("/")
             }}
-            className="hidden shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:inline-flex"
+            className="hidden shrink-0 rounded-md border border-rose-800/80 bg-rose-950/30 px-3 py-1 text-xs text-rose-200 hover:border-rose-500/80 hover:bg-rose-950/60 lg:inline-flex"
           >
             Leave
           </button>
@@ -617,7 +622,7 @@ export default function RoomContent({
         className="flex flex-1 flex-col overflow-hidden md:flex-row"
       >
         <div
-          className="flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
+          className="room-panel flex flex-1 flex-col overflow-hidden border-b border-slate-800/80 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
           {/* #111: Agent workspace snapshots — observation only, available in
@@ -636,7 +641,7 @@ export default function RoomContent({
                     name={activeShare.name}
                   />
                 )}
-                <div className="scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-gray-800 p-2">
+                <div className="room-participant-strip scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-slate-800/80 p-2">
                   {participants.map((p) => (
                     <div
                       key={p.peerId}
@@ -644,7 +649,7 @@ export default function RoomContent({
                         p.screenShareEnabled &&
                         p.peerId !== LOCAL_PEER_ID &&
                         p.peerId === activeSharePeerId
-                          ? "ring-2 ring-blue-400"
+                          ? "shadow-[0_0_16px_rgba(103,232,249,0.26)] ring-1 ring-cyan-300"
                           : ""
                       } ${
                         p.screenShareEnabled && p.peerId !== LOCAL_PEER_ID
@@ -677,7 +682,7 @@ export default function RoomContent({
                         }
                         voiceEnabled={p.voiceEnabled}
                         onToggleAgentVoice={() => toggleAgentVoice(p)}
-                        className="w-20"
+                        className="w-[5.25rem]"
                         compact
                       />
                     </div>
@@ -685,7 +690,7 @@ export default function RoomContent({
                 </div>
               </>
             ) : (
-              <div className="scrollbar-thin flex h-full flex-wrap content-start items-start gap-2 overflow-y-auto p-3">
+              <div className="room-participants-grid scrollbar-thin grid h-full grid-cols-2 content-start items-start gap-2 overflow-y-auto p-3 sm:flex sm:flex-wrap">
                 {participants.map((p) => (
                   <div
                     key={p.peerId}
@@ -708,7 +713,7 @@ export default function RoomContent({
                       voiceEnabled={p.voiceEnabled}
                       onToggleAgentVoice={() => toggleAgentVoice(p)}
                       screenshareAllowed={screenshareAllowed}
-                      className="w-40 flex-none"
+                      className="w-full flex-none sm:w-40"
                     />
                     {p.peerId === LOCAL_PEER_ID && (
                       <div className="hidden items-center gap-1 md:flex">
@@ -742,14 +747,14 @@ export default function RoomContent({
         </div>
 
         <div
-          className="hidden w-1 cursor-col-resize bg-gray-800 transition-colors hover:bg-blue-500/50 active:bg-blue-500 md:block"
+          className="hidden w-1 cursor-col-resize bg-slate-800/70 transition-colors hover:bg-cyan-500/50 active:bg-cyan-500 md:block"
           onMouseDown={(e) => {
             isDragging.current = true
             e.preventDefault()
           }}
         />
 
-        <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="room-panel flex flex-1 flex-col overflow-hidden">
           <TextChatCard
             room={roomName}
             nickName={nickName}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -185,6 +185,7 @@ export default function RoomContent({
     (p) =>
       p.screenShareEnabled && p.peerId !== LOCAL_PEER_ID && p.screenShareStream
   )
+  const hasActiveScreenShare = activeScreenShares.length > 0
   const useConstellation = participants.length > 0 && participants.length <= 6
 
   const [activeSharePeerId, setActiveSharePeerId] = useState<string | null>(
@@ -620,11 +621,21 @@ export default function RoomContent({
 
       <div
         ref={containerRef}
-        className="flex flex-1 flex-col overflow-hidden md:flex-row"
+        className={`room-content flex min-h-0 flex-1 flex-col overflow-hidden ${
+          hasActiveScreenShare ? "md:flex-row" : "room-content--stacked"
+        }`}
       >
         <div
-          className="room-panel flex flex-1 flex-col overflow-hidden border-b border-slate-800/80 md:flex-none md:border-b-0 md:border-r"
-          style={isMd ? { width: `${splitRatio}%` } : undefined}
+          className={`room-panel flex min-h-0 flex-col overflow-hidden ${
+            hasActiveScreenShare
+              ? "flex-1 border-b border-slate-800/80 md:flex-none md:border-b-0 md:border-r"
+              : "w-full flex-none border-b border-slate-800/80"
+          }`}
+          style={
+            hasActiveScreenShare && isMd
+              ? { width: `${splitRatio}%` }
+              : undefined
+          }
         >
           {/* #111: Agent workspace snapshots — observation only, available in
               every room type; Human screen share is untouched below. */}
@@ -632,7 +643,11 @@ export default function RoomContent({
             participants={participants}
             getLocalRoomAuth={getLocalRoomAuth}
           />
-          <div className="relative flex flex-1 flex-col overflow-hidden">
+          <div
+            className={`relative flex flex-col overflow-hidden ${
+              hasActiveScreenShare ? "min-h-0 flex-1" : "flex-none"
+            }`}
+          >
             {activeScreenShares.length > 0 ? (
               <>
                 {activeShare && (
@@ -693,12 +708,10 @@ export default function RoomContent({
               </>
             ) : (
               <div
-                className={`room-participants-grid scrollbar-thin grid grid-cols-2 content-start items-start gap-2 overflow-y-auto p-3 ${
-                  !useConstellation ? "h-full" : ""
-                } ${
+                className={`room-participants-grid scrollbar-thin room-participants-grid--band gap-2 p-3 ${
                   useConstellation
-                    ? "room-participants-grid--constellation"
-                    : ""
+                    ? "room-participants-grid--node-band"
+                    : "room-participants-grid--card-band"
                 }`}
               >
                 {participants.map((p) => (
@@ -757,15 +770,17 @@ export default function RoomContent({
           </div>
         </div>
 
-        <div
-          className="hidden w-1 cursor-col-resize bg-slate-800/70 transition-colors hover:bg-cyan-500/50 active:bg-cyan-500 md:block"
-          onMouseDown={(e) => {
-            isDragging.current = true
-            e.preventDefault()
-          }}
-        />
+        {hasActiveScreenShare && (
+          <div
+            className="hidden w-1 cursor-col-resize bg-slate-800/70 transition-colors hover:bg-cyan-500/50 active:bg-cyan-500 md:block"
+            onMouseDown={(e) => {
+              isDragging.current = true
+              e.preventDefault()
+            }}
+          />
+        )}
 
-        <div className="room-panel flex flex-1 flex-col overflow-hidden">
+        <div className="room-panel flex min-h-0 flex-1 flex-col overflow-hidden">
           <TextChatCard
             room={roomName}
             nickName={nickName}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -185,6 +185,7 @@ export default function RoomContent({
     (p) =>
       p.screenShareEnabled && p.peerId !== LOCAL_PEER_ID && p.screenShareStream
   )
+  const useConstellation = participants.length > 0 && participants.length <= 6
 
   const [activeSharePeerId, setActiveSharePeerId] = useState<string | null>(
     null
@@ -684,13 +685,22 @@ export default function RoomContent({
                         onToggleAgentVoice={() => toggleAgentVoice(p)}
                         className="w-[5.25rem]"
                         compact
+                        node
                       />
                     </div>
                   ))}
                 </div>
               </>
             ) : (
-              <div className="room-participants-grid scrollbar-thin grid h-full grid-cols-2 content-start items-start gap-2 overflow-y-auto p-3 sm:flex sm:flex-wrap">
+              <div
+                className={`room-participants-grid scrollbar-thin grid grid-cols-2 content-start items-start gap-2 overflow-y-auto p-3 ${
+                  !useConstellation ? "h-full" : ""
+                } ${
+                  useConstellation
+                    ? "room-participants-grid--constellation"
+                    : ""
+                }`}
+              >
                 {participants.map((p) => (
                   <div
                     key={p.peerId}
@@ -713,6 +723,7 @@ export default function RoomContent({
                       voiceEnabled={p.voiceEnabled}
                       onToggleAgentVoice={() => toggleAgentVoice(p)}
                       screenshareAllowed={screenshareAllowed}
+                      node={useConstellation}
                       className="w-full flex-none sm:w-40"
                     />
                     {p.peerId === LOCAL_PEER_ID && (

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -495,10 +495,6 @@ export default function RoomContent({
           <h1 className="min-w-0 flex-1 truncate font-mono text-lg font-medium tracking-wide text-cyan-100 lg:flex-none">
             #{roomName}
           </h1>
-          <span className="hidden font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500 sm:inline">
-            temporary room · {participants.length} peer
-            {participants.length === 1 ? "" : "s"} online
-          </span>
           <button
             type="button"
             onClick={() => {

--- a/app/src/components/TextChatCard.attachment.test.tsx
+++ b/app/src/components/TextChatCard.attachment.test.tsx
@@ -136,6 +136,19 @@ describe("buildRoomTimeline (#234)", () => {
 })
 
 describe("standalone Agent attachment rendering (#234)", () => {
+  it("uses the compact local participant avatar grammar for timeline senders", () => {
+    renderCard([message(2, "hi")], [AGENT_ATTACHMENT], vi.fn())
+
+    const avatars = screen.getAllByTestId("participant-avatar")
+    expect(avatars).toHaveLength(2)
+    expect(
+      avatars.every((avatar) =>
+        avatar.classList.contains("participant-avatar--compact")
+      )
+    ).toBe(true)
+    expect(document.querySelectorAll("img")).toHaveLength(0)
+  })
+
   it("renders sender, file name, mime, size and a Preview action", async () => {
     const onReadArtifact = vi.fn().mockResolvedValue({
       attachment: {

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, memo } from "react"
 
-import Avatar from "boring-avatars"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -16,6 +15,7 @@ import {
   isCollabRequestAnswered,
 } from "./collabUi"
 import HumanCollabResultComposer from "./HumanCollabResultComposer"
+import ParticipantAvatar from "./ParticipantAvatar"
 import { resolveAgentTargetIds } from "../common/agentMentions"
 import type { UserInfo } from "../common/types"
 import type {
@@ -1187,10 +1187,11 @@ export default function TextChatCard({
               return (
                 <div className="mb-4 flex w-full items-end" key={attachment.id}>
                   <div className="mr-2 flex-shrink-0">
-                    <Avatar
-                      size={28}
-                      variant="beam"
+                    <ParticipantAvatar
                       name={attachment.senderName}
+                      kind={attachment.senderKind}
+                      size="compact"
+                      className="text-chat-avatar"
                     />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -1220,7 +1221,18 @@ export default function TextChatCard({
                 key={i}
               >
                 <div className={`flex-shrink-0 ${isSelf ? "ml-2" : "mr-2"}`}>
-                  <Avatar size={28} variant="beam" name={p.name} />
+                  <ParticipantAvatar
+                    name={p.name}
+                    kind={
+                      p.kind ??
+                      participants.find(
+                        (participant) => participant.peerId === p.peerId
+                      )?.kind ??
+                      "human"
+                    }
+                    size="compact"
+                    className="text-chat-avatar"
+                  />
                 </div>
                 <div className="min-w-0 flex-1">
                   {!isSelf && (
@@ -1281,7 +1293,12 @@ export default function TextChatCard({
               className="mb-4 flex w-full flex-row-reverse items-end"
             >
               <div className="ml-2 flex-shrink-0">
-                <Avatar size={28} variant="beam" name={nickName} />
+                <ParticipantAvatar
+                  name={nickName}
+                  kind="human"
+                  size="compact"
+                  className="text-chat-avatar"
+                />
               </div>
               <div style={{ maxWidth: "72%" }}>
                 <div

--- a/app/src/components/UserCard.capabilities.test.tsx
+++ b/app/src/components/UserCard.capabilities.test.tsx
@@ -13,19 +13,20 @@ function base(overrides: Record<string, unknown> = {}) {
   }
 }
 
-describe("Agent advertised capability chips (#234)", () => {
-  it("renders advertised capability chips for an Agent in full layout", () => {
+describe("Agent advertised capabilities stay out of the presence surface", () => {
+  it("does not render capability inventory in full layout", () => {
     const { getByText } = render(
       <UserCard
         {...base({ name: "Pi", kind: "agent", peerId: "agent-pi" })}
         capabilities={["code.edit", "shell"]}
       />
     )
-    expect(getByText("code.edit")).toBeTruthy()
-    expect(getByText("shell")).toBeTruthy()
+    expect(getByText("Pi")).toBeTruthy()
+    expect(document.querySelector('[title="code.edit"]')).toBeNull()
+    expect(document.querySelector('[title="shell"]')).toBeNull()
   })
 
-  it("compact layout also displays Agent capability chips without breaking layout", () => {
+  it("compact layout also keeps capability inventory out of the node", () => {
     const { getByText } = render(
       <UserCard
         {...base({
@@ -37,7 +38,8 @@ describe("Agent advertised capability chips (#234)", () => {
         capabilities={["code.edit"]}
       />
     )
-    expect(getByText("code.edit")).toBeTruthy()
+    expect(getByText("Pi")).toBeTruthy()
+    expect(document.querySelector('[title="code.edit"]')).toBeNull()
   })
 
   it("never shows a Human capability editor entry (removed with #234)", () => {

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef, useState } from "react"
-
-import Avatar from "boring-avatars"
+import type { CSSProperties, ReactNode } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
-import { strToBgColor } from "@common/utils"
 
-import { UserInfo } from "../common/types"
-import AudioVisualizer from "../components/AudioVisualizer"
+import AudioVisualizer from "./AudioVisualizer"
+import ParticipantAvatar, { participantAccent } from "./ParticipantAvatar"
+import type { UserInfo } from "../common/types"
 
 interface UserCardProps extends UserInfo {
   onMuteSelf?: () => void
@@ -19,9 +18,52 @@ interface UserCardProps extends UserInfo {
   onToggleAgentVoice?: () => void
 }
 
+function MicIcon({ muted = false }: { muted?: boolean }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+      {muted ? (
+        <>
+          <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1Zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4Zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3Z" />
+          <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607ZM1.646 1.354l12 12-.708.708-12-12 .708-.708Z" />
+        </>
+      ) : (
+        <>
+          <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5Z" />
+          <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0v5ZM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3Z" />
+        </>
+      )}
+    </svg>
+  )
+}
+
+function ScreenIcon({ active = false }: { active?: boolean }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+      {active ? (
+        <path d="M0 4s0-2 2-2h12s2 0 2 2v6s0 2-2 2h-4c0 .667.083 1.167.25 1.5H11a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1h.75c.167-.333.25-.833.25-1.5H2s-2 0-2-2V4Zm1.398-.855a.758.758 0 0 0-.254.302A1.46 1.46 0 0 0 1 4.01V10c0 .325.078.502.145.602.07.105.17.188.302.254a1.464 1.464 0 0 0 .538.143L2.01 11H14c.325 0 .502-.078.602-.145a.758.758 0 0 0 .254-.302 1.464 1.464 0 0 0 .143-.538L15 9.99V4c0-.325-.078-.502-.145-.602a.757.757 0 0 0-.302-.254A1.46 1.46 0 0 0 13.99 3H2c-.325 0-.502.078-.602.145Z" />
+      ) : (
+        <path d="M6 12c0 .667-.083 1.167-.25 1.5H5a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-.75c-.167-.333-.25-.833-.25-1.5h4c2 0 2-2 2-2V4c0-2-2-2-2-2H2C0 2 0 4 0 4v6c0 2 2 2 2 2h4Z" />
+      )}
+    </svg>
+  )
+}
+
+function StatusPill({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode
+  tone?: "neutral" | "active" | "warning"
+}) {
+  return (
+    <span className={`participant-status participant-status--${tone}`}>
+      {children}
+    </span>
+  )
+}
+
 export default function UserCard(user: UserCardProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
-  const videoRef = useRef<HTMLVideoElement>(null)
   const [canScreenShare] = useState(() => {
     if (typeof navigator === "undefined") return false
     const isMobileDevice = /Mobi|Android|iPhone|iPad|iPod/i.test(
@@ -31,257 +73,122 @@ export default function UserCard(user: UserCardProps) {
     return typeof navigator.mediaDevices?.getDisplayMedia === "function"
   })
 
-  const enterFullscreen = () => {
-    const v = videoRef.current
-    if (!v) return
-    if (v.requestFullscreen) {
-      v.requestFullscreen()
-    } else if ((v as any).webkitEnterFullscreen) {
-      ;(v as any).webkitEnterFullscreen()
-    }
-  }
-
   useEffect(() => {
     if (audioRef.current) {
       audioRef.current.srcObject = user.audioStream ?? null
     }
   }, [user.audioStream])
 
-  useEffect(() => {
-    if (videoRef.current) {
-      videoRef.current.srcObject = user.screenShareStream ?? null
-    }
-  }, [user.screenShareStream])
-
   const isSelf = user.peerId === LOCAL_PEER_ID
-  const displayName = isSelf ? user.name + " (ME)" : user.name
+  const displayName = isSelf ? `${user.name} (ME)` : user.name
+  const accent = participantAccent(user.name)
+  const style = { "--participant-accent": accent } as CSSProperties
+  const visibleCapabilities = (user.capabilities ?? []).slice(
+    0,
+    user.compact ? 2 : 3
+  )
+  const extraCapabilities = Math.max(
+    0,
+    (user.capabilities?.length ?? 0) - visibleCapabilities.length
+  )
 
-  if (user.compact) {
-    return (
-      <div className={user.className}>
-        <div
-          className="flex flex-col items-center rounded-xl border border-gray-700 px-2 py-2"
-          style={{ backgroundColor: strToBgColor(user.name) }}
-        >
-          <div className="relative">
-            <Avatar size={36} variant="beam" name={user.name} />
-            {user.muteState && (
-              <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
-                <svg
-                  className="h-2.5 w-2.5 text-red-400"
-                  fill="currentColor"
-                  viewBox="0 0 16 16"
-                >
-                  <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3z" />
-                  <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
-                </svg>
+  return (
+    <div className={`${user.className ?? ""} min-w-0`}>
+      <article
+        data-testid="participant-card"
+        data-peer-id={user.peerId}
+        data-participant-kind={user.kind}
+        className={`participant-card ${
+          user.compact ? "participant-card--compact" : ""
+        }`}
+        style={style}
+      >
+        <div className="participant-card__main">
+          <div className="participant-card__avatar-wrap">
+            <AudioVisualizer
+              audio={user.audioStream}
+              name={user.name}
+              muteState={user.muteState}
+            />
+            <ParticipantAvatar
+              name={user.name}
+              kind={user.kind}
+              size={user.compact ? "compact" : "full"}
+              muted={Boolean(user.muteState)}
+            />
+
+            {!isSelf && user.muteState && (
+              <span className="participant-card__corner participant-card__corner--mute">
+                <MicIcon muted />
               </span>
             )}
             {user.screenShareEnabled && (
-              <span className="absolute -bottom-1 -left-1 rounded-full bg-gray-900 p-0.5">
-                <svg
-                  className="h-2.5 w-2.5 text-green-400"
-                  fill="currentColor"
-                  viewBox="0 0 16 16"
-                >
-                  <path d="M0 4s0-2 2-2h12s2 0 2 2v6s0 2-2 2h-4c0 .667.083 1.167.25 1.5H11a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1h.75c.167-.333.25-.833.25-1.5H2s-2 0-2-2V4z" />
-                </svg>
-              </span>
-            )}
-          </div>
-          <p className="mt-1.5 w-full truncate text-center text-xs text-white">
-            {displayName}
-          </p>
-          {user.kind === "agent" && (
-            <span className="mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
-              🤖 Agent
-            </span>
-          )}
-          {user.kind === "agent" && (
-            <button
-              type="button"
-              onClick={user.onToggleAgentVoice}
-              disabled={!user.voiceAvailable}
-              title={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
-                  ? `Mute ${user.name}`
-                  : `Enable voice for ${user.name}`
-              }
-              aria-label={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
-                  ? `Mute ${user.name}`
-                  : `Enable voice for ${user.name}`
-              }
-              className="mt-1 min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {user.voiceEnabled ? "🔊" : "🔇"}
-            </button>
-          )}
-          {(user.capabilities ?? []).slice(0, 2).map((capability) => (
-            <span
-              key={capability}
-              title={capability}
-              className="mt-1 max-w-[64px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[8px] text-white/70"
-            >
-              {capability}
-            </span>
-          ))}
-          {isSelf && (
-            <div className="mt-1 flex gap-1">
-              <button
-                className="opacity-50 transition-opacity hover:opacity-80"
-                onClick={user.onMuteSelf}
-              >
-                {!user.muteState ? (
-                  <svg
-                    fill="currentColor"
-                    height="12"
-                    viewBox="0 0 16 16"
-                    width="12"
-                  >
-                    <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z" />
-                    <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0v5zM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3z" />
-                  </svg>
-                ) : (
-                  <svg
-                    fill="currentColor"
-                    height="12"
-                    viewBox="0 0 16 16"
-                    width="12"
-                  >
-                    <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3z" />
-                    <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
-                  </svg>
-                )}
-              </button>
-              {canScreenShare && user.screenshareAllowed && (
-                <button
-                  className="opacity-50 transition-opacity hover:opacity-80"
-                  onClick={user.onToggleScreenShare}
-                >
-                  <svg
-                    fill="currentColor"
-                    height="12"
-                    viewBox="0 0 16 16"
-                    width="12"
-                  >
-                    <path d="M0 4s0-2 2-2h12s2 0 2 2v6s0 2-2 2h-4c0 .667.083 1.167.25 1.5H11a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1h.75c.167-.333.25-.833.25-1.5H2s-2 0-2-2V4z" />
-                  </svg>
-                </button>
-              )}
-            </div>
-          )}
-          <audio ref={audioRef} autoPlay={!isSelf} muted={isSelf} />
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className={user.className}>
-      <div
-        className="flex min-h-[196px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3"
-        style={{ backgroundColor: strToBgColor(user.name) }}
-      >
-        <div className="flex flex-1 flex-col items-center justify-center gap-2">
-          <div className="relative">
-            <Avatar size={56} variant="beam" name={user.name} />
-            {!isSelf && user.muteState && (
-              <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
-                <svg
-                  className="h-3 w-3 text-red-400"
-                  fill="currentColor"
-                  viewBox="0 0 16 16"
-                >
-                  <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3z" />
-                  <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
-                </svg>
+              <span className="participant-card__corner participant-card__corner--share">
+                <ScreenIcon active />
               </span>
             )}
             {isSelf && (
               <button
-                className="absolute -bottom-1 -left-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
+                type="button"
+                className={`participant-card__corner participant-card__corner--self ${
+                  user.muteState ? "is-muted" : ""
+                }`}
                 onClick={user.onMuteSelf}
                 title={user.muteState ? "Unmute" : "Mute"}
+                aria-label={user.muteState ? "Unmute" : "Mute"}
               >
-                {!user.muteState ? (
-                  <svg
-                    className="h-3 w-3 text-white"
-                    fill="currentColor"
-                    viewBox="0 0 16 16"
-                  >
-                    <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z" />
-                    <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0v5zM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3z" />
-                  </svg>
-                ) : (
-                  <svg
-                    className="h-3 w-3 text-red-400"
-                    fill="currentColor"
-                    viewBox="0 0 16 16"
-                  >
-                    <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3z" />
-                    <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
-                  </svg>
-                )}
+                <MicIcon muted={Boolean(user.muteState)} />
               </button>
             )}
             {isSelf && canScreenShare && user.screenshareAllowed && (
               <button
-                className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
+                type="button"
+                className={`participant-card__corner participant-card__corner--screen ${
+                  user.screenShareEnabled ? "is-active" : ""
+                }`}
                 onClick={user.onToggleScreenShare}
-                title="Screen share"
+                title={
+                  user.screenShareEnabled ? "Stop sharing" : "Share screen"
+                }
+                aria-label={
+                  user.screenShareEnabled ? "Stop sharing" : "Share screen"
+                }
               >
-                <svg
-                  className={`h-3 w-3 ${
-                    user.screenShareEnabled ? "text-green-400" : "text-white"
-                  }`}
-                  fill="currentColor"
-                  viewBox="0 0 16 16"
-                >
-                  {user.screenShareEnabled ? (
-                    <path d="M0 4s0-2 2-2h12s2 0 2 2v6s0 2-2 2h-4c0 .667.083 1.167.25 1.5H11a.5.5 0 0 1 0 1H5a.5.5 0 0 1 0-1h.75c.167-.333.25-.833.25-1.5H2s-2 0-2-2V4zm1.398-.855a.758.758 0 0 0-.254.302A1.46 1.46 0 0 0 1 4.01V10c0 .325.078.502.145.602.07.105.17.188.302.254a1.464 1.464 0 0 0 .538.143L2.01 11H14c.325 0 .502-.078.602-.145a.758.758 0 0 0 .254-.302 1.464 1.464 0 0 0 .143-.538L15 9.99V4c0-.325-.078-.502-.145-.602a.757.757 0 0 0-.302-.254A1.46 1.46 0 0 0 13.99 3H2c-.325 0-.502.078-.602.145z" />
-                  ) : (
-                    <path d="M6 12c0 .667-.083 1.167-.25 1.5H5a.5.5 0 0 0 0 1h6a.5.5 0 0 0 0-1h-.75C10.083 13.167 10 12.667 10 12h4c2 0 2-2 2-2V4c0-2-2-2-2-2H2C0 2 0 4 0 4v6c0 2 2 2 2 2h4z" />
-                  )}
-                </svg>
+                <ScreenIcon active={Boolean(user.screenShareEnabled)} />
               </button>
             )}
           </div>
 
-          <p
-            className="w-full break-words text-center text-xs leading-tight text-white"
-            title={displayName}
-          >
-            {isSelf ? user.name : displayName}
-            {isSelf && (
-              <span className="ml-1 rounded bg-black/30 px-1 py-0.5 text-[10px] text-white/70">
-                ME
-              </span>
-            )}
+          <p className="participant-card__name" title={displayName}>
+            {user.name}
+            {isSelf && <span className="participant-card__me">ME</span>}
           </p>
+
+          <div className="participant-card__status-row">
+            <StatusPill>
+              {user.kind === "agent" ? "🤖 Agent" : "Human"}
+            </StatusPill>
+            {user.screenShareEnabled && (
+              <StatusPill tone="active">Sharing</StatusPill>
+            )}
+            {user.kind === "agent" && user.voiceEnabled && (
+              <StatusPill tone="active">Voice</StatusPill>
+            )}
+          </div>
         </div>
 
-        <div className="mb-1 flex min-h-[18px] flex-wrap items-center justify-center gap-1">
-          <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
-            {user.kind === "agent" ? "🤖 Agent" : "Human"}
-          </span>
-          {(user.capabilities ?? []).slice(0, 3).map((capability) => (
+        <div className="participant-card__details">
+          {visibleCapabilities.map((capability) => (
             <span
               key={capability}
               title={capability}
-              className="max-w-[72px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70"
+              className="participant-capability"
             >
               {capability}
             </span>
           ))}
-          {(user.capabilities?.length ?? 0) > 3 && (
-            <span className="rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70">
-              +{(user.capabilities?.length ?? 0) - 3}
-            </span>
+          {extraCapabilities > 0 && (
+            <span className="participant-capability">+{extraCapabilities}</span>
           )}
           {user.kind === "agent" && (
             <button
@@ -302,21 +209,15 @@ export default function UserCard(user: UserCardProps) {
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
-              className="min-h-7 rounded-full border border-gray-500 px-2 text-[10px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="participant-voice-button"
             >
-              {user.voiceEnabled ? "🔊 Voice" : "🔇 Voice"}
+              {user.voiceEnabled ? "◉ Voice" : "○ Voice"}
             </button>
           )}
         </div>
 
         <audio ref={audioRef} autoPlay={!isSelf} muted={isSelf} />
-
-        <AudioVisualizer
-          audio={user.audioStream}
-          name={user.name}
-          muteState={user.muteState}
-        />
-      </div>
+      </article>
     </div>
   )
 }

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -12,6 +12,8 @@ interface UserCardProps extends UserInfo {
   onToggleScreenShare?: () => void
   screenshareAllowed?: boolean
   compact?: boolean
+  /** Presentation-only constellation node mode for small Rooms. */
+  node?: boolean
   /** Room-wide publish authorization for this eligible Agent only. */
   voiceAvailable?: boolean
   voiceEnabled?: boolean
@@ -83,14 +85,6 @@ export default function UserCard(user: UserCardProps) {
   const displayName = isSelf ? `${user.name} (ME)` : user.name
   const accent = participantAccent(user.name)
   const style = { "--participant-accent": accent } as CSSProperties
-  const visibleCapabilities = (user.capabilities ?? []).slice(
-    0,
-    user.compact ? 2 : 3
-  )
-  const extraCapabilities = Math.max(
-    0,
-    (user.capabilities?.length ?? 0) - visibleCapabilities.length
-  )
 
   return (
     <div className={`${user.className ?? ""} min-w-0`}>
@@ -100,7 +94,7 @@ export default function UserCard(user: UserCardProps) {
         data-participant-kind={user.kind}
         className={`participant-card ${
           user.compact ? "participant-card--compact" : ""
-        }`}
+        } ${user.node ? "participant-card--node" : ""}`}
         style={style}
       >
         <div className="participant-card__main">
@@ -174,23 +168,12 @@ export default function UserCard(user: UserCardProps) {
             {user.kind === "agent" && user.voiceEnabled && (
               <StatusPill tone="active">Voice</StatusPill>
             )}
+            {user.muteState && <StatusPill tone="warning">Muted</StatusPill>}
           </div>
         </div>
 
-        <div className="participant-card__details">
-          {visibleCapabilities.map((capability) => (
-            <span
-              key={capability}
-              title={capability}
-              className="participant-capability"
-            >
-              {capability}
-            </span>
-          ))}
-          {extraCapabilities > 0 && (
-            <span className="participant-capability">+{extraCapabilities}</span>
-          )}
-          {user.kind === "agent" && (
+        {user.kind === "agent" && (
+          <div className="participant-card__details">
             <button
               type="button"
               onClick={user.onToggleAgentVoice}
@@ -209,12 +192,14 @@ export default function UserCard(user: UserCardProps) {
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
-              className="participant-voice-button"
+              className={`participant-voice-button ${
+                user.voiceEnabled ? "is-enabled" : ""
+              }`}
             >
               {user.voiceEnabled ? "◉ Voice" : "○ Voice"}
             </button>
-          )}
-        </div>
+          </div>
+        )}
 
         <audio ref={audioRef} autoPlay={!isSelf} muted={isSelf} />
       </article>

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -91,6 +91,10 @@ describe("participant card equal-height contract (#228)", () => {
     // The grid top-aligns rows; no full-panel-height stretching remains.
     const grid = document.querySelector(".room-participants-grid")
     expect(grid).toBeTruthy()
+    expect(grid).toHaveClass("room-participants-grid--constellation")
+    expect(
+      cards.every((card) => card.className.includes("participant-card--node"))
+    ).toBe(true)
     expect(document.querySelector(".items-stretch")).toBeNull()
   })
 })

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 /**
  * #228/#234 participant-card visual consistency: in the NORMAL participant
- * grid, every UserCard root carries the same compact presentation contract, so
+ * band, every UserCard root carries the same compact presentation contract, so
  * Agent-only controls (Voice) live inside the same bounded card surface as
  * Human presence. jsdom cannot measure layout; this pins the semantic card
  * marker and grid contract. Visual confirmation happens in the production
@@ -54,7 +54,7 @@ function hookReturn(participants: Array<Record<string, unknown>>) {
   }
 }
 
-describe("participant card equal-height contract (#228)", () => {
+describe("participant card presentation contract (#228)", () => {
   afterEach(cleanup)
 
   beforeEach(() => {
@@ -88,10 +88,12 @@ describe("participant card equal-height contract (#228)", () => {
       cards.every((card) => card.className.includes("participant-card"))
     ).toBe(true)
 
-    // The grid top-aligns rows; no full-panel-height stretching remains.
+    // A normal Room keeps presence in a bounded band; chat owns the remaining
+    // viewport rather than sharing a full-height split panel.
     const grid = document.querySelector(".room-participants-grid")
     expect(grid).toBeTruthy()
-    expect(grid).toHaveClass("room-participants-grid--constellation")
+    expect(grid).toHaveClass("room-participants-grid--band")
+    expect(grid).toHaveClass("room-participants-grid--node-band")
     expect(
       cards.every((card) => card.className.includes("participant-card--node"))
     ).toBe(true)

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -2,12 +2,11 @@ import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 /**
  * #228/#234 participant-card visual consistency: in the NORMAL participant
- * grid, every UserCard root carries the SAME uniform min-height contract, so
- * Agent-only controls (Voice) live inside a shared reserved card height
- * instead of stretching Agent cards taller than Human cards.
- * jsdom cannot measure layout; this pins the class contract that produces
- * equal heights (uniform min-height on every normal card root). Visual
- * confirmation happens in the production regression pass.
+ * grid, every UserCard root carries the same compact presentation contract, so
+ * Agent-only controls (Voice) live inside the same bounded card surface as
+ * Human presence. jsdom cannot measure layout; this pins the semantic card
+ * marker and grid contract. Visual confirmation happens in the production
+ * regression pass.
  */
 
 vi.mock("next/router", () => ({
@@ -62,7 +61,7 @@ describe("participant card equal-height contract (#228)", () => {
     Element.prototype.scrollIntoView = vi.fn()
   })
 
-  it("normal-grid participant cards share the stretch/height contract regardless of kind", () => {
+  it("normal-grid participant cards share the bounded presentation contract regardless of kind", () => {
     mockUseSfuChatRoom.mockReturnValue(
       hookReturn([
         { peerId: LOCAL, name: "Hannah", kind: "human", room: "test-room" },
@@ -79,17 +78,19 @@ describe("participant card equal-height contract (#228)", () => {
       <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
     )
 
-    // Every normal-grid participant card root carries the SAME uniform
-    // min-height — Human self, Agents with controls, remote Humans.
+    // Every normal-grid participant card root carries the same semantic marker
+    // — Human self, Agents with controls, and remote Humans.
     const cards = Array.from(
-      document.querySelectorAll("div.rounded-xl.border-gray-700")
-    ).filter((el) => el.className.includes("min-h-[196px]"))
+      document.querySelectorAll('[data-testid="participant-card"]')
+    )
     expect(cards.length).toBe(3)
+    expect(
+      cards.every((card) => card.className.includes("participant-card"))
+    ).toBe(true)
 
     // The grid top-aligns rows; no full-panel-height stretching remains.
-    const grid = document.querySelector(".flex-wrap.items-start")
+    const grid = document.querySelector(".room-participants-grid")
     expect(grid).toBeTruthy()
-    expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
-    expect(document.querySelectorAll("[data-peer]").length).toBe(0)
+    expect(document.querySelector(".items-stretch")).toBeNull()
   })
 })

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -82,3 +82,550 @@ html {
     animation: none;
   }
 }
+
+/* --- Temporary Room surface --- */
+
+.room-shell {
+  background-color: #030712;
+  background-image: radial-gradient(
+      circle at 15% 10%,
+      rgba(34, 211, 238, 0.1),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 90% 20%,
+      rgba(168, 85, 247, 0.08),
+      transparent 28%
+    ),
+    linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px);
+  background-size: auto, auto, 36px 36px, 36px 36px;
+}
+
+.room-header {
+  background: rgba(3, 7, 18, 0.86);
+  border-color: rgba(71, 85, 105, 0.72);
+  box-shadow: 0 1px 0 rgba(34, 211, 238, 0.07);
+}
+
+.room-panel {
+  background: rgba(2, 6, 23, 0.44);
+}
+
+.room-share-viewer {
+  background: #01030a;
+  background-image: linear-gradient(
+      90deg,
+      rgba(34, 211, 238, 0.08) 1px,
+      transparent 1px
+    ),
+    linear-gradient(rgba(34, 211, 238, 0.05) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.room-share-viewer::before {
+  position: absolute;
+  inset: 0.55rem;
+  border: 1px solid rgba(34, 211, 238, 0.24);
+  border-radius: 0.65rem;
+  box-shadow: inset 0 0 28px rgba(34, 211, 238, 0.045);
+  content: "";
+  pointer-events: none;
+}
+
+.room-share-viewer__label,
+.room-share-viewer__fullscreen {
+  z-index: 1;
+  border: 1px solid rgba(71, 85, 105, 0.72);
+  background: rgba(2, 6, 23, 0.84);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.room-share-viewer__label {
+  left: 1rem;
+  bottom: 1rem;
+  color: #cbd5e1;
+  font-size: 0.65rem;
+  letter-spacing: 0.03em;
+}
+
+.room-share-viewer__fullscreen {
+  right: 1rem;
+  bottom: 1rem;
+}
+
+.room-participant-strip {
+  background: rgba(2, 6, 23, 0.56);
+}
+
+/* --- Participant node cards --- */
+
+.participant-card {
+  position: relative;
+  display: flex;
+  min-height: 164px;
+  width: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--participant-accent) 38%, #334155);
+  border-radius: 0.8rem;
+  background: linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--participant-accent) 8%, transparent),
+      transparent 48%
+    ),
+    rgba(2, 6, 23, 0.88);
+  padding: 0.7rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035),
+    0 12px 28px rgba(0, 0, 0, 0.12);
+  transition: border-color 160ms ease, box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.participant-card::before {
+  position: absolute;
+  top: 0.45rem;
+  left: 0.45rem;
+  width: 1.15rem;
+  height: 0.35rem;
+  border-top: 1px solid var(--participant-accent);
+  border-left: 1px solid var(--participant-accent);
+  content: "";
+  opacity: 0.75;
+}
+
+.participant-card::after {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 0.45rem;
+  width: 1.15rem;
+  height: 0.35rem;
+  border-right: 1px solid var(--participant-accent);
+  border-bottom: 1px solid var(--participant-accent);
+  content: "";
+  opacity: 0.42;
+}
+
+.participant-card:hover {
+  border-color: color-mix(in srgb, var(--participant-accent) 72%, #64748b);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 0 22px color-mix(in srgb, var(--participant-accent) 12%, transparent);
+  transform: translateY(-1px);
+}
+
+.participant-card--compact {
+  min-height: 94px;
+  border-radius: 0.65rem;
+  padding: 0.45rem;
+}
+
+.participant-card__main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.24rem;
+}
+
+.participant-card__avatar-wrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 5.1rem;
+  height: 5.1rem;
+}
+
+.participant-card--compact .participant-card__avatar-wrap {
+  width: 3rem;
+  height: 3rem;
+}
+
+.participant-card__name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.participant-card--compact .participant-card__name {
+  font-size: 0.65rem;
+}
+
+.participant-card__me {
+  margin-left: 0.25rem;
+  border: 1px solid rgba(103, 232, 249, 0.36);
+  border-radius: 999px;
+  padding: 0.08rem 0.28rem;
+  color: #67e8f9;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.52rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  vertical-align: middle;
+}
+
+.participant-card__status-row,
+.participant-card__details {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.participant-card__status-row {
+  min-height: 1.1rem;
+}
+
+.participant-status {
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  padding: 0.14rem 0.38rem;
+  color: #cbd5e1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.54rem;
+  line-height: 1;
+}
+
+.participant-status--active {
+  border-color: color-mix(in srgb, var(--participant-accent) 68%, #475569);
+  color: var(--participant-accent);
+}
+
+.participant-status--warning {
+  border-color: rgba(251, 191, 36, 0.5);
+  color: #fcd34d;
+}
+
+.participant-capability {
+  max-width: 4.7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  padding: 0.16rem 0.38rem;
+  color: #94a3b8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.52rem;
+  line-height: 1;
+}
+
+.participant-voice-button {
+  min-height: 1.45rem;
+  border: 1px solid color-mix(in srgb, var(--participant-accent) 42%, #475569);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.72);
+  padding: 0.18rem 0.45rem;
+  color: #cbd5e1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.54rem;
+  line-height: 1;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.participant-voice-button:hover:not(:disabled) {
+  border-color: var(--participant-accent);
+  background: color-mix(in srgb, var(--participant-accent) 16%, #0f172a);
+  color: #f8fafc;
+}
+
+.participant-voice-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.participant-card__corner {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  width: 1.35rem;
+  height: 1.35rem;
+  place-items: center;
+  border: 1px solid rgba(15, 23, 42, 0.9);
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.92);
+  color: #94a3b8;
+}
+
+.participant-card__corner svg {
+  width: 0.72rem;
+  height: 0.72rem;
+}
+
+.participant-card__corner--mute {
+  right: -0.15rem;
+  bottom: -0.05rem;
+  color: #fb7185;
+}
+
+.participant-card__corner--share {
+  bottom: -0.05rem;
+  left: -0.15rem;
+  color: #bef264;
+}
+
+.participant-card__corner--self {
+  bottom: -0.05rem;
+  left: -0.15rem;
+  cursor: pointer;
+}
+
+.participant-card__corner--self:hover,
+.participant-card__corner--screen:hover,
+.participant-card__corner--self.is-muted {
+  color: #f8fafc;
+}
+
+.participant-card__corner--screen {
+  right: -0.15rem;
+  bottom: -0.05rem;
+  cursor: pointer;
+}
+
+.participant-card__corner--screen.is-active {
+  color: #bef264;
+}
+
+/* Deterministic local planet/orb avatar shared by Humans and Agents. */
+
+.participant-avatar {
+  position: relative;
+  z-index: 1;
+  width: 4.1rem;
+  height: 4.1rem;
+  color: var(--participant-accent);
+}
+
+.participant-avatar--compact {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.participant-avatar__orb {
+  position: absolute;
+  inset: 0.42rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--participant-accent) 84%, #fff);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--participant-accent) 16%, #020617);
+  box-shadow: 0 0 14px
+      color-mix(in srgb, var(--participant-accent) 46%, transparent),
+    inset 0 0 12px rgba(255, 255, 255, 0.12);
+}
+
+.participant-avatar__orb svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.participant-avatar__orbit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 38%;
+  border: 1px solid
+    color-mix(in srgb, var(--participant-accent) 70%, transparent);
+  border-radius: 50%;
+  transform: translate(-50%, -50%) rotate(-22deg);
+  opacity: 0.78;
+}
+
+.participant-avatar__orbit--two {
+  width: 78%;
+  height: 28%;
+  transform: translate(-50%, -50%) rotate(54deg);
+  opacity: 0.36;
+}
+
+.participant-avatar--compact .participant-avatar__orbit {
+  width: 112%;
+}
+
+.participant-avatar__status {
+  position: absolute;
+  top: 0.24rem;
+  left: 0.34rem;
+  width: 0.4rem;
+  height: 0.4rem;
+  border: 1px solid #020617;
+  border-radius: 50%;
+  background: #bef264;
+  box-shadow: 0 0 8px rgba(190, 242, 100, 0.78);
+}
+
+.participant-avatar__status.is-muted {
+  background: #fb7185;
+  box-shadow: 0 0 8px rgba(251, 113, 133, 0.58);
+}
+
+.participant-avatar__kind {
+  position: absolute;
+  right: 0.12rem;
+  bottom: 0.1rem;
+  display: grid;
+  width: 1rem;
+  height: 1rem;
+  place-items: center;
+  border: 1px solid #020617;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--participant-accent) 78%, #020617);
+  color: #020617;
+}
+
+.participant-avatar__kind svg {
+  width: 0.68rem;
+  height: 0.68rem;
+}
+
+.participant-avatar--compact .participant-avatar__kind {
+  right: -0.08rem;
+  bottom: -0.05rem;
+  width: 0.72rem;
+  height: 0.72rem;
+}
+
+.participant-avatar--compact .participant-avatar__kind svg {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+/* Local analyser output is deliberately a light signal around the node, not
+   a fixed waveform or a Room-level audio meter. */
+
+.participant-signal {
+  position: absolute;
+  z-index: 0;
+  inset: -0.28rem;
+  pointer-events: none;
+}
+
+.participant-signal__ring,
+.participant-signal__dot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.participant-signal__ring {
+  width: 78%;
+  height: 78%;
+  border: 1px solid var(--participant-accent);
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.participant-signal__ring--outer {
+  width: 100%;
+  height: 100%;
+  border-width: 1px;
+  box-shadow: 0 0 12px
+    color-mix(in srgb, var(--participant-accent) 44%, transparent);
+}
+
+.participant-signal__ring--inner {
+  border-style: dashed;
+  opacity: 0;
+}
+
+.participant-signal[data-speaking="true"] .participant-signal__ring {
+  opacity: calc(0.16 + var(--audio-level, 0) * 0.72);
+  transform: translate(-50%, -50%) scale(calc(1 + var(--audio-level, 0) * 0.12));
+}
+
+.participant-signal[data-speaking="true"] .participant-signal__ring--inner {
+  animation: participant-signal-spin 4s linear infinite;
+}
+
+.participant-signal[data-speaking="true"]
+  .participant-signal__ring--outer.is-strong {
+  animation: participant-signal-pulse 1.2s ease-in-out infinite;
+}
+
+.participant-signal__dot {
+  width: 0.25rem;
+  height: 0.25rem;
+  background: var(--participant-accent);
+  box-shadow: 0 0 8px var(--participant-accent);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.participant-signal[data-speaking="true"] .participant-signal__dot {
+  opacity: 0.9;
+}
+
+@keyframes participant-signal-spin {
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+@keyframes participant-signal-pulse {
+  50% {
+    opacity: 0.72;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .participant-card,
+  .participant-signal__ring,
+  .participant-signal__dot {
+    transition: none;
+  }
+
+  .participant-signal[data-speaking="true"] .participant-signal__ring {
+    animation: none;
+  }
+}
+
+@media (max-width: 639px) {
+  .participant-card:not(.participant-card--compact) {
+    height: 112px;
+    min-height: 112px;
+    padding: 0.55rem;
+  }
+
+  .participant-card:not(.participant-card--compact)
+    .participant-card__avatar-wrap {
+    width: 2.8rem;
+    height: 2.8rem;
+  }
+
+  .participant-card:not(.participant-card--compact) .participant-avatar {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+
+  .participant-card:not(.participant-card--compact) .participant-capability {
+    max-width: 4.1rem;
+  }
+
+  .participant-card:not(.participant-card--compact)
+    .participant-capability
+    ~ .participant-capability {
+    display: none;
+  }
+
+  .participant-card:not(.participant-card--compact) .participant-card__details {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    gap: 0.16rem;
+  }
+}

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -221,76 +221,69 @@ html {
   background: rgba(2, 6, 23, 0.56);
 }
 
-.room-participants-grid--constellation {
-  position: relative;
-  display: grid;
-  flex: 1;
-  min-height: 0;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(7.5rem, 1fr));
-  align-content: center;
-  justify-items: center;
-  gap: 0;
-  overflow: hidden;
+.room-content--stacked {
+  flex-direction: column;
 }
 
-.room-participants-grid--constellation::before,
-.room-participants-grid--constellation::after {
+.room-content--stacked > .room-panel:first-child {
+  width: 100%;
+}
+
+.room-content--stacked > .room-panel:last-child {
+  min-height: 0;
+}
+
+/* Normal Rooms use a short presence band. The conversation remains the
+   dominant surface below it; this is intentionally not a full-height map. */
+.room-participants-grid--band {
+  position: relative;
+  z-index: 0;
+  flex: none;
+  min-height: 0;
+  height: clamp(11.25rem, 24vh, 13.75rem);
+  align-items: center;
+  padding-inline: clamp(1rem, 5vw, 5rem);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.room-participants-grid--band::before {
   position: absolute;
   top: 50%;
-  left: 50%;
-  border: 1px solid rgba(103, 232, 249, 0.14);
+  left: 12%;
+  width: 76%;
+  height: 34%;
+  border: 1px solid rgba(103, 232, 249, 0.07);
   border-radius: 50%;
   content: "";
   pointer-events: none;
-  transform: translate(-50%, -50%) rotate(-13deg);
+  transform: translateY(-50%) rotate(-2deg);
 }
 
-.room-participants-grid--constellation::before {
-  width: 72%;
-  height: 46%;
+.room-participants-grid--node-band {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: center;
+  gap: 0.25rem clamp(1.25rem, 5vw, 5rem);
 }
 
-.room-participants-grid--constellation::after {
-  width: 43%;
-  height: 82%;
-  border-color: rgba(196, 181, 253, 0.1);
-  transform: translate(-50%, -50%) rotate(38deg);
-}
-
-.room-participants-grid--constellation > div {
+.room-participants-grid--node-band > div {
   z-index: 1;
-  width: clamp(7.5rem, 18vw, 10rem);
+  width: clamp(5.75rem, 11vw, 7.5rem);
+  flex: 0 1 clamp(5.75rem, 11vw, 7.5rem);
 }
 
-.room-participants-grid--constellation > div:nth-child(1) {
-  grid-column: 2;
-  grid-row: 3;
+.room-participants-grid--card-band {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  align-content: start;
+  overflow-y: auto;
 }
 
-.room-participants-grid--constellation > div:nth-child(2) {
-  grid-column: 2;
-  grid-row: 1;
-}
-
-.room-participants-grid--constellation > div:nth-child(3) {
-  grid-column: 3;
-  grid-row: 2;
-}
-
-.room-participants-grid--constellation > div:nth-child(4) {
-  grid-column: 1;
-  grid-row: 2;
-}
-
-.room-participants-grid--constellation > div:nth-child(5) {
-  grid-column: 3;
-  grid-row: 1;
-}
-
-.room-participants-grid--constellation > div:nth-child(6) {
-  grid-column: 1;
-  grid-row: 1;
+.room-participants-grid--card-band > div {
+  min-width: 0;
 }
 
 /* --- Participant node cards --- */
@@ -802,30 +795,33 @@ html {
 }
 
 @media (max-width: 639px) {
-  .room-participants-grid--constellation {
+  .room-participants-grid--node-band {
     display: flex;
     flex: none;
-    height: auto;
-    min-height: 8.5rem;
+    height: 7.25rem;
+    min-height: 7.25rem;
     align-items: center;
-    gap: 0.1rem;
+    justify-content: flex-start;
+    gap: 0.25rem;
     overflow-x: auto;
     overflow-y: hidden;
+    padding-inline: 1rem;
   }
 
-  .room-participants-grid--constellation::before,
-  .room-participants-grid--constellation::after {
+  .room-participants-grid--node-band::before {
     display: none;
   }
 
-  .room-participants-grid--constellation > div {
+  .room-participants-grid--node-band > div {
     width: 4.5rem;
     flex: none;
   }
 
-  .room-participants-grid--constellation > div:nth-child(n) {
-    grid-column: auto;
-    grid-row: auto;
+  .room-participants-grid--card-band {
+    height: 9.5rem;
+    min-height: 9.5rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    overflow-y: auto;
   }
 
   .participant-card--node {
@@ -860,7 +856,6 @@ html {
   }
 
   .participant-card:not(.participant-card--compact) {
-    min-height: 112px;
     padding: 0.55rem;
   }
 
@@ -879,15 +874,5 @@ html {
     flex-wrap: nowrap;
     overflow: hidden;
     gap: 0.16rem;
-  }
-
-  .participant-card--node:not(.participant-card--compact) {
-    min-height: 5.5rem;
-  }
-}
-
-@media (min-width: 640px) {
-  .room-participants-grid:not(.room-participants-grid--constellation) {
-    grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
   }
 }

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -86,20 +86,83 @@ html {
 /* --- Temporary Room surface --- */
 
 .room-shell {
+  position: relative;
+  isolation: isolate;
   background-color: #030712;
   background-image: radial-gradient(
-      circle at 15% 10%,
-      rgba(34, 211, 238, 0.1),
-      transparent 30%
+      circle at 14% 18%,
+      rgba(34, 211, 238, 0.1) 0,
+      transparent 25%
     ),
     radial-gradient(
-      circle at 90% 20%,
-      rgba(168, 85, 247, 0.08),
-      transparent 28%
+      circle at 78% 22%,
+      rgba(168, 85, 247, 0.1) 0,
+      transparent 26%
     ),
-    linear-gradient(rgba(34, 211, 238, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(34, 211, 238, 0.035) 1px, transparent 1px);
-  background-size: auto, auto, 36px 36px, 36px 36px;
+    radial-gradient(
+      circle at 58% 78%,
+      rgba(190, 242, 100, 0.045) 0,
+      transparent 22%
+    ),
+    radial-gradient(
+      circle at 8% 74%,
+      rgba(251, 113, 133, 0.05) 0,
+      transparent 18%
+    ),
+    radial-gradient(
+      circle at 12% 14%,
+      rgba(226, 232, 240, 0.65) 0 1px,
+      transparent 1.5px
+    ),
+    radial-gradient(
+      circle at 36% 32%,
+      rgba(103, 232, 249, 0.55) 0 1px,
+      transparent 1.5px
+    ),
+    radial-gradient(
+      circle at 68% 12%,
+      rgba(226, 232, 240, 0.5) 0 1px,
+      transparent 1.5px
+    ),
+    radial-gradient(
+      circle at 86% 48%,
+      rgba(196, 181, 253, 0.5) 0 1px,
+      transparent 1.5px
+    ),
+    radial-gradient(
+      circle at 64% 86%,
+      rgba(226, 232, 240, 0.42) 0 1px,
+      transparent 1.5px
+    ),
+    linear-gradient(rgba(34, 211, 238, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(34, 211, 238, 0.018) 1px, transparent 1px);
+  background-size: auto, auto, auto, auto, auto, auto, auto, auto, auto,
+    48px 48px, 48px 48px;
+}
+
+.room-shell::after {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  box-shadow: inset 0 0 120px rgba(0, 0, 0, 0.48);
+  content: "";
+  pointer-events: none;
+}
+
+.room-shell::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(148, 163, 184, 0.035) 0,
+    rgba(148, 163, 184, 0.035) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  content: "";
+  pointer-events: none;
 }
 
 .room-header {
@@ -156,6 +219,78 @@ html {
 
 .room-participant-strip {
   background: rgba(2, 6, 23, 0.56);
+}
+
+.room-participants-grid--constellation {
+  position: relative;
+  display: grid;
+  flex: 1;
+  min-height: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(7.5rem, 1fr));
+  align-content: center;
+  justify-items: center;
+  gap: 0;
+  overflow: hidden;
+}
+
+.room-participants-grid--constellation::before,
+.room-participants-grid--constellation::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 1px solid rgba(103, 232, 249, 0.14);
+  border-radius: 50%;
+  content: "";
+  pointer-events: none;
+  transform: translate(-50%, -50%) rotate(-13deg);
+}
+
+.room-participants-grid--constellation::before {
+  width: 72%;
+  height: 46%;
+}
+
+.room-participants-grid--constellation::after {
+  width: 43%;
+  height: 82%;
+  border-color: rgba(196, 181, 253, 0.1);
+  transform: translate(-50%, -50%) rotate(38deg);
+}
+
+.room-participants-grid--constellation > div {
+  z-index: 1;
+  width: clamp(7.5rem, 18vw, 10rem);
+}
+
+.room-participants-grid--constellation > div:nth-child(1) {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+.room-participants-grid--constellation > div:nth-child(2) {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.room-participants-grid--constellation > div:nth-child(3) {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.room-participants-grid--constellation > div:nth-child(4) {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.room-participants-grid--constellation > div:nth-child(5) {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.room-participants-grid--constellation > div:nth-child(6) {
+  grid-column: 1;
+  grid-row: 1;
 }
 
 /* --- Participant node cards --- */
@@ -218,6 +353,64 @@ html {
   min-height: 94px;
   border-radius: 0.65rem;
   padding: 0.45rem;
+}
+
+.participant-card--node {
+  min-height: 0;
+  border-color: transparent;
+  border-radius: 999px;
+  background: transparent;
+  padding: 0.35rem;
+  box-shadow: none;
+}
+
+.participant-card--node::before,
+.participant-card--node::after {
+  display: none;
+}
+
+.participant-card--node:hover {
+  border-color: transparent;
+  background: color-mix(in srgb, var(--participant-accent) 5%, transparent);
+  box-shadow: 0 0 28px
+    color-mix(in srgb, var(--participant-accent) 12%, transparent);
+  transform: none;
+}
+
+.participant-card--node .participant-card__main {
+  gap: 0.38rem;
+}
+
+.participant-card--node .participant-card__name {
+  font-size: 0.78rem;
+}
+
+.participant-card--node .participant-card__status-row {
+  min-height: 0;
+}
+
+.participant-card--node .participant-status {
+  background: transparent;
+}
+
+.participant-card--node .participant-card__details {
+  min-height: 0;
+}
+
+.participant-card--node .participant-voice-button {
+  padding: 0.16rem 0.38rem;
+}
+
+.participant-card--node .participant-voice-button::before {
+  content: "";
+}
+
+.participant-card--node .participant-voice-button.is-enabled::before {
+  content: "◉";
+}
+
+.participant-card--node .participant-voice-button:not(.is-enabled)::before {
+  content: "○";
 }
 
 .participant-card__main {
@@ -414,6 +607,11 @@ html {
   height: 2.25rem;
 }
 
+.participant-avatar.text-chat-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
+}
+
 .participant-avatar__orb {
   position: absolute;
   inset: 0.42rem;
@@ -549,6 +747,14 @@ html {
   transform: translate(-50%, -50%) scale(calc(1 + var(--audio-level, 0) * 0.12));
 }
 
+.participant-signal[data-speaking="true"]
+  + .participant-avatar
+  .participant-avatar__orb {
+  box-shadow: 0 0 calc(14px + var(--audio-level, 0) * 18px)
+      color-mix(in srgb, var(--participant-accent) 62%, transparent),
+    inset 0 0 12px rgba(255, 255, 255, 0.16);
+}
+
 .participant-signal[data-speaking="true"] .participant-signal__ring--inner {
   animation: participant-signal-spin 4s linear infinite;
 }
@@ -596,8 +802,64 @@ html {
 }
 
 @media (max-width: 639px) {
+  .room-participants-grid--constellation {
+    display: flex;
+    flex: none;
+    height: auto;
+    min-height: 8.5rem;
+    align-items: center;
+    gap: 0.1rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .room-participants-grid--constellation::before,
+  .room-participants-grid--constellation::after {
+    display: none;
+  }
+
+  .room-participants-grid--constellation > div {
+    width: 4.5rem;
+    flex: none;
+  }
+
+  .room-participants-grid--constellation > div:nth-child(n) {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .participant-card--node {
+    min-height: 5.5rem;
+    padding: 0.15rem;
+  }
+
+  .participant-card--node .participant-card__main {
+    gap: 0.2rem;
+  }
+
+  .participant-card--node .participant-card__name {
+    font-size: 0.6rem;
+  }
+
+  .participant-card--node .participant-status {
+    padding: 0.1rem 0.2rem;
+    font-size: 0.44rem;
+  }
+
+  .participant-card--node .participant-card__details {
+    position: absolute;
+    right: 0.15rem;
+    bottom: 0.12rem;
+  }
+
+  .participant-card--node .participant-voice-button {
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    font-size: 0;
+  }
+
   .participant-card:not(.participant-card--compact) {
-    height: 112px;
     min-height: 112px;
     padding: 0.55rem;
   }
@@ -613,19 +875,19 @@ html {
     height: 2.2rem;
   }
 
-  .participant-card:not(.participant-card--compact) .participant-capability {
-    max-width: 4.1rem;
-  }
-
-  .participant-card:not(.participant-card--compact)
-    .participant-capability
-    ~ .participant-capability {
-    display: none;
-  }
-
   .participant-card:not(.participant-card--compact) .participant-card__details {
     flex-wrap: nowrap;
     overflow: hidden;
     gap: 0.16rem;
+  }
+
+  .participant-card--node:not(.participant-card--compact) {
+    min-height: 5.5rem;
+  }
+}
+
+@media (min-width: 640px) {
+  .room-participants-grid:not(.room-participants-grid--constellation) {
+    grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
   }
 }

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -266,13 +266,13 @@ html {
   flex-wrap: wrap;
   justify-content: center;
   align-content: center;
-  gap: 0.25rem clamp(1.25rem, 5vw, 5rem);
+  gap: 0.25rem clamp(0.75rem, 3vw, 3rem);
 }
 
 .room-participants-grid--node-band > div {
   z-index: 1;
-  width: clamp(5.75rem, 11vw, 7.5rem);
-  flex: 0 1 clamp(5.75rem, 11vw, 7.5rem);
+  width: clamp(5.25rem, 10vw, 7rem);
+  flex: 0 1 clamp(5.25rem, 10vw, 7rem);
 }
 
 .room-participants-grid--card-band {
@@ -607,92 +607,20 @@ html {
 
 .participant-avatar__orb {
   position: absolute;
-  inset: 0.42rem;
+  inset: 0.32rem;
   overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--participant-accent) 84%, #fff);
+  border: 1px solid color-mix(in srgb, var(--participant-accent) 72%, #fff);
   border-radius: 50%;
   background: color-mix(in srgb, var(--participant-accent) 16%, #020617);
-  box-shadow: 0 0 14px
-      color-mix(in srgb, var(--participant-accent) 46%, transparent),
-    inset 0 0 12px rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 10px
+      color-mix(in srgb, var(--participant-accent) 34%, transparent),
+    inset 0 0 10px rgba(255, 255, 255, 0.1);
 }
 
 .participant-avatar__orb svg {
   display: block;
   width: 100%;
   height: 100%;
-}
-
-.participant-avatar__orbit {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  height: 38%;
-  border: 1px solid
-    color-mix(in srgb, var(--participant-accent) 70%, transparent);
-  border-radius: 50%;
-  transform: translate(-50%, -50%) rotate(-22deg);
-  opacity: 0.78;
-}
-
-.participant-avatar__orbit--two {
-  width: 78%;
-  height: 28%;
-  transform: translate(-50%, -50%) rotate(54deg);
-  opacity: 0.36;
-}
-
-.participant-avatar--compact .participant-avatar__orbit {
-  width: 112%;
-}
-
-.participant-avatar__status {
-  position: absolute;
-  top: 0.24rem;
-  left: 0.34rem;
-  width: 0.4rem;
-  height: 0.4rem;
-  border: 1px solid #020617;
-  border-radius: 50%;
-  background: #bef264;
-  box-shadow: 0 0 8px rgba(190, 242, 100, 0.78);
-}
-
-.participant-avatar__status.is-muted {
-  background: #fb7185;
-  box-shadow: 0 0 8px rgba(251, 113, 133, 0.58);
-}
-
-.participant-avatar__kind {
-  position: absolute;
-  right: 0.12rem;
-  bottom: 0.1rem;
-  display: grid;
-  width: 1rem;
-  height: 1rem;
-  place-items: center;
-  border: 1px solid #020617;
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--participant-accent) 78%, #020617);
-  color: #020617;
-}
-
-.participant-avatar__kind svg {
-  width: 0.68rem;
-  height: 0.68rem;
-}
-
-.participant-avatar--compact .participant-avatar__kind {
-  right: -0.08rem;
-  bottom: -0.05rem;
-  width: 0.72rem;
-  height: 0.72rem;
-}
-
-.participant-avatar--compact .participant-avatar__kind svg {
-  width: 0.5rem;
-  height: 0.5rem;
 }
 
 /* Local analyser output is deliberately a light signal around the node, not


### PR DESCRIPTION
## Summary

- Present typical 1–6 participant Rooms as a deterministic constellation band of local Human/Agent nodes above the conversation.
- Use five local SVG avatar variants (planet, ringed planet, moon, crystal, and energy orb) selected from the participant name hash.
- Keep larger rooms on a compact auto-fill grid fallback, and keep screen-share on its existing dominant viewer plus compact strip path.
- Replace the heavy waveform/capability-dashboard treatment with local speaking signal rings and identity/current-state metadata.
- Reuse the same compact `ParticipantAvatar` grammar in the roster, chat messages, attachments, and pending local files.
- Keep the Room header focused on the room id and actions; omit redundant live peer-count copy.
- Preserve Room/SFU/DO/media/screen-share/Runtime semantics.

## Details

The default no-screen-share Room uses a stacked composition: header, a bounded roughly 180–220px desktop participant presence band, then full-width chat and composer. Small rooms use a simple horizontal constellation of nodes rather than a full-height canvas or 3×3 map; larger rooms retain a predictable compact grid fallback. Participant kind and current state remain visible, while capability inventory is intentionally not rendered on the default surface. Mobile uses a roughly 100–120px horizontally scrollable node strip, with chat beginning immediately below it and no page-level overflow. When screen share is active, the existing split viewer/chat layout and compact participant strip remain in place.

Avatar geometry and accent colors are deterministic per participant name. Each local SVG avatar is intentionally simple—a single colored orb with one restrained planet, crescent, crystal, or energy detail—without stacked outer orbit decorations or extra kind/status badges. SVG gradient IDs use `useId()` so a participant can safely appear in both the roster and chat without collisions. `TextChatCard` now shares the compact avatar component instead of mixing in the legacy `boring-avatars` presentation.

Audio visualization is presentation-only: `AudioVisualizer` samples the already-local `MediaStream` through `AnalyserNode`, applies smoothing/decay, and renders CSS orbital rings and a restrained orb glow. No audio level or new state is sent through SFU, RoomSession, DO, or the Runtime protocol. Existing mute, screen-share, Agent Voice, and audio-element paths are preserved.

## Validation

- `cd app && yarn prettier --check ...` ✅
- `cd app && yarn type-check` ✅
- `cd app && yarn eslint src --no-fix` ✅
- `cd app && yarn test --run` ✅ (65 files, 618 tests)
- `cd app && yarn cf-build` ✅
- `git diff --check` ✅

The local E2E skill documents that the internal `SFU_ROOM` Durable Object cannot provide a real browser WebRTC/SFU session in local dev. I therefore rendered the production components in a temporary mock page and checked the actual default stacked Room composition plus mobile node strip with Playwright, including speaking rings, chat avatar consistency, retained controls, and no horizontal page overflow. The mock route remains untracked locally for visual review and is not included in this PR.

Refs #258
