### PR TITLE
feat(room): apply retro sci-fi visual skin

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",
     "agents": "0.21.0",
-    "boring-avatars": "^1.7.0",
     "next": "15.5.24",
+    "planet-avatar": "0.1.0",
     "react": "19",
     "react-dom": "19",
     "react-markdown": "^10.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,6 @@
     "react-dom": "19",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "unique-names-generator": "^4.7.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/app/src/__tests__/pages/index.test.tsx
+++ b/app/src/__tests__/pages/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 vi.mock("next/router", () => ({
@@ -48,5 +48,25 @@ describe("Home page", () => {
     expect(
       screen.queryByText(/verifying you.re human/i)
     ).not.toBeInTheDocument()
+  })
+
+  it("prefills separate cosmic defaults and keeps both dice controls wired", async () => {
+    render(<Home />)
+
+    await waitFor(() => {
+      const room = screen.getByLabelText("Room") as HTMLInputElement
+      const nickname = screen.getByLabelText("Nickname") as HTMLInputElement
+      expect(room.value).toMatch(/^[a-z]+-[a-z]+-[a-z0-9]+$/)
+      expect(nickname.value).toMatch(/^[A-Z][a-z]+$/)
+    })
+
+    fireEvent.click(screen.getByTitle("Randomize room name"))
+    fireEvent.click(screen.getByTitle("Randomize nickname"))
+    expect((screen.getByLabelText("Room") as HTMLInputElement).value).toMatch(
+      /^[a-z]+-[a-z]+-[a-z0-9]+$/
+    )
+    expect(
+      (screen.getByLabelText("Nickname") as HTMLInputElement).value
+    ).toMatch(/^[A-Z][a-z]+$/)
   })
 })

--- a/app/src/__tests__/pages/room.test.tsx
+++ b/app/src/__tests__/pages/room.test.tsx
@@ -18,4 +18,13 @@ describe("Room page", () => {
       /<meta\s+name="robots"\s+content="noindex,\s*nofollow"\s*\/>/
     )
   })
+
+  it("uses a generated planet-style default only for an unsaved direct invite", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/pages/room.tsx"),
+      "utf-8"
+    )
+    expect(source).toMatch(/setNickName\(generateParticipantName\(\)\)/)
+    expect(source).toMatch(/setNickName\(room\.nickName\)/)
+  })
 })

--- a/app/src/common/cosmicNames.test.ts
+++ b/app/src/common/cosmicNames.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { generateParticipantName, generateRoomName } from "./cosmicNames"
+
+const roomPattern = /^[a-z]+-[a-z]+-[23456789abcdefghjkmnpqrstuvwxyz]{12}$/
+
+describe("cosmic naming", () => {
+  it("generates a readable Room id with injected deterministic entropy", () => {
+    const room = generateRoomName(() => 0)
+
+    expect(room).toBe("andromeda-arc-222222222222")
+    expect(room).toMatch(roomPattern)
+    expect(room.length).toBeLessThanOrEqual(64)
+  })
+
+  it("keeps Room ids in the URL-safe, lowercase namespace", () => {
+    const entropy = (() => {
+      let value = 0
+      return () => {
+        value = (value + 0.173) % 1
+        return value
+      }
+    })()
+
+    const room = generateRoomName(entropy)
+    expect(room).toMatch(roomPattern)
+    expect(room).not.toMatch(/[A-Z\s_]/)
+  })
+
+  it("generates short planet-style participant names", () => {
+    const name = generateParticipantName(() => 0)
+
+    expect(name).toBe("Veyra")
+    expect(name).toMatch(/^[A-Z][a-z]+$/)
+    expect(name).not.toMatch(/[0-9\s-]/)
+    expect(name.length).toBeLessThanOrEqual(32)
+  })
+
+  it("keeps participant output deterministic for a supplied entropy source", () => {
+    const entropy = () => 0.5
+    expect(generateParticipantName(entropy)).toBe(
+      generateParticipantName(entropy)
+    )
+  })
+})

--- a/app/src/common/cosmicNames.ts
+++ b/app/src/common/cosmicNames.ts
@@ -1,0 +1,283 @@
+/**
+ * Small deterministic naming helpers shared by the browser and Worker.
+ *
+ * The public Room id keeps a readable cosmic prefix, but always ends in a
+ * cryptographically generated suffix so the word lists are not a namespace.
+ */
+
+export type EntropySource = () => number
+
+const ROOM_SUFFIX_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
+const ROOM_SUFFIX_LENGTH = 12
+
+const COSMIC_ROOTS = [
+  "andromeda",
+  "aquila",
+  "aurora",
+  "carina",
+  "cassiopeia",
+  "centauri",
+  "ceres",
+  "corvus",
+  "cygnus",
+  "deneb",
+  "draco",
+  "elara",
+  "eridanus",
+  "europa",
+  "helios",
+  "hydra",
+  "io",
+  "lyra",
+  "maia",
+  "mensa",
+  "meridian",
+  "nebula",
+  "neptune",
+  "nova",
+  "orion",
+  "pegasus",
+  "perseus",
+  "phoenix",
+  "polaris",
+  "proxima",
+  "rigel",
+  "sagitta",
+  "saturn",
+  "sirius",
+  "solstice",
+  "spica",
+  "taurus",
+  "ursa",
+  "vega",
+  "vela",
+  "venus",
+  "virgo",
+  "zenith",
+  "altair",
+  "antares",
+  "aphelion",
+  "arcturus",
+  "asteria",
+  "cosmos",
+  "eclipse",
+  "galatea",
+  "gemini",
+  "halley",
+  "hyperion",
+  "kepler",
+  "lunaris",
+  "metis",
+  "miranda",
+  "orbital",
+  "pulsar",
+  "quasar",
+  "selenite",
+  "stellar",
+]
+
+const REGION_WORDS = [
+  "arc",
+  "beacon",
+  "cluster",
+  "corridor",
+  "drift",
+  "expanse",
+  "field",
+  "frontier",
+  "gate",
+  "harbor",
+  "haven",
+  "horizon",
+  "nexus",
+  "orbit",
+  "passage",
+  "reach",
+  "relay",
+  "rift",
+  "sector",
+  "span",
+  "verge",
+  "wake",
+  "apex",
+  "belt",
+  "bridge",
+  "channel",
+  "crescent",
+  "domain",
+  "edge",
+  "flux",
+  "grid",
+  "halo",
+]
+
+// 64 x 64 combinations provide several thousand short, pronounceable
+// defaults without making a generated participant name a persistent identity.
+const PLANET_STARTS = [
+  "vey",
+  "aev",
+  "ael",
+  "aer",
+  "ali",
+  "ara",
+  "ari",
+  "aro",
+  "ava",
+  "avi",
+  "bel",
+  "cal",
+  "cer",
+  "cy",
+  "dar",
+  "del",
+  "dov",
+  "ela",
+  "eli",
+  "era",
+  "eri",
+  "eva",
+  "gal",
+  "hal",
+  "ila",
+  "ily",
+  "io",
+  "kai",
+  "kel",
+  "kora",
+  "lae",
+  "lea",
+  "li",
+  "luma",
+  "ly",
+  "mae",
+  "mira",
+  "nae",
+  "nea",
+  "neo",
+  "nexa",
+  "oli",
+  "ori",
+  "oria",
+  "pel",
+  "rae",
+  "rei",
+  "rhea",
+  "sela",
+  "sera",
+  "sol",
+  "tala",
+  "tea",
+  "tera",
+  "va",
+  "vel",
+  "vela",
+  "vira",
+  "wren",
+  "xena",
+  "ya",
+  "yara",
+  "zel",
+]
+
+const PLANET_ENDINGS = [
+  "ra",
+  "ris",
+  "ron",
+  "ria",
+  "len",
+  "lex",
+  "lia",
+  "ion",
+  "ara",
+  "en",
+  "is",
+  "os",
+  "ora",
+  "iel",
+  "une",
+  "ael",
+  "an",
+  "aris",
+  "eris",
+  "essa",
+  "eus",
+  "eon",
+  "ira",
+  "ium",
+  "on",
+  "or",
+  "rin",
+  "sel",
+  "sen",
+  "tis",
+  "tor",
+  "yne",
+  "zel",
+  "ae",
+  "el",
+  "eth",
+  "ia",
+  "il",
+  "in",
+  "ith",
+  "ula",
+  "us",
+  "yn",
+  "yra",
+  "eron",
+  "orin",
+  "avel",
+  "eira",
+  "ulis",
+  "vera",
+  "ylen",
+  "zora",
+  "aeris",
+  "arin",
+  "elis",
+  "oris",
+  "unee",
+  "yven",
+  "aura",
+  "evar",
+  "iren",
+  "ovar",
+  "ulen",
+  "yora",
+  "zeon",
+]
+
+function secureEntropy(): number {
+  const bytes = new Uint32Array(1)
+  globalThis.crypto.getRandomValues(bytes)
+  return bytes[0] / 0x1_0000_0000
+}
+
+function pick<T>(values: readonly T[], entropy: EntropySource): T {
+  const sample = entropy()
+  if (!Number.isFinite(sample)) throw new Error("entropy must be finite")
+  const normalized = Math.min(0.999999999, Math.max(0, sample))
+  return values[Math.floor(normalized * values.length)]
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+export function generateRoomName(entropy: EntropySource = secureEntropy) {
+  const root = pick(COSMIC_ROOTS, entropy)
+  const region = pick(REGION_WORDS, entropy)
+  let suffix = ""
+  for (let i = 0; i < ROOM_SUFFIX_LENGTH; i += 1) {
+    suffix += pick(ROOM_SUFFIX_ALPHABET.split(""), entropy)
+  }
+  return `${root}-${region}-${suffix}`
+}
+
+export function generateParticipantName(
+  entropy: EntropySource = secureEntropy
+) {
+  return titleCase(
+    `${pick(PLANET_STARTS, entropy)}${pick(PLANET_ENDINGS, entropy)}`
+  )
+}

--- a/app/src/common/utils.tsx
+++ b/app/src/common/utils.tsx
@@ -1,21 +1,4 @@
-import {
-  uniqueNamesGenerator,
-  Config,
-  adjectives,
-  colors,
-} from "unique-names-generator"
-
 import { Color } from "@common/types"
-
-const customConfig: Config = {
-  dictionaries: [adjectives, colors],
-  separator: "-",
-  length: 2,
-}
-
-export const randomName = () => {
-  return uniqueNamesGenerator(customConfig)
-}
 
 export const saveRoomToLocalStorage = (roomName, nickName) => {
   var rooms: {}[] = JSON.parse(localStorage.getItem("rooms") || "[]")

--- a/app/src/components/AudioVisualizer.test.tsx
+++ b/app/src/components/AudioVisualizer.test.tsx
@@ -5,9 +5,7 @@ import AudioVisualizer from "./AudioVisualizer"
 
 describe("AudioVisualizer", () => {
   it("does not render an empty frame without an audio track", () => {
-    const { container } = render(
-      <AudioVisualizer name="Hermes" muteState={false} />
-    )
+    const { container } = render(<AudioVisualizer muteState={false} />)
 
     expect(container.firstChild).toBeNull()
   })
@@ -17,9 +15,22 @@ describe("AudioVisualizer", () => {
       getAudioTracks: () => [{}],
     } as unknown as MediaStream
     const { container } = render(
-      <AudioVisualizer audio={stream} name="Hermes" muteState={true} />
+      <AudioVisualizer audio={stream} muteState={true} />
     )
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it("renders an avatar-sized orbit only for an active track", () => {
+    const stream = {
+      getAudioTracks: () => [{}],
+    } as unknown as MediaStream
+    const { container } = render(
+      <AudioVisualizer audio={stream} muteState={false} size="full" />
+    )
+
+    expect(container.querySelector("canvas")).toHaveClass(
+      "participant-audio-orbit--full"
+    )
   })
 })

--- a/app/src/components/AudioVisualizer.test.tsx
+++ b/app/src/components/AudioVisualizer.test.tsx
@@ -22,15 +22,61 @@ describe("AudioVisualizer", () => {
   })
 
   it("renders an avatar-sized orbit only for an active track", () => {
+    const originalAudioContext = window.AudioContext
+    const originalGetContext = HTMLCanvasElement.prototype.getContext
+    class FakeAudioContext {
+      createAnalyser() {
+        return {
+          fftSize: 256,
+          getByteTimeDomainData: (samples: Uint8Array) => samples.fill(128),
+          disconnect: () => undefined,
+        } as unknown as AnalyserNode
+      }
+
+      createMediaStreamSource() {
+        return {
+          connect: () => undefined,
+          disconnect: () => undefined,
+        } as unknown as MediaStreamAudioSourceNode
+      }
+
+      resume() {
+        return Promise.resolve()
+      }
+
+      close() {
+        return Promise.resolve()
+      }
+    }
+    Object.defineProperty(window, "AudioContext", {
+      configurable: true,
+      value: FakeAudioContext,
+    })
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: () => null,
+    })
+
     const stream = {
       getAudioTracks: () => [{}],
     } as unknown as MediaStream
-    const { container } = render(
-      <AudioVisualizer audio={stream} muteState={false} size="full" />
-    )
+    try {
+      const { container } = render(
+        <AudioVisualizer audio={stream} muteState={false} size="full" />
+      )
 
-    expect(container.querySelector("canvas")).toHaveClass(
-      "participant-audio-orbit--full"
-    )
+      expect(container.querySelector("canvas")).toHaveClass(
+        "participant-audio-orbit--full"
+      )
+    } finally {
+      Object.defineProperty(window, "AudioContext", {
+        configurable: true,
+        value: originalAudioContext,
+      })
+      Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+        configurable: true,
+        value: originalGetContext,
+      })
+    }
   })
 })

--- a/app/src/components/AudioVisualizer.test.tsx
+++ b/app/src/components/AudioVisualizer.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import AudioVisualizer from "./AudioVisualizer"
+
+describe("AudioVisualizer", () => {
+  it("does not render an empty frame without an audio track", () => {
+    const { container } = render(
+      <AudioVisualizer name="Hermes" muteState={false} />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("hides the ambient waveform while the participant is muted", () => {
+    const stream = {
+      getAudioTracks: () => [{}],
+    } as unknown as MediaStream
+    const { container } = render(
+      <AudioVisualizer audio={stream} name="Hermes" muteState={true} />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useEffect } from "react"
 
 interface Audio {
   audio?: MediaStream | null
@@ -7,8 +7,12 @@ interface Audio {
   onLevel?: (level: number) => void
 }
 
+/**
+ * Samples a participant track for presentation-only activity indicators.
+ * The component intentionally renders no waveform DOM; UserCard consumes the
+ * smoothed level to animate the avatar ripple instead.
+ */
 export default function AudioVisualizer(props: Audio) {
-  const analyserCanvas = useRef(null)
   const { audio, name, muteState, onLevel } = props
   useEffect(() => {
     if (!audio || audio.getAudioTracks().length === 0 || muteState) return
@@ -18,54 +22,29 @@ export default function AudioVisualizer(props: Audio) {
     const audioSrc = audioCtx.createMediaStreamSource(audio)
     audioSrc.connect(analyser)
     analyser.fftSize = 256
-    const bufferLength = analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    analyser.getByteTimeDomainData(dataArray)
-
-    const canvas = analyserCanvas.current
-    const canvasCtx = canvas.getContext("2d")
+    const levelArray = new Uint8Array(analyser.fftSize)
 
     let animationFrame = 0
     let lastLevelReport = 0
+    let smoothedLevel = 0
     const draw = () => {
-      const WIDTH = canvas.width
-      const HEIGHT = canvas.height
-
       animationFrame = requestAnimationFrame(draw)
-      analyser.getByteFrequencyData(dataArray)
+      analyser.getByteTimeDomainData(levelArray)
 
-      // clear canvas for next drawing
-      canvasCtx.fillStyle = "rgba(2, 8, 20, 0.78)"
-      canvasCtx.fillRect(0, 0, WIDTH, HEIGHT)
-
-      const barWidth = 4
-      let barHeight: number
-      let x = 0
-      let levelTotal = 0
-
-      for (let i = 0; i < bufferLength; i++) {
-        barHeight = dataArray[i] / 2
-        levelTotal += dataArray[i]
-
-        // const r = Math.floor(barHeight + 64)
-        // if (g % 3 === 0) {
-        //   canvasCtx.fillStyle = `rgb(${r},${g},${b})`
-        // } else if (g % 3 === 1) {
-        //   canvasCtx.fillStyle = `rgb(${g},${r},${b})`
-        // } else {
-        //   canvasCtx.fillStyle = `rgb(${g},${b},${r})`
-        // }
-        canvasCtx.fillStyle = "rgba(166, 243, 255, 0.92)"
-
-        canvasCtx.fillRect(x, 40 - barHeight / 2, barWidth, barHeight)
-
-        x += barWidth + 2
+      let squareTotal = 0
+      for (const sample of levelArray) {
+        const centeredSample = (sample - 128) / 128
+        squareTotal += centeredSample * centeredSample
       }
+      const rms = Math.sqrt(squareTotal / levelArray.length)
+      const targetLevel = Math.min(1, Math.max(0, (rms - 0.015) / 0.22))
+      const smoothing = targetLevel > smoothedLevel ? 0.28 : 0.12
+      smoothedLevel += (targetLevel - smoothedLevel) * smoothing
 
       const now = performance.now()
       if (onLevel && now - lastLevelReport >= 80) {
         lastLevelReport = now
-        onLevel(Math.min(1, levelTotal / bufferLength / 255))
+        onLevel(smoothedLevel)
       }
     }
     const resume = () => {
@@ -86,14 +65,5 @@ export default function AudioVisualizer(props: Audio) {
     }
   }, [audio, name, muteState, onLevel])
 
-  if (!audio || audio.getAudioTracks().length === 0 || muteState) return null
-
-  return (
-    <div className="visualizer room-visualizer mx-auto mt-4">
-      <canvas
-        ref={analyserCanvas}
-        className="room-visualizer__canvas h-12 w-4/5"
-      ></canvas>
-    </div>
-  )
+  return null
 }

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -4,21 +4,18 @@ interface Audio {
   audio?: MediaStream | null
   name: string
   muteState: boolean | false
+  onLevel?: (level: number) => void
 }
 
 export default function AudioVisualizer(props: Audio) {
   const analyserCanvas = useRef(null)
+  const { audio, name, muteState, onLevel } = props
   useEffect(() => {
-    if (
-      !props.audio ||
-      props.audio.getAudioTracks().length === 0 ||
-      props.muteState
-    )
-      return
+    if (!audio || audio.getAudioTracks().length === 0 || muteState) return
     const audioCtx = new AudioContext()
     void audioCtx.resume().catch(() => undefined)
     const analyser = audioCtx.createAnalyser()
-    const audioSrc = audioCtx.createMediaStreamSource(props.audio)
+    const audioSrc = audioCtx.createMediaStreamSource(audio)
     audioSrc.connect(analyser)
     analyser.fftSize = 256
     const bufferLength = analyser.frequencyBinCount
@@ -29,6 +26,7 @@ export default function AudioVisualizer(props: Audio) {
     const canvasCtx = canvas.getContext("2d")
 
     let animationFrame = 0
+    let lastLevelReport = 0
     const draw = () => {
       const WIDTH = canvas.width
       const HEIGHT = canvas.height
@@ -43,9 +41,11 @@ export default function AudioVisualizer(props: Audio) {
       const barWidth = 4
       let barHeight: number
       let x = 0
+      let levelTotal = 0
 
       for (let i = 0; i < bufferLength; i++) {
         barHeight = dataArray[i] / 2
+        levelTotal += dataArray[i]
 
         // const r = Math.floor(barHeight + 64)
         // if (g % 3 === 0) {
@@ -61,23 +61,32 @@ export default function AudioVisualizer(props: Audio) {
 
         x += barWidth + 2
       }
+
+      const now = performance.now()
+      if (onLevel && now - lastLevelReport >= 80) {
+        lastLevelReport = now
+        onLevel(Math.min(1, levelTotal / bufferLength / 255))
+      }
     }
+    const resume = () => {
+      void audioCtx.resume().catch(() => undefined)
+    }
+    window.addEventListener("pointerdown", resume)
+    window.addEventListener("keydown", resume)
     draw()
 
     return () => {
       cancelAnimationFrame(animationFrame)
+      window.removeEventListener("pointerdown", resume)
+      window.removeEventListener("keydown", resume)
+      onLevel?.(0)
       audioSrc.disconnect()
       analyser.disconnect()
       void audioCtx.close().catch(() => undefined)
     }
-  }, [props.audio, props.name, props.muteState])
+  }, [audio, name, muteState, onLevel])
 
-  if (
-    !props.audio ||
-    props.audio.getAudioTracks().length === 0 ||
-    props.muteState
-  )
-    return null
+  if (!audio || audio.getAudioTracks().length === 0 || muteState) return null
 
   return (
     <div className="visualizer room-visualizer mx-auto mt-4">

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react"
 
 interface Audio {
-  audio: MediaStream
+  audio?: MediaStream | null
   name: string
   muteState: boolean | false
 }
@@ -9,7 +9,12 @@ interface Audio {
 export default function AudioVisualizer(props: Audio) {
   const analyserCanvas = useRef(null)
   useEffect(() => {
-    if (!props.audio || props.audio.getAudioTracks().length === 0) return
+    if (
+      !props.audio ||
+      props.audio.getAudioTracks().length === 0 ||
+      props.muteState
+    )
+      return
     const audioCtx = new AudioContext()
     void audioCtx.resume().catch(() => undefined)
     const analyser = audioCtx.createAnalyser()
@@ -65,7 +70,14 @@ export default function AudioVisualizer(props: Audio) {
       analyser.disconnect()
       void audioCtx.close().catch(() => undefined)
     }
-  }, [props.audio, props.name])
+  }, [props.audio, props.name, props.muteState])
+
+  if (
+    !props.audio ||
+    props.audio.getAudioTracks().length === 0 ||
+    props.muteState
+  )
+    return null
 
   return (
     <div className="visualizer room-visualizer mx-auto mt-4">

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from "react"
 
-import { nameToColor, strToRGB } from "../common/utils"
-
 interface Audio {
   audio: MediaStream
   name: string
@@ -11,7 +9,6 @@ interface Audio {
 export default function AudioVisualizer(props: Audio) {
   const analyserCanvas = useRef(null)
   useEffect(() => {
-    const color = nameToColor(props.name)
     if (!props.audio || props.audio.getAudioTracks().length === 0) return
     const audioCtx = new AudioContext()
     void audioCtx.resume().catch(() => undefined)
@@ -26,9 +23,6 @@ export default function AudioVisualizer(props: Audio) {
     const canvas = analyserCanvas.current
     const canvasCtx = canvas.getContext("2d")
 
-    const g = color[1]
-    const b = color[2]
-
     let animationFrame = 0
     const draw = () => {
       const WIDTH = canvas.width
@@ -38,7 +32,7 @@ export default function AudioVisualizer(props: Audio) {
       analyser.getByteFrequencyData(dataArray)
 
       // clear canvas for next drawing
-      canvasCtx.fillStyle = strToRGB(props.name)
+      canvasCtx.fillStyle = "rgba(2, 8, 20, 0.78)"
       canvasCtx.fillRect(0, 0, WIDTH, HEIGHT)
 
       const barWidth = 4
@@ -56,7 +50,7 @@ export default function AudioVisualizer(props: Audio) {
         // } else {
         //   canvasCtx.fillStyle = `rgb(${g},${b},${r})`
         // }
-        canvasCtx.fillStyle = `rgb(255,255,255)`
+        canvasCtx.fillStyle = "rgba(166, 243, 255, 0.92)"
 
         canvasCtx.fillRect(x, 40 - barHeight / 2, barWidth, barHeight)
 
@@ -74,8 +68,11 @@ export default function AudioVisualizer(props: Audio) {
   }, [props.audio, props.name])
 
   return (
-    <div className="visualizer mx-auto mt-4">
-      <canvas ref={analyserCanvas} className="h-12 w-4/5"></canvas>
+    <div className="visualizer room-visualizer mx-auto mt-4">
+      <canvas
+        ref={analyserCanvas}
+        className="room-visualizer__canvas h-12 w-4/5"
+      ></canvas>
     </div>
   )
 }

--- a/app/src/components/AudioVisualizer.tsx
+++ b/app/src/components/AudioVisualizer.tsx
@@ -1,69 +1,184 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
-interface Audio {
+type AudioVisualizerSize = "full" | "compact"
+
+interface AudioVisualizerProps {
   audio?: MediaStream | null
-  name: string
-  muteState: boolean | false
-  onLevel?: (level: number) => void
+  muteState: boolean
+  size?: AudioVisualizerSize
 }
 
-/**
- * Samples a participant track for presentation-only activity indicators.
- * The component intentionally renders no waveform DOM; UserCard consumes the
- * smoothed level to animate the avatar ripple instead.
- */
-export default function AudioVisualizer(props: Audio) {
-  const { audio, name, muteState, onLevel } = props
-  useEffect(() => {
-    if (!audio || audio.getAudioTracks().length === 0 || muteState) return
-    const audioCtx = new AudioContext()
-    void audioCtx.resume().catch(() => undefined)
-    const analyser = audioCtx.createAnalyser()
-    const audioSrc = audioCtx.createMediaStreamSource(audio)
-    audioSrc.connect(analyser)
-    analyser.fftSize = 256
-    const levelArray = new Uint8Array(analyser.fftSize)
+const ORBIT_POINTS = 48
+const TWO_PI = Math.PI * 2
 
-    let animationFrame = 0
-    let lastLevelReport = 0
+/**
+ * Draws a small, presentation-only audio orbit around a participant avatar.
+ *
+ * The analyser and animation loop stay entirely inside this component. The
+ * parent card therefore does not re-render at audio-frame frequency, and no
+ * room or media state is changed by the visualizer.
+ */
+export default function AudioVisualizer({
+  audio,
+  muteState,
+  size = "full",
+}: AudioVisualizerProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const hasAudioTrack = Boolean(audio && audio.getAudioTracks().length > 0)
+  const canUseAudioContext =
+    typeof window !== "undefined" && typeof window.AudioContext !== "undefined"
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (
+      !canvas ||
+      !audio ||
+      audio.getAudioTracks().length === 0 ||
+      muteState ||
+      typeof window === "undefined" ||
+      typeof window.AudioContext === "undefined"
+    ) {
+      return
+    }
+
+    const context = new window.AudioContext()
+    const analyser = context.createAnalyser()
+    analyser.fftSize = 256
+
+    let source: MediaStreamAudioSourceNode
+    try {
+      source = context.createMediaStreamSource(audio)
+      source.connect(analyser)
+    } catch {
+      void context.close().catch(() => undefined)
+      return
+    }
+
+    const rect = canvas.getBoundingClientRect()
+    const cssSize = Math.max(1, rect.width || (size === "compact" ? 52 : 82))
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+    canvas.width = Math.round(cssSize * pixelRatio)
+    canvas.height = Math.round(cssSize * pixelRatio)
+
+    const context2d = canvas.getContext("2d")
+    if (!context2d) {
+      source.disconnect()
+      analyser.disconnect()
+      void context.close().catch(() => undefined)
+      return
+    }
+    context2d.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
+
+    const samples = new Uint8Array(analyser.fftSize)
+    const pointEnvelope = new Float32Array(ORBIT_POINTS)
+    const pointCoordinates = new Float32Array(ORBIT_POINTS * 2)
+    const center = cssSize / 2
+    const baseRadius = size === "compact" ? cssSize * 0.34 : cssSize * 0.43
+    const maxDeformation = size === "compact" ? 3 : 9
     let smoothedLevel = 0
+    let animationFrame = 0
+
     const draw = () => {
-      animationFrame = requestAnimationFrame(draw)
-      analyser.getByteTimeDomainData(levelArray)
+      analyser.getByteTimeDomainData(samples)
 
       let squareTotal = 0
-      for (const sample of levelArray) {
+      for (const sample of samples) {
         const centeredSample = (sample - 128) / 128
         squareTotal += centeredSample * centeredSample
       }
-      const rms = Math.sqrt(squareTotal / levelArray.length)
+      const rms = Math.sqrt(squareTotal / samples.length)
       const targetLevel = Math.min(1, Math.max(0, (rms - 0.015) / 0.22))
       const smoothing = targetLevel > smoothedLevel ? 0.28 : 0.12
       smoothedLevel += (targetLevel - smoothedLevel) * smoothing
 
-      const now = performance.now()
-      if (onLevel && now - lastLevelReport >= 80) {
-        lastLevelReport = now
-        onLevel(smoothedLevel)
+      context2d.clearRect(0, 0, cssSize, cssSize)
+      const quiet = smoothedLevel < 0.02
+
+      for (let point = 0; point < ORBIT_POINTS; point += 1) {
+        const angle = (point / ORBIT_POINTS) * TWO_PI - Math.PI / 2
+        const sampleIndex = Math.floor((point / ORBIT_POINTS) * samples.length)
+        const centeredSample = (samples[sampleIndex] - 128) / 128
+        const targetEnvelope = quiet
+          ? 0
+          : Math.min(1, Math.abs(centeredSample) * 4.2)
+        const envelope = pointEnvelope[point]
+        const envelopeSmoothing = targetEnvelope > envelope ? 0.22 : 0.1
+        pointEnvelope[point] += (targetEnvelope - envelope) * envelopeSmoothing
+
+        const staticContour =
+          Math.sin(angle * 3) * 0.35 + Math.sin(angle * 5 + 0.7) * 0.18
+        const deformation = quiet
+          ? staticContour
+          : pointEnvelope[point] * maxDeformation + smoothedLevel * 2.1
+        const radius = baseRadius + deformation
+        const x = center + Math.cos(angle) * radius
+        const y = center + Math.sin(angle) * radius
+        pointCoordinates[point * 2] = x
+        pointCoordinates[point * 2 + 1] = y
       }
+
+      const firstX = pointCoordinates[0]
+      const firstY = pointCoordinates[1]
+      const secondX = pointCoordinates[2]
+      const secondY = pointCoordinates[3]
+      context2d.beginPath()
+      context2d.moveTo((firstX + secondX) / 2, (firstY + secondY) / 2)
+      for (let point = 1; point <= ORBIT_POINTS; point += 1) {
+        const currentIndex = (point % ORBIT_POINTS) * 2
+        const nextIndex = ((point + 1) % ORBIT_POINTS) * 2
+        const currentX = pointCoordinates[currentIndex]
+        const currentY = pointCoordinates[currentIndex + 1]
+        const nextMidX = (currentX + pointCoordinates[nextIndex]) / 2
+        const nextMidY = (currentY + pointCoordinates[nextIndex + 1]) / 2
+        context2d.quadraticCurveTo(currentX, currentY, nextMidX, nextMidY)
+      }
+      context2d.closePath()
+
+      const gradient = context2d.createLinearGradient(0, 0, cssSize, cssSize)
+      const opacity = 0.14 + smoothedLevel * 0.66
+      gradient.addColorStop(0, `rgba(103, 232, 249, ${opacity})`)
+      gradient.addColorStop(0.58, `rgba(129, 140, 248, ${opacity * 0.82})`)
+      gradient.addColorStop(1, `rgba(192, 132, 252, ${opacity * 0.7})`)
+
+      context2d.lineWidth = size === "compact" ? 0.9 : 1.25
+      context2d.lineJoin = "round"
+      context2d.lineCap = "round"
+      context2d.strokeStyle = gradient
+      context2d.shadowColor = `rgba(103, 232, 249, ${
+        0.12 + smoothedLevel * 0.35
+      })`
+      context2d.shadowBlur = size === "compact" ? 3 : 4 + smoothedLevel * 9
+      context2d.stroke()
+      context2d.shadowBlur = 0
+
+      animationFrame = requestAnimationFrame(draw)
     }
+
     const resume = () => {
-      void audioCtx.resume().catch(() => undefined)
+      void context.resume().catch(() => undefined)
     }
     window.addEventListener("pointerdown", resume)
     window.addEventListener("keydown", resume)
+    void context.resume().catch(() => undefined)
     draw()
 
     return () => {
       cancelAnimationFrame(animationFrame)
       window.removeEventListener("pointerdown", resume)
       window.removeEventListener("keydown", resume)
-      onLevel?.(0)
-      audioSrc.disconnect()
+      source.disconnect()
       analyser.disconnect()
-      void audioCtx.close().catch(() => undefined)
+      void context.close().catch(() => undefined)
     }
-  }, [audio, name, muteState, onLevel])
+  }, [audio, muteState, size])
 
-  return null
+  if (!hasAudioTrack || muteState || !canUseAudioContext) return null
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`participant-audio-orbit participant-audio-orbit--${size}`}
+      aria-hidden="true"
+    />
+  )
 }

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -1,0 +1,32 @@
+import { PlanetAvatar } from "planet-avatar/react"
+
+export type ParticipantAvatarSize = "compact" | "full"
+
+export default function ParticipantAvatar({
+  name,
+  size = "full",
+  className,
+}: {
+  name: string
+  size?: ParticipantAvatarSize
+  className?: string
+}) {
+  const compact = size === "compact"
+
+  return (
+    <span
+      className={`participant-avatar ${
+        compact ? "participant-avatar--compact" : ""
+      } ${className ?? ""}`.trim()}
+      aria-hidden="true"
+    >
+      <PlanetAvatar
+        seed={name}
+        size={compact ? 36 : 56}
+        variant="auto"
+        rings="auto"
+        background="transparent"
+      />
+    </span>
+  )
+}

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -17,6 +17,7 @@ export default function ParticipantAvatar({
 }) {
   const compact = size === "compact"
   const normalizedSpeakingLevel = Math.min(1, Math.max(0, speakingLevel))
+  const rippleDuration = `${(1.8 - normalizedSpeakingLevel * 0.95).toFixed(2)}s`
 
   return (
     <span
@@ -27,6 +28,7 @@ export default function ParticipantAvatar({
       style={
         {
           "--speaking-level": normalizedSpeakingLevel,
+          "--ripple-duration": rippleDuration,
         } as CSSProperties
       }
       aria-hidden="true"

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react"
+
 import { PlanetAvatar } from "planet-avatar/react"
 
 export type ParticipantAvatarSize = "compact" | "full"
@@ -6,25 +8,37 @@ export default function ParticipantAvatar({
   name,
   size = "full",
   className,
+  speakingLevel = 0,
 }: {
   name: string
   size?: ParticipantAvatarSize
   className?: string
+  speakingLevel?: number
 }) {
   const compact = size === "compact"
+  const normalizedSpeakingLevel = Math.min(1, Math.max(0, speakingLevel))
 
   return (
     <span
       className={`participant-avatar ${
         compact ? "participant-avatar--compact" : ""
       } ${className ?? ""}`.trim()}
+      data-speaking={normalizedSpeakingLevel > 0.02 ? "true" : "false"}
+      style={
+        {
+          "--speaking-level": normalizedSpeakingLevel,
+        } as CSSProperties
+      }
       aria-hidden="true"
     >
+      <span className="participant-avatar__ripple participant-avatar__ripple--one" />
+      <span className="participant-avatar__ripple participant-avatar__ripple--two" />
       <PlanetAvatar
+        className="participant-avatar__planet"
         seed={name}
         size={compact ? 36 : 56}
         variant="auto"
-        rings="auto"
+        rings={false}
         background="transparent"
       />
     </span>

--- a/app/src/components/ParticipantAvatar.tsx
+++ b/app/src/components/ParticipantAvatar.tsx
@@ -1,5 +1,3 @@
-import type { CSSProperties } from "react"
-
 import { PlanetAvatar } from "planet-avatar/react"
 
 export type ParticipantAvatarSize = "compact" | "full"
@@ -8,33 +6,20 @@ export default function ParticipantAvatar({
   name,
   size = "full",
   className,
-  speakingLevel = 0,
 }: {
   name: string
   size?: ParticipantAvatarSize
   className?: string
-  speakingLevel?: number
 }) {
   const compact = size === "compact"
-  const normalizedSpeakingLevel = Math.min(1, Math.max(0, speakingLevel))
-  const rippleDuration = `${(1.8 - normalizedSpeakingLevel * 0.95).toFixed(2)}s`
 
   return (
     <span
       className={`participant-avatar ${
         compact ? "participant-avatar--compact" : ""
       } ${className ?? ""}`.trim()}
-      data-speaking={normalizedSpeakingLevel > 0.02 ? "true" : "false"}
-      style={
-        {
-          "--speaking-level": normalizedSpeakingLevel,
-          "--ripple-duration": rippleDuration,
-        } as CSSProperties
-      }
       aria-hidden="true"
     >
-      <span className="participant-avatar__ripple participant-avatar__ripple--one" />
-      <span className="participant-avatar__ripple participant-avatar__ripple--two" />
       <PlanetAvatar
         className="participant-avatar__planet"
         seed={name}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -476,7 +476,7 @@ export default function RoomContent({
   }
 
   return (
-    <main className="flex h-screen flex-col overflow-hidden bg-gray-900 text-white">
+    <main className="room-shell flex h-screen flex-col overflow-hidden bg-gray-900 text-white">
       {connectionStatus === "reconnecting" && (
         <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60">
           <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-gray-700 border-t-yellow-400" />
@@ -484,7 +484,7 @@ export default function RoomContent({
         </div>
       )}
 
-      <header className="flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center">
+      <header className="room-header flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center">
         <div
           data-testid="room-header-identity"
           className="flex min-w-0 items-center gap-2"
@@ -614,10 +614,10 @@ export default function RoomContent({
 
       <div
         ref={containerRef}
-        className="flex flex-1 flex-col overflow-hidden md:flex-row"
+        className="room-content flex flex-1 flex-col overflow-hidden md:flex-row"
       >
         <div
-          className="flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
+          className="room-panel flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
           {/* #111: Agent workspace snapshots — observation only, available in
@@ -636,7 +636,7 @@ export default function RoomContent({
                     name={activeShare.name}
                   />
                 )}
-                <div className="scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-gray-800 p-2">
+                <div className="room-participant-strip scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-gray-800 p-2">
                   {participants.map((p) => (
                     <div
                       key={p.peerId}
@@ -685,7 +685,7 @@ export default function RoomContent({
                 </div>
               </>
             ) : (
-              <div className="scrollbar-thin flex h-full flex-wrap content-start items-start gap-2 overflow-y-auto p-3">
+              <div className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start gap-2 overflow-y-auto p-3">
                 {participants.map((p) => (
                   <div
                     key={p.peerId}
@@ -711,7 +711,7 @@ export default function RoomContent({
                       className="w-40 flex-none"
                     />
                     {p.peerId === LOCAL_PEER_ID && (
-                      <div className="hidden items-center gap-1 md:flex">
+                      <div className="room-reactions hidden items-center gap-1 md:flex">
                         {REACTION_EMOJIS.map((emoji) => (
                           <button
                             key={emoji}
@@ -749,7 +749,7 @@ export default function RoomContent({
           }}
         />
 
-        <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="room-panel room-chat-panel flex flex-1 flex-col overflow-hidden">
           <TextChatCard
             room={roomName}
             nickName={nickName}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -677,7 +677,7 @@ export default function RoomContent({
                         }
                         voiceEnabled={p.voiceEnabled}
                         onToggleAgentVoice={() => toggleAgentVoice(p)}
-                        className="w-20"
+                        className="w-[84px]"
                         compact
                       />
                     </div>

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, memo } from "react"
 
-import Avatar from "boring-avatars"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -16,6 +15,7 @@ import {
   isCollabRequestAnswered,
 } from "./collabUi"
 import HumanCollabResultComposer from "./HumanCollabResultComposer"
+import ParticipantAvatar from "./ParticipantAvatar"
 import { resolveAgentTargetIds } from "../common/agentMentions"
 import type { UserInfo } from "../common/types"
 import type {
@@ -1187,10 +1187,10 @@ export default function TextChatCard({
               return (
                 <div className="mb-4 flex w-full items-end" key={attachment.id}>
                   <div className="mr-2 flex-shrink-0">
-                    <Avatar
-                      size={28}
-                      variant="beam"
+                    <ParticipantAvatar
                       name={attachment.senderName}
+                      size="compact"
+                      className="text-chat-avatar"
                     />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -1220,7 +1220,11 @@ export default function TextChatCard({
                 key={i}
               >
                 <div className={`flex-shrink-0 ${isSelf ? "ml-2" : "mr-2"}`}>
-                  <Avatar size={28} variant="beam" name={p.name} />
+                  <ParticipantAvatar
+                    name={p.name}
+                    size="compact"
+                    className="text-chat-avatar"
+                  />
                 </div>
                 <div className="min-w-0 flex-1">
                   {!isSelf && (
@@ -1281,7 +1285,11 @@ export default function TextChatCard({
               className="mb-4 flex w-full flex-row-reverse items-end"
             >
               <div className="ml-2 flex-shrink-0">
-                <Avatar size={28} variant="beam" name={nickName} />
+                <ParticipantAvatar
+                  name={nickName}
+                  size="compact"
+                  className="text-chat-avatar"
+                />
               </div>
               <div style={{ maxWidth: "72%" }}>
                 <div

--- a/app/src/components/UserCard.agentVoice.test.tsx
+++ b/app/src/components/UserCard.agentVoice.test.tsx
@@ -24,12 +24,12 @@ describe("UserCard Agent Voice", () => {
     expect(props.onToggleAgentVoice).toHaveBeenCalledOnce()
   })
 
-  it("renders an independent enabled control and a disabled unavailable control", () => {
-    const { getByRole, rerender } = render(
+  it("renders enabled controls independently and hides unavailable voice", () => {
+    const { getByRole, queryByRole, rerender } = render(
       <UserCard {...card({ voiceEnabled: true })} />
     )
     expect(getByRole("button", { name: "Mute Pi" })).not.toBeDisabled()
     rerender(<UserCard {...card({ voiceAvailable: false })} />)
-    expect(getByRole("button", { name: "Voice unavailable" })).toBeDisabled()
+    expect(queryByRole("button", { name: "Voice unavailable" })).toBeNull()
   })
 })

--- a/app/src/components/UserCard.capabilities.test.tsx
+++ b/app/src/components/UserCard.capabilities.test.tsx
@@ -13,20 +13,20 @@ function base(overrides: Record<string, unknown> = {}) {
   }
 }
 
-describe("Agent advertised capability chips (#234)", () => {
-  it("renders advertised capability chips for an Agent in full layout", () => {
-    const { getByText } = render(
+describe("Agent advertised capabilities (#234)", () => {
+  it("keeps advertised capabilities out of the default full card UI", () => {
+    const { queryByText } = render(
       <UserCard
         {...base({ name: "Pi", kind: "agent", peerId: "agent-pi" })}
         capabilities={["code.edit", "shell"]}
       />
     )
-    expect(getByText("code.edit")).toBeTruthy()
-    expect(getByText("shell")).toBeTruthy()
+    expect(queryByText("code.edit")).toBeNull()
+    expect(queryByText("shell")).toBeNull()
   })
 
-  it("compact layout also displays Agent capability chips without breaking layout", () => {
-    const { getByText } = render(
+  it("keeps advertised capabilities out of the compact card UI", () => {
+    const { queryByText } = render(
       <UserCard
         {...base({
           name: "Pi",
@@ -37,7 +37,7 @@ describe("Agent advertised capability chips (#234)", () => {
         capabilities={["code.edit"]}
       />
     )
-    expect(getByText("code.edit")).toBeTruthy()
+    expect(queryByText("code.edit")).toBeNull()
   })
 
   it("never shows a Human capability editor entry (removed with #234)", () => {

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
@@ -20,10 +20,6 @@ interface UserCardProps extends UserInfo {
 export default function UserCard(user: UserCardProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
-  const [speakingLevel, setSpeakingLevel] = useState(0)
-  const handleAudioLevel = useCallback((level: number) => {
-    setSpeakingLevel(level)
-  }, [])
   const [canScreenShare] = useState(() => {
     if (typeof navigator === "undefined") return false
     const isMobileDevice = /Mobi|Android|iPhone|iPad|iPod/i.test(
@@ -67,11 +63,7 @@ export default function UserCard(user: UserCardProps) {
       >
         <div className="flex w-full min-w-0 flex-col items-center rounded-xl border border-gray-700 px-2 py-2">
           <div className="participant-card__avatar relative">
-            <ParticipantAvatar
-              name={user.name}
-              size="compact"
-              speakingLevel={speakingLevel}
-            />
+            <ParticipantAvatar name={user.name} size="compact" />
             {user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -181,11 +173,12 @@ export default function UserCard(user: UserCardProps) {
       <div className="participant-card-shell participant-card-shell--full flex h-[200px] min-h-[200px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3">
         <div className="flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-2">
           <div className="participant-card__avatar relative">
-            <ParticipantAvatar
-              name={user.name}
+            <AudioVisualizer
+              audio={user.audioStream}
+              muteState={user.muteState}
               size="full"
-              speakingLevel={speakingLevel}
             />
+            <ParticipantAvatar name={user.name} size="full" />
             {!isSelf && user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -289,13 +282,6 @@ export default function UserCard(user: UserCardProps) {
         </div>
 
         <audio ref={audioRef} autoPlay={!isSelf} muted={isSelf} />
-
-        <AudioVisualizer
-          audio={user.audioStream}
-          name={user.name}
-          muteState={user.muteState}
-          onLevel={handleAudioLevel}
-        />
       </div>
     </div>
   )

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
@@ -20,6 +20,10 @@ interface UserCardProps extends UserInfo {
 export default function UserCard(user: UserCardProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
+  const [speakingLevel, setSpeakingLevel] = useState(0)
+  const handleAudioLevel = useCallback((level: number) => {
+    setSpeakingLevel(level)
+  }, [])
   const [canScreenShare] = useState(() => {
     if (typeof navigator === "undefined") return false
     const isMobileDevice = /Mobi|Android|iPhone|iPad|iPod/i.test(
@@ -63,7 +67,11 @@ export default function UserCard(user: UserCardProps) {
       >
         <div className="flex w-full min-w-0 flex-col items-center rounded-xl border border-gray-700 px-2 py-2">
           <div className="participant-card__avatar relative">
-            <ParticipantAvatar name={user.name} size="compact" />
+            <ParticipantAvatar
+              name={user.name}
+              size="compact"
+              speakingLevel={speakingLevel}
+            />
             {user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -173,7 +181,11 @@ export default function UserCard(user: UserCardProps) {
       <div className="participant-card-shell participant-card-shell--full flex h-[200px] min-h-[200px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3">
         <div className="flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-2">
           <div className="participant-card__avatar relative">
-            <ParticipantAvatar name={user.name} size="full" />
+            <ParticipantAvatar
+              name={user.name}
+              size="full"
+              speakingLevel={speakingLevel}
+            />
             {!isSelf && user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -282,6 +294,7 @@ export default function UserCard(user: UserCardProps) {
           audio={user.audioStream}
           name={user.name}
           muteState={user.muteState}
+          onLevel={handleAudioLevel}
         />
       </div>
     </div>

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -120,7 +120,7 @@ export default function UserCard(user: UserCardProps) {
               }
               className="participant-card__voice-button participant-card__voice-button--compact mt-1 min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {user.voiceEnabled ? "🔊" : "🔇"}
+              {user.voiceEnabled ? "VOICE ●" : "VOICE"}
             </button>
           )}
           {isSelf && (
@@ -283,7 +283,7 @@ export default function UserCard(user: UserCardProps) {
               }
               className="participant-card__voice-button participant-card__voice-button--full min-h-7 rounded-full border border-gray-500 px-2 text-[10px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {user.voiceEnabled ? "🔊 Voice" : "🔇 Voice"}
+              {user.voiceEnabled ? "VOICE ●" : "VOICE"}
             </button>
           )}
         </div>

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useRef, useState } from "react"
 
-import Avatar from "boring-avatars"
-
 import { LOCAL_PEER_ID } from "@common/consts"
-import { strToBgColor } from "@common/utils"
 
 import { UserInfo } from "../common/types"
 import AudioVisualizer from "../components/AudioVisualizer"
+import ParticipantAvatar from "../components/ParticipantAvatar"
 
 interface UserCardProps extends UserInfo {
   onMuteSelf?: () => void
@@ -58,13 +56,14 @@ export default function UserCard(user: UserCardProps) {
 
   if (user.compact) {
     return (
-      <div className={user.className}>
-        <div
-          className="flex flex-col items-center rounded-xl border border-gray-700 px-2 py-2"
-          style={{ backgroundColor: strToBgColor(user.name) }}
-        >
-          <div className="relative">
-            <Avatar size={36} variant="beam" name={user.name} />
+      <div
+        className={`participant-card-shell participant-card-shell--compact ${
+          user.className ?? ""
+        }`}
+      >
+        <div className="flex flex-col items-center rounded-xl border border-gray-700 px-2 py-2">
+          <div className="participant-card__avatar relative">
+            <ParticipantAvatar name={user.name} size="compact" />
             {user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -93,7 +92,7 @@ export default function UserCard(user: UserCardProps) {
             {displayName}
           </p>
           {user.kind === "agent" && (
-            <span className="mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
+            <span className="participant-card__kind mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
               🤖 Agent
             </span>
           )}
@@ -116,7 +115,7 @@ export default function UserCard(user: UserCardProps) {
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
-              className="mt-1 min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="participant-card__voice-button participant-card__voice-button--compact mt-1 min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {user.voiceEnabled ? "🔊" : "🔇"}
             </button>
@@ -125,7 +124,7 @@ export default function UserCard(user: UserCardProps) {
             <span
               key={capability}
               title={capability}
-              className="mt-1 max-w-[64px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[8px] text-white/70"
+              className="participant-card__capability mt-1 max-w-[64px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[8px] text-white/70"
             >
               {capability}
             </span>
@@ -133,7 +132,8 @@ export default function UserCard(user: UserCardProps) {
           {isSelf && (
             <div className="mt-1 flex gap-1">
               <button
-                className="opacity-50 transition-opacity hover:opacity-80"
+                type="button"
+                className="participant-card__self-action opacity-50 transition-opacity hover:opacity-80"
                 onClick={user.onMuteSelf}
               >
                 {!user.muteState ? (
@@ -160,7 +160,8 @@ export default function UserCard(user: UserCardProps) {
               </button>
               {canScreenShare && user.screenshareAllowed && (
                 <button
-                  className="opacity-50 transition-opacity hover:opacity-80"
+                  type="button"
+                  className="participant-card__self-action participant-card__self-action--share opacity-50 transition-opacity hover:opacity-80"
                   onClick={user.onToggleScreenShare}
                 >
                   <svg
@@ -183,13 +184,10 @@ export default function UserCard(user: UserCardProps) {
 
   return (
     <div className={user.className}>
-      <div
-        className="flex min-h-[196px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3"
-        style={{ backgroundColor: strToBgColor(user.name) }}
-      >
+      <div className="participant-card-shell participant-card-shell--full flex min-h-[196px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3">
         <div className="flex flex-1 flex-col items-center justify-center gap-2">
-          <div className="relative">
-            <Avatar size={56} variant="beam" name={user.name} />
+          <div className="participant-card__avatar relative">
+            <ParticipantAvatar name={user.name} size="full" />
             {!isSelf && user.muteState && (
               <span className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5">
                 <svg
@@ -204,7 +202,8 @@ export default function UserCard(user: UserCardProps) {
             )}
             {isSelf && (
               <button
-                className="absolute -bottom-1 -left-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
+                type="button"
+                className="participant-card__self-action absolute -bottom-1 -left-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
                 onClick={user.onMuteSelf}
                 title={user.muteState ? "Unmute" : "Mute"}
               >
@@ -231,7 +230,8 @@ export default function UserCard(user: UserCardProps) {
             )}
             {isSelf && canScreenShare && user.screenshareAllowed && (
               <button
-                className="absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
+                type="button"
+                className="participant-card__self-action participant-card__self-action--share absolute -bottom-1 -right-1 rounded-full bg-gray-900 p-0.5 opacity-70 transition-opacity hover:opacity-100"
                 onClick={user.onToggleScreenShare}
                 title="Screen share"
               >
@@ -266,20 +266,20 @@ export default function UserCard(user: UserCardProps) {
         </div>
 
         <div className="mb-1 flex min-h-[18px] flex-wrap items-center justify-center gap-1">
-          <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
+          <span className="participant-card__kind rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
             {user.kind === "agent" ? "🤖 Agent" : "Human"}
           </span>
           {(user.capabilities ?? []).slice(0, 3).map((capability) => (
             <span
               key={capability}
               title={capability}
-              className="max-w-[72px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70"
+              className="participant-card__capability max-w-[72px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70"
             >
               {capability}
             </span>
           ))}
           {(user.capabilities?.length ?? 0) > 3 && (
-            <span className="rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70">
+            <span className="participant-card__capability rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70">
               +{(user.capabilities?.length ?? 0) - 3}
             </span>
           )}
@@ -302,7 +302,7 @@ export default function UserCard(user: UserCardProps) {
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
-              className="min-h-7 rounded-full border border-gray-500 px-2 text-[10px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="participant-card__voice-button participant-card__voice-button--full min-h-7 rounded-full border border-gray-500 px-2 text-[10px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {user.voiceEnabled ? "🔊 Voice" : "🔇 Voice"}
             </button>

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -61,7 +61,7 @@ export default function UserCard(user: UserCardProps) {
           user.className ?? ""
         }`}
       >
-        <div className="flex flex-col items-center rounded-xl border border-gray-700 px-2 py-2">
+        <div className="flex w-full min-w-0 flex-col items-center rounded-xl border border-gray-700 px-2 py-2">
           <div className="participant-card__avatar relative">
             <ParticipantAvatar name={user.name} size="compact" />
             {user.muteState && (
@@ -88,7 +88,7 @@ export default function UserCard(user: UserCardProps) {
               </span>
             )}
           </div>
-          <p className="mt-1.5 w-full truncate text-center text-xs text-white">
+          <p className="mt-1.5 min-w-0 max-w-full truncate text-center text-xs text-white">
             {displayName}
           </p>
           {user.kind === "agent" && (
@@ -96,22 +96,17 @@ export default function UserCard(user: UserCardProps) {
               🤖 Agent
             </span>
           )}
-          {user.kind === "agent" && (
+          {user.kind === "agent" && user.voiceAvailable && (
             <button
               type="button"
               onClick={user.onToggleAgentVoice}
-              disabled={!user.voiceAvailable}
               title={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
+                user.voiceEnabled
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
               aria-label={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
+                user.voiceEnabled
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
@@ -120,15 +115,6 @@ export default function UserCard(user: UserCardProps) {
               {user.voiceEnabled ? "🔊" : "🔇"}
             </button>
           )}
-          {(user.capabilities ?? []).slice(0, 2).map((capability) => (
-            <span
-              key={capability}
-              title={capability}
-              className="participant-card__capability mt-1 max-w-[64px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[8px] text-white/70"
-            >
-              {capability}
-            </span>
-          ))}
           {isSelf && (
             <div className="mt-1 flex gap-1">
               <button
@@ -184,8 +170,8 @@ export default function UserCard(user: UserCardProps) {
 
   return (
     <div className={user.className}>
-      <div className="participant-card-shell participant-card-shell--full flex min-h-[196px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3">
-        <div className="flex flex-1 flex-col items-center justify-center gap-2">
+      <div className="participant-card-shell participant-card-shell--full flex h-[200px] min-h-[200px] w-full flex-col items-center justify-between overflow-hidden rounded-xl border border-gray-700 px-3 py-3">
+        <div className="flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-2">
           <div className="participant-card__avatar relative">
             <ParticipantAvatar name={user.name} size="full" />
             {!isSelf && user.muteState && (
@@ -253,7 +239,7 @@ export default function UserCard(user: UserCardProps) {
           </div>
 
           <p
-            className="w-full break-words text-center text-xs leading-tight text-white"
+            className="w-full min-w-0 max-w-full truncate whitespace-nowrap text-center text-xs leading-tight text-white"
             title={displayName}
           >
             {isSelf ? user.name : displayName}
@@ -269,36 +255,17 @@ export default function UserCard(user: UserCardProps) {
           <span className="participant-card__kind rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
             {user.kind === "agent" ? "🤖 Agent" : "Human"}
           </span>
-          {(user.capabilities ?? []).slice(0, 3).map((capability) => (
-            <span
-              key={capability}
-              title={capability}
-              className="participant-card__capability max-w-[72px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70"
-            >
-              {capability}
-            </span>
-          ))}
-          {(user.capabilities?.length ?? 0) > 3 && (
-            <span className="participant-card__capability rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70">
-              +{(user.capabilities?.length ?? 0) - 3}
-            </span>
-          )}
-          {user.kind === "agent" && (
+          {user.kind === "agent" && user.voiceAvailable && (
             <button
               type="button"
               onClick={user.onToggleAgentVoice}
-              disabled={!user.voiceAvailable}
               title={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
+                user.voiceEnabled
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }
               aria-label={
-                !user.voiceAvailable
-                  ? "Voice unavailable"
-                  : user.voiceEnabled
+                user.voiceEnabled
                   ? `Mute ${user.name}`
                   : `Enable voice for ${user.name}`
               }

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -2,11 +2,11 @@ import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 /**
  * #228/#234 participant-card visual consistency: in the NORMAL participant
- * grid, every UserCard root carries the SAME uniform min-height contract, so
- * Agent-only controls (Voice) live inside a shared reserved card height
- * instead of stretching Agent cards taller than Human cards.
+ * grid, every UserCard root carries the SAME fixed height contract, so
+ * Agent-only controls (Voice) live inside a shared card height instead of
+ * stretching Agent cards taller than Human cards.
  * jsdom cannot measure layout; this pins the class contract that produces
- * equal heights (uniform min-height on every normal card root). Visual
+ * equal heights (fixed height on every normal card root). Visual
  * confirmation happens in the production regression pass.
  */
 
@@ -79,11 +79,11 @@ describe("participant card equal-height contract (#228)", () => {
       <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
     )
 
-    // Every normal-grid participant card root carries the SAME uniform
-    // min-height — Human self, Agents with controls, remote Humans.
+    // Every normal-grid participant card root carries the SAME fixed height —
+    // Human self, Agents with controls, remote Humans.
     const cards = Array.from(
       document.querySelectorAll("div.rounded-xl.border-gray-700")
-    ).filter((el) => el.className.includes("min-h-[196px]"))
+    ).filter((el) => el.className.includes("h-[200px]"))
     expect(cards.length).toBe(3)
 
     // The grid top-aligns rows; no full-panel-height stretching remains.

--- a/app/src/components/roomCapabilities.wiring.test.tsx
+++ b/app/src/components/roomCapabilities.wiring.test.tsx
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 /**
  * #234 production wiring proof: after the Request-work modal and the Human
  * self-capability editor were removed, RoomContent must never render either
- * entry point, and Agent advertised capability chips still surface from the
- * canonical Room participant state.
+ * entry point. Agent capability metadata remains in the canonical Room
+ * participant state but is not part of the default participant-card UI.
  */
 
 vi.mock("next/router", () => ({

--- a/app/src/mcp/server.test.ts
+++ b/app/src/mcp/server.test.ts
@@ -42,7 +42,7 @@ describe("public MCP tool surface", () => {
     expect(names).toHaveLength(17)
   })
 
-  it("preserves the server Agent lease through join_room and create_room", async () => {
+  it("preserves legacy Room ids and the server Agent lease", async () => {
     const leaseMs = 90_000
     const sessions = new Map<string, RoomSession>()
     const sessionFor = (room: string) => {
@@ -129,14 +129,21 @@ describe("public MCP tool surface", () => {
       return JSON.parse(text ?? "{}") as Record<string, unknown>
     }
 
+    const uuidRoomId = "123e4567-e89b-42d3-a456-426614174000"
+    const legacyRoomId = "room-239"
     const joined = await callTool("join_room", {
-      roomId: "room-239",
+      roomId: uuidRoomId,
       name: "Join Agent",
+    })
+    const legacyJoined = await callTool("join_room", {
+      roomId: legacyRoomId,
+      name: "Legacy Agent",
     })
     const created = await callTool("create_room", {
       name: "Create Agent",
     })
     expect(joined.agentLeaseMs).toBe(leaseMs)
+    expect(legacyJoined.agentLeaseMs).toBe(leaseMs)
     expect(created.agentLeaseMs).toBe(leaseMs)
     expect(created.invite).toMatchObject({
       roomId: expect.stringMatching(
@@ -146,7 +153,9 @@ describe("public MCP tool surface", () => {
     expect((created.invite as { roomUrl: string }).roomUrl).toContain(
       encodeURIComponent((created.invite as { roomId: string }).roomId)
     )
-    expect(sessions.size).toBe(2)
+    expect(sessions.has(uuidRoomId)).toBe(true)
+    expect(sessions.has(legacyRoomId)).toBe(true)
+    expect(sessions.size).toBe(3)
   })
 
   it("retries a cosmic Room id collision without joining the first id", async () => {

--- a/app/src/mcp/server.test.ts
+++ b/app/src/mcp/server.test.ts
@@ -138,6 +138,110 @@ describe("public MCP tool surface", () => {
     })
     expect(joined.agentLeaseMs).toBe(leaseMs)
     expect(created.agentLeaseMs).toBe(leaseMs)
+    expect(created.invite).toMatchObject({
+      roomId: expect.stringMatching(
+        /^[a-z]+-[a-z]+-[23456789abcdefghjkmnpqrstuvwxyz]{12}$/
+      ),
+    })
+    expect((created.invite as { roomUrl: string }).roomUrl).toContain(
+      encodeURIComponent((created.invite as { roomId: string }).roomId)
+    )
     expect(sessions.size).toBe(2)
+  })
+
+  it("retries a cosmic Room id collision without joining the first id", async () => {
+    const attemptedRoomIds: string[] = []
+    let attempts = 0
+    let entropyCalls = 0
+    const entropy = vi
+      .spyOn(globalThis.crypto, "getRandomValues")
+      .mockImplementation((array) => {
+        const value = entropyCalls < 14 ? 0 : 0x80000000
+        entropyCalls += 1
+        const values = array as Uint32Array
+        values.fill(value)
+        return array
+      })
+    const env = {
+      ROOMS_KV: {
+        get: vi.fn(async () => null),
+        put: vi.fn(async () => undefined),
+      },
+      SFU_ROOM: {
+        idFromName: (name: string) => {
+          attemptedRoomIds.push(name)
+          return name
+        },
+        get: () => ({
+          fetch: async () => {
+            attempts += 1
+            if (attempts === 1) {
+              return new Response(
+                JSON.stringify({ error: "room_already_exists" }),
+                {
+                  status: 409,
+                  headers: { "Content-Type": "application/json" },
+                }
+              )
+            }
+            return new Response(
+              JSON.stringify({
+                participant: { id: "agent-1", name: "Pi", kind: "agent" },
+                cursor: 0,
+                expiresAt: 0,
+                agentLeaseMs: 90_000,
+              }),
+              { headers: { "Content-Type": "application/json" } }
+            )
+          },
+        }),
+      },
+    } as unknown as McpEnv
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://www.free4.chat/mcp", {
+          method: "POST",
+          headers: {
+            Origin: "https://www.free4.chat",
+            Host: "www.free4.chat",
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "Mcp-Method": "tools/call",
+            "Mcp-Name": "create_room",
+            "MCP-Protocol-Version": "2026-07-28",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "create_room",
+              arguments: { name: "Pi" },
+              _meta: {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+              },
+            },
+          }),
+        }),
+        env,
+        {} as ExecutionContext
+      )
+      const payload = (await response.json()) as {
+        result?: { content?: Array<{ type?: string; text?: string }> }
+      }
+      const result = JSON.parse(
+        payload.result?.content?.find((block) => block.type === "text")?.text ??
+          "{}"
+      ) as { invite?: { roomId?: string } }
+
+      expect(response.status).toBe(200)
+      expect(attempts).toBe(2)
+      expect(attemptedRoomIds).toHaveLength(2)
+      expect(attemptedRoomIds[0]).not.toBe(attemptedRoomIds[1])
+      expect(result.invite?.roomId).toBe(attemptedRoomIds[1])
+    } finally {
+      entropy.mockRestore()
+    }
   })
 })

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 
 import { buildRoomInvite } from "./invite"
 import { imageToolResult } from "./toolResults"
+import { generateRoomName } from "../common/cosmicNames"
 import { classifyRoomCreationSource } from "../do/roomAnalytics"
 import type { RoomSession } from "../do/RoomSession"
 
@@ -369,7 +370,7 @@ function createMcpServer(context: McpRequestContext) {
         context.requestInfo.headers.get("user-agent") ?? ""
       )
       for (let attempt = 0; attempt < 3; attempt += 1) {
-        roomId = crypto.randomUUID()
+        roomId = generateRoomName()
         const result = await roomControl(env, roomId, {
           action: "agent-create-room",
           creationSource,

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -4,7 +4,10 @@ import Link from "next/link"
 import { useRouter } from "next/router"
 
 import {
-  randomName,
+  generateParticipantName,
+  generateRoomName,
+} from "../common/cosmicNames"
+import {
   saveRoomToLocalStorage,
   umamiEvent,
   trackAnalyticsEvent,
@@ -30,7 +33,8 @@ export default function Home() {
   const [isDesktop, setIsDesktop] = useState<boolean>(false)
 
   useEffect(() => {
-    setRoomName(randomName())
+    setRoomName(generateRoomName())
+    setNickName(generateParticipantName())
     setIsDesktop(!/Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent))
   }, [])
 
@@ -105,7 +109,7 @@ export default function Home() {
 
                   <span className="absolute inset-y-0 right-0 grid w-10 place-content-center">
                     <button
-                      onClick={() => setRoomName(randomName())}
+                      onClick={() => setRoomName(generateRoomName())}
                       type="button"
                       className={diceClasses}
                       title="Randomize room name"
@@ -142,7 +146,7 @@ export default function Home() {
 
                   <span className="absolute inset-y-0 right-0 grid w-10 place-content-center">
                     <button
-                      onClick={() => setNickName(randomName())}
+                      onClick={() => setNickName(generateParticipantName())}
                       type="button"
                       className={diceClasses}
                       title="Randomize nickname"

--- a/app/src/pages/room.tsx
+++ b/app/src/pages/room.tsx
@@ -4,8 +4,8 @@ import dynamic from "next/dynamic"
 import Head from "next/head"
 import { useRouter } from "next/router"
 
+import { generateParticipantName } from "../common/cosmicNames"
 import {
-  randomName,
   saveRoomToLocalStorage,
   gtagEvent,
   umamiEvent,
@@ -51,9 +51,11 @@ export default function Room() {
           setNickName(room.nickName)
           setReady(true)
         } else {
+          setNickName(generateParticipantName())
           setShowNickNamePop(true)
         }
       } catch {
+        setNickName(generateParticipantName())
         setShowNickNamePop(true)
       }
     }
@@ -101,7 +103,7 @@ export default function Room() {
               />
               <span className="absolute inset-y-0 right-0 grid w-10 place-content-center">
                 <button
-                  onClick={() => setNickName(randomName())}
+                  onClick={() => setNickName(generateParticipantName())}
                   type="button"
                   className="text-black hover:bg-red-400"
                 >

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -216,6 +216,15 @@ html {
     transform 160ms ease;
 }
 
+.participant-card-shell--full {
+  height: 12.5rem;
+  min-height: 12.5rem;
+}
+
+.room-shell .participant-card__capability {
+  display: none;
+}
+
 .participant-card-shell--full:hover,
 .participant-card-shell--compact > div:hover {
   border-color: rgba(103, 232, 249, 0.7) !important;
@@ -361,8 +370,26 @@ html {
 }
 
 .participant-card-shell--full > .room-visualizer,
-.participant-card-shell--compact .room-visualizer {
-  width: 100%;
+.participant-card-shell--compact > div > .room-visualizer {
+  position: absolute;
+  right: 0.65rem;
+  bottom: 0.65rem;
+  left: 0.65rem;
+  z-index: 0;
+  width: auto !important;
+  height: 2.5rem;
+  margin: 0 !important;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  opacity: 0.48;
+  pointer-events: none;
+}
+
+.participant-card-shell--full > :not(.room-visualizer),
+.participant-card-shell--compact > div > :not(.room-visualizer) {
+  position: relative;
+  z-index: 1;
 }
 
 .room-visualizer {
@@ -388,7 +415,7 @@ html {
   display: block;
   width: 86% !important;
   margin: 0 auto;
-  opacity: 0.92;
+  opacity: 0.82;
 }
 
 .room-chat-panel {

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -82,3 +82,323 @@ html {
     animation: none;
   }
 }
+
+/* --- Room visual skin (presentation only) ---
+
+   The selectors below deliberately target the production Room structure. They
+   do not change participant state, media behavior, or the placement of any
+   existing interaction. */
+
+.room-shell {
+  position: relative;
+  isolation: isolate;
+  background-color: #050b18 !important;
+  background-image: radial-gradient(
+      circle at 15% 12%,
+      rgba(103, 232, 249, 0.08),
+      transparent 28rem
+    ),
+    radial-gradient(
+      circle at 85% 86%,
+      rgba(167, 139, 250, 0.07),
+      transparent 30rem
+    ),
+    linear-gradient(rgba(103, 232, 249, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(103, 232, 249, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 32px 32px, 32px 32px;
+}
+
+.room-shell::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(103, 232, 249, 0.025) 0,
+    rgba(103, 232, 249, 0.025) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.room-header {
+  border-color: rgba(71, 85, 105, 0.72) !important;
+  background: rgba(3, 9, 22, 0.9);
+  box-shadow: 0 1px 0 rgba(103, 232, 249, 0.06);
+}
+
+.room-header h1 {
+  color: #dffaff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.03em;
+  text-shadow: 0 0 14px rgba(103, 232, 249, 0.22);
+}
+
+.room-header button {
+  border-color: rgba(100, 116, 139, 0.78) !important;
+  background: rgba(15, 23, 42, 0.86) !important;
+  color: #cbd5e1 !important;
+  transition: border-color 160ms ease, color 160ms ease, box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.room-header button:hover,
+.room-header button:focus-visible {
+  border-color: rgba(103, 232, 249, 0.82) !important;
+  background: rgba(8, 47, 73, 0.62) !important;
+  box-shadow: 0 0 14px rgba(103, 232, 249, 0.12);
+  color: #ecfeff !important;
+  outline: none;
+}
+
+.room-content {
+  background: transparent;
+}
+
+.room-panel {
+  border-color: rgba(51, 65, 85, 0.8) !important;
+  background: rgba(3, 9, 22, 0.52);
+}
+
+.room-participants-grid {
+  background-image: radial-gradient(
+    circle at 8% 18%,
+    rgba(103, 232, 249, 0.1) 0 1px,
+    transparent 1.5px
+  );
+  background-size: 92px 86px;
+}
+
+.room-participant-strip {
+  border-color: rgba(51, 65, 85, 0.86) !important;
+  background: rgba(2, 8, 20, 0.88);
+}
+
+.room-participant-strip > div {
+  border-radius: 0.75rem;
+}
+
+.room-reactions {
+  margin-top: -0.15rem;
+  padding: 0.12rem 0.35rem;
+  border: 1px solid rgba(103, 232, 249, 0.18);
+  border-radius: 999px;
+  background: rgba(2, 8, 20, 0.62);
+}
+
+.room-reactions button {
+  border-radius: 999px;
+  padding: 0.12rem 0.35rem;
+  font-size: 0.9rem;
+  line-height: 1;
+  transition: background 160ms ease, transform 160ms ease, filter 160ms ease;
+}
+
+.room-reactions button:hover,
+.room-reactions button:focus-visible {
+  background: rgba(103, 232, 249, 0.16);
+  filter: drop-shadow(0 0 5px rgba(103, 232, 249, 0.45));
+  outline: none;
+  transform: translateY(-1px) scale(1.12);
+}
+
+.participant-card-shell--full,
+.participant-card-shell--compact > div {
+  position: relative;
+  border-color: color-mix(in srgb, #67e8f9 26%, #334155) !important;
+  background: linear-gradient(145deg, rgba(8, 47, 73, 0.32), transparent 42%),
+    rgba(6, 14, 30, 0.88) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 28px rgba(0, 0, 0, 0.18);
+  transition: border-color 160ms ease, box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.participant-card-shell--full:hover,
+.participant-card-shell--compact > div:hover {
+  border-color: rgba(103, 232, 249, 0.7) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 22px rgba(103, 232, 249, 0.1);
+  transform: translateY(-1px);
+}
+
+.participant-card-shell--full::before,
+.participant-card-shell--full::after,
+.participant-card-shell--compact > div::before,
+.participant-card-shell--compact > div::after {
+  position: absolute;
+  width: 1.15rem;
+  height: 0.35rem;
+  border-color: rgba(103, 232, 249, 0.72);
+  content: "";
+  pointer-events: none;
+}
+
+.participant-card-shell--full::before,
+.participant-card-shell--compact > div::before {
+  top: 0.45rem;
+  left: 0.45rem;
+  border-top: 1px solid;
+  border-left: 1px solid;
+}
+
+.participant-card-shell--full::after,
+.participant-card-shell--compact > div::after {
+  right: 0.45rem;
+  bottom: 0.45rem;
+  border-right: 1px solid;
+  border-bottom: 1px solid;
+  opacity: 0.45;
+}
+
+.participant-card__avatar {
+  display: grid;
+  place-items: center;
+  padding: 0.18rem;
+  border: 1px solid rgba(103, 232, 249, 0.28);
+  border-radius: 50%;
+  background: rgba(2, 8, 20, 0.72);
+  box-shadow: 0 0 14px rgba(103, 232, 249, 0.12);
+}
+
+.participant-avatar {
+  display: block;
+  width: 56px;
+  height: 56px;
+}
+
+.participant-avatar--compact {
+  width: 36px;
+  height: 36px;
+}
+
+.participant-avatar.text-chat-avatar {
+  width: 28px;
+  height: 28px;
+}
+
+.participant-avatar svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.08) drop-shadow(0 0 7px rgba(103, 232, 249, 0.2));
+}
+
+.participant-card__kind,
+.participant-card__capability {
+  border: 1px solid rgba(103, 232, 249, 0.24);
+  background: rgba(8, 47, 73, 0.4) !important;
+  color: #b9f7ff !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.02em;
+}
+
+.participant-card__capability {
+  border-color: rgba(167, 139, 250, 0.3);
+  background: rgba(49, 46, 129, 0.3) !important;
+  color: #ddd6fe !important;
+}
+
+.participant-card__voice-button {
+  min-width: 3.8rem;
+  border-color: rgba(167, 139, 250, 0.62) !important;
+  border-radius: 0.45rem !important;
+  background: rgba(49, 46, 129, 0.28) !important;
+  color: #e9d5ff !important;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.04em;
+  transition: border-color 160ms ease, background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.participant-card__voice-button:hover:not(:disabled),
+.participant-card__voice-button:focus-visible {
+  border-color: #c4b5fd !important;
+  background: rgba(109, 40, 217, 0.38) !important;
+  box-shadow: 0 0 12px rgba(167, 139, 250, 0.18);
+  outline: none;
+}
+
+.participant-card__voice-button:disabled {
+  border-color: rgba(100, 116, 139, 0.45) !important;
+  background: rgba(15, 23, 42, 0.58) !important;
+  color: #64748b !important;
+}
+
+.participant-card__self-action {
+  display: grid;
+  width: 1.55rem;
+  height: 1.55rem;
+  place-items: center;
+  border: 1px solid rgba(103, 232, 249, 0.44) !important;
+  border-radius: 0.4rem !important;
+  background: rgba(2, 8, 20, 0.94) !important;
+  color: #cbd5e1;
+  opacity: 1 !important;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease,
+    transform 160ms ease;
+}
+
+.participant-card__self-action:hover,
+.participant-card__self-action:focus-visible {
+  border-color: #67e8f9 !important;
+  background: rgba(8, 47, 73, 0.9) !important;
+  color: #ecfeff;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.participant-card__self-action--share {
+  border-color: rgba(190, 242, 100, 0.52) !important;
+  color: #d9f99d;
+}
+
+.participant-card__self-action svg {
+  width: 0.82rem;
+  height: 0.82rem;
+}
+
+.participant-card-shell--full > .room-visualizer,
+.participant-card-shell--compact .room-visualizer {
+  width: 100%;
+}
+
+.room-visualizer {
+  position: relative;
+  border: 1px solid rgba(103, 232, 249, 0.22);
+  border-radius: 0.45rem;
+  background: rgba(2, 8, 20, 0.72);
+  box-shadow: inset 0 0 12px rgba(103, 232, 249, 0.06);
+}
+
+.room-visualizer::before {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  left: 0.45rem;
+  border-top: 1px dashed rgba(103, 232, 249, 0.18);
+  content: "";
+  pointer-events: none;
+}
+
+.room-visualizer__canvas {
+  position: relative;
+  display: block;
+  width: 86% !important;
+  margin: 0 auto;
+  opacity: 0.92;
+}
+
+.room-chat-panel {
+  background: rgba(2, 8, 20, 0.66);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .room-shell *,
+  .room-shell *::before,
+  .room-shell *::after {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -216,6 +216,11 @@ html {
     transform 160ms ease;
 }
 
+.participant-card-shell--compact > div {
+  height: 8rem;
+  min-height: 8rem;
+}
+
 .participant-card-shell--full {
   height: 12.5rem;
   min-height: 12.5rem;
@@ -233,35 +238,6 @@ html {
   transform: translateY(-1px);
 }
 
-.participant-card-shell--full::before,
-.participant-card-shell--full::after,
-.participant-card-shell--compact > div::before,
-.participant-card-shell--compact > div::after {
-  position: absolute;
-  width: 1.15rem;
-  height: 0.35rem;
-  border-color: rgba(103, 232, 249, 0.72);
-  content: "";
-  pointer-events: none;
-}
-
-.participant-card-shell--full::before,
-.participant-card-shell--compact > div::before {
-  top: 0.45rem;
-  left: 0.45rem;
-  border-top: 1px solid;
-  border-left: 1px solid;
-}
-
-.participant-card-shell--full::after,
-.participant-card-shell--compact > div::after {
-  right: 0.45rem;
-  bottom: 0.45rem;
-  border-right: 1px solid;
-  border-bottom: 1px solid;
-  opacity: 0.45;
-}
-
 .participant-card__avatar {
   display: grid;
   place-items: center;
@@ -273,9 +249,13 @@ html {
 }
 
 .participant-avatar {
+  position: relative;
+  flex: 0 0 auto;
   display: block;
   width: 56px;
   height: 56px;
+  isolation: isolate;
+  overflow: visible;
 }
 
 .participant-avatar--compact {
@@ -293,6 +273,63 @@ html {
   width: 100%;
   height: 100%;
   filter: saturate(1.08) drop-shadow(0 0 7px rgba(103, 232, 249, 0.2));
+}
+
+.participant-avatar__planet {
+  position: relative;
+  z-index: 1;
+  display: block !important;
+  width: 56px !important;
+  height: 56px !important;
+}
+
+.participant-avatar--compact .participant-avatar__planet {
+  width: 36px !important;
+  height: 36px !important;
+}
+
+.participant-avatar__ripple {
+  position: absolute;
+  z-index: 0;
+  inset: -0.35rem;
+  border: 1px solid rgba(103, 232, 249, 0.78);
+  border-radius: 50%;
+  opacity: 0;
+  pointer-events: none;
+  will-change: opacity, transform;
+}
+
+.participant-avatar__ripple--two {
+  inset: -0.35rem;
+  border-color: rgba(167, 139, 250, 0.58);
+}
+
+.participant-avatar--compact .participant-avatar__ripple {
+  inset: -0.23rem;
+}
+
+.participant-avatar[data-speaking="true"] .participant-avatar__ripple--one {
+  animation: participant-avatar-ripple 1.35s ease-out infinite;
+}
+
+.participant-avatar[data-speaking="true"] .participant-avatar__ripple--two {
+  animation: participant-avatar-ripple 1.35s 0.48s ease-out infinite;
+}
+
+@keyframes participant-avatar-ripple {
+  0% {
+    opacity: calc(0.22 + var(--speaking-level) * 0.52);
+    transform: scale(0.9);
+  }
+
+  72% {
+    opacity: 0.08;
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1.58);
+  }
 }
 
 .participant-card__kind,
@@ -427,5 +464,9 @@ html {
   .room-shell *::before,
   .room-shell *::after {
     transition-duration: 0.01ms !important;
+  }
+
+  .participant-avatar__ripple {
+    animation: none !important;
   }
 }

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -310,10 +310,12 @@ html {
 
 .participant-avatar[data-speaking="true"] .participant-avatar__ripple--one {
   animation: participant-avatar-ripple 1.35s ease-out infinite;
+  animation-duration: var(--ripple-duration, 1.8s);
 }
 
 .participant-avatar[data-speaking="true"] .participant-avatar__ripple--two {
   animation: participant-avatar-ripple 1.35s 0.48s ease-out infinite;
+  animation-duration: var(--ripple-duration, 1.8s);
 }
 
 @keyframes participant-avatar-ripple {
@@ -404,55 +406,6 @@ html {
 .participant-card__self-action svg {
   width: 0.82rem;
   height: 0.82rem;
-}
-
-.participant-card-shell--full > .room-visualizer,
-.participant-card-shell--compact > div > .room-visualizer {
-  position: absolute;
-  right: 0.65rem;
-  bottom: 0.65rem;
-  left: 0.65rem;
-  z-index: 0;
-  width: auto !important;
-  height: 2.5rem;
-  margin: 0 !important;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-  opacity: 0.48;
-  pointer-events: none;
-}
-
-.participant-card-shell--full > :not(.room-visualizer),
-.participant-card-shell--compact > div > :not(.room-visualizer) {
-  position: relative;
-  z-index: 1;
-}
-
-.room-visualizer {
-  position: relative;
-  border: 1px solid rgba(103, 232, 249, 0.22);
-  border-radius: 0.45rem;
-  background: rgba(2, 8, 20, 0.72);
-  box-shadow: inset 0 0 12px rgba(103, 232, 249, 0.06);
-}
-
-.room-visualizer::before {
-  position: absolute;
-  top: 50%;
-  right: 0.45rem;
-  left: 0.45rem;
-  border-top: 1px dashed rgba(103, 232, 249, 0.18);
-  content: "";
-  pointer-events: none;
-}
-
-.room-visualizer__canvas {
-  position: relative;
-  display: block;
-  width: 86% !important;
-  margin: 0 auto;
-  opacity: 0.82;
 }
 
 .room-chat-panel {

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -239,6 +239,7 @@ html {
 }
 
 .participant-card__avatar {
+  position: relative;
   display: grid;
   place-items: center;
   padding: 0.18rem;
@@ -288,50 +289,23 @@ html {
   height: 36px !important;
 }
 
-.participant-avatar__ripple {
+.participant-audio-orbit {
   position: absolute;
+  top: 50%;
+  left: 50%;
   z-index: 0;
-  inset: -0.35rem;
-  border: 1px solid rgba(103, 232, 249, 0.78);
-  border-radius: 50%;
-  opacity: 0;
+  display: block;
+  width: 5.1rem;
+  height: 5.1rem;
+  max-width: none;
+  transform: translate(-50%, -50%);
   pointer-events: none;
-  will-change: opacity, transform;
+  overflow: visible;
 }
 
-.participant-avatar__ripple--two {
-  inset: -0.35rem;
-  border-color: rgba(167, 139, 250, 0.58);
-}
-
-.participant-avatar--compact .participant-avatar__ripple {
-  inset: -0.23rem;
-}
-
-.participant-avatar[data-speaking="true"] .participant-avatar__ripple--one {
-  animation: participant-avatar-ripple 1.35s ease-out infinite;
-  animation-duration: var(--ripple-duration, 1.8s);
-}
-
-.participant-avatar[data-speaking="true"] .participant-avatar__ripple--two {
-  animation: participant-avatar-ripple 1.35s 0.48s ease-out infinite;
-  animation-duration: var(--ripple-duration, 1.8s);
-}
-
-@keyframes participant-avatar-ripple {
-  0% {
-    opacity: calc(0.22 + var(--speaking-level) * 0.52);
-    transform: scale(0.9);
-  }
-
-  72% {
-    opacity: 0.08;
-  }
-
-  100% {
-    opacity: 0;
-    transform: scale(1.58);
-  }
+.participant-audio-orbit--compact {
+  width: 3.25rem;
+  height: 3.25rem;
 }
 
 .participant-card__kind,
@@ -417,9 +391,5 @@ html {
   .room-shell *::before,
   .room-shell *::after {
     transition-duration: 0.01ms !important;
-  }
-
-  .participant-avatar__ripple {
-    animation: none !important;
   }
 }

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -336,9 +336,9 @@ html {
 
 .participant-card__kind,
 .participant-card__capability {
-  border: 1px solid rgba(103, 232, 249, 0.24);
-  background: rgba(8, 47, 73, 0.4) !important;
-  color: #b9f7ff !important;
+  border: 1px solid rgba(103, 232, 249, 0.16);
+  background: rgba(8, 47, 73, 0.24) !important;
+  color: rgba(185, 247, 255, 0.72) !important;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   letter-spacing: 0.02em;
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -8166,11 +8166,6 @@ unified@^11.0.0:
     trough "^2.0.0"
     vfile "^6.0.0"
 
-unique-names-generator@^4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/unique-names-generator/-/unique-names-generator-4.7.1.tgz#966407b12ba97f618928f77322cfac8c80df5597"
-  integrity sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==
-
 unist-util-is@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3592,11 +3592,6 @@ body-parser@^2.2.1:
     raw-body "^3.0.1"
     type-is "^2.0.1"
 
-boring-avatars@^1.7.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/boring-avatars/-/boring-avatars-1.11.2.tgz#365e0b765fb0065ca0cb2fd20c200674d0a9ded6"
-  integrity sha512-3+wkwPeObwS4R37FGXMYViqc4iTrIRj5yzfX9Qy4mnpZ26sX41dGMhsAgmKks1r/uufY1pl4vpgzMWHYfJRb2A==
-
 bowser@^2.11.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
@@ -6924,6 +6919,11 @@ pirates@^4.0.1:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+planet-avatar@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/planet-avatar/-/planet-avatar-0.1.0.tgz#ba6d923ef183b405c7c682ba070403f4a45097b8"
+  integrity sha512-FtRx2rbbuuas5mA6WHA1LeTJORJqHG2FNEJKTvU4hGJ43ZWFVFDyGCeoTZKBd5AC+stgZ24Wrkvrm367rcfZOw==
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary

- Rebuild the Room presentation from the latest `cf-sfu` production structure with a restrained retro-sci-fi terminal skin.
- Use deterministic, self-contained `planet-avatar` artwork for Human and Agent participants and aligned chat/attachment avatars.
- Keep the existing Room behavior and media semantics: participant cards, per-Agent Voice controls, local mute/share, multiple screen-share switching, reactions, chat/composer, attachments, and responsive layout.
- Add cosmic naming only for newly generated Rooms and anonymous browser Human defaults.

## Scope and behavior contract

This PR supersedes the earlier #264 constellation/node direction. The Room UI now has a fixed participant-card composition, a local circular audio orbit around active avatars, explicit existing controls, and the production screen-share viewer/compact switching strip. The final naming polish does not alter those components.

Existing behavior remains authoritative:

- every eligible Agent keeps its own Voice control and availability state;
- local mute/unmute and screen-share controls stay on the local participant card;
- multiple simultaneous screen shares keep the existing active-share viewer and switching strip;
- reactions remain compact and adjacent to the local participant;
- text chat, attachments, pending files, ordering, composer behavior, and mobile layout remain intact;
- Agent names, manually entered Human names, participant handles, authorization, and Room lifecycle semantics are unchanged.

No SFU, RoomSession, Runtime, ACP, MCP authorization, media publication/subscription, or screen-share state semantics were changed. The MCP change only selects a new public Room-id format in `create_room`; participant IDs, tokens, handles, and bounded create-only collision retry remain unchanged.

## Visual implementation

- `ParticipantAvatar` wraps `PlanetAvatar` from `planet-avatar`; the visible participant name remains its stable seed.
- Room-scoped CSS provides the deep-space navy, scanlines, terminal typography, restrained glows, fixed card composition, explicit controls, and screen-share treatment.
- The circular Web Audio/canvas orbit is presentation-only, stays local to the avatar, and is absent without an active unmuted track.

## Cosmic naming polish

- Newly auto-generated browser Rooms and MCP `create_room` Rooms use lowercase `<cosmic-root>-<region>-<secure-suffix>` IDs.
- The 12-character suffix is generated from `globalThis.crypto` using a URL-safe lowercase alphabet; the readable prefix is not used as the uniqueness mechanism.
- Anonymous browser Humans receive an editable TitleCase planet-style default nickname. Saved/manual Human names and explicit Agent names remain authoritative.
- Existing UUID, legacy, and manually entered Room IDs remain fully supported; no alias layer, migration, persistence, or cosmic-format validation was added.

## Validation

- `cd app && yarn prettier --check .` ✅
- `cd app && yarn eslint src --no-fix` ✅
- `cd app && yarn type-check` ✅
- `cd app && yarn docs:check` ✅
- `cd app && yarn test --run` ✅ (65 files, 623 tests)
- `cd app && yarn cf-build` ✅
- `git diff --check` ✅

The test-only AudioVisualizer fixture supplies Web Audio/canvas APIs in jsdom; it does not change production UI or behavior.

The MCP compatibility regression explicitly joins both an existing UUID Room ID and a legacy arbitrary Room ID, asserting that each is passed through unchanged while new `create_room` calls use the cosmic format.

Closes #258
Supersedes #264
