### PR TITLE
[codex] fix responsive Room layout and terminal styling

### DIFF
--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -498,7 +498,7 @@ export default function RoomContent({
               leaveRoom()
               router.push("/")
             }}
-            className="shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:hidden"
+            className="room-header-leave shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:hidden"
           >
             Leave
           </button>
@@ -507,7 +507,7 @@ export default function RoomContent({
           data-testid="room-header-features"
           className="flex flex-none flex-col gap-2 lg:ml-auto lg:flex-row lg:items-center lg:gap-2"
         >
-          <div className="grid grid-cols-3 gap-2 lg:flex lg:items-center">
+          <div className="room-header-toolbar grid grid-cols-3 gap-2 lg:flex lg:items-center">
             <button
               type="button"
               onClick={copyRoomLink}
@@ -559,7 +559,7 @@ export default function RoomContent({
               leaveRoom()
               router.push("/")
             }}
-            className="hidden shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:inline-flex"
+            className="room-header-leave hidden shrink-0 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 lg:inline-flex"
           >
             Leave
           </button>
@@ -617,7 +617,7 @@ export default function RoomContent({
         className="room-content flex flex-1 flex-col overflow-hidden md:flex-row"
       >
         <div
-          className="room-panel flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
+          className="room-panel room-participants-panel flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
           {/* #111: Agent workspace snapshots — observation only, available in
@@ -685,7 +685,7 @@ export default function RoomContent({
                 </div>
               </>
             ) : (
-              <div className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start gap-2 overflow-y-auto p-3">
+              <div className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start justify-center gap-2 overflow-y-auto p-3">
                 {participants.map((p) => (
                   <div
                     key={p.peerId}

--- a/app/src/components/participantCardAlignment.test.tsx
+++ b/app/src/components/participantCardAlignment.test.tsx
@@ -89,6 +89,7 @@ describe("participant card equal-height contract (#228)", () => {
     // The grid top-aligns rows; no full-panel-height stretching remains.
     const grid = document.querySelector(".flex-wrap.items-start")
     expect(grid).toBeTruthy()
+    expect(grid).toHaveClass("justify-center")
     expect(document.querySelector(".flex-wrap.items-stretch")).toBeNull()
     expect(document.querySelectorAll("[data-peer]").length).toBe(0)
   })

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -72,7 +72,7 @@ export default function Home() {
       <Header></Header>
       <main className="flex min-h-screen flex-col">
         <div className="mx-auto flex w-full max-w-screen-xl flex-1 flex-col overflow-y-auto px-4 py-12">
-          <div className="slogan mx-auto my-auto w-full max-w-3xl text-center">
+          <div className="slogan mx-auto my-auto w-full max-w-5xl text-center">
             <p className="font-mono text-xs tracking-widest text-emerald-500">
               FREE4CHAT://TERMINAL — SESSION READY
               <span className="cursor-blink" />
@@ -91,9 +91,9 @@ export default function Home() {
               No permanent Room history — empty Rooms expire automatically.
             </p>
 
-            <div className="mx-auto mt-8 max-w-xl">
+            <div className="mx-auto mt-8 w-full max-w-xl lg:max-w-5xl">
               <div className="flex flex-col gap-4 sm:flex-row">
-                <div className="relative flex-1">
+                <div className="relative min-w-0 flex-1 sm:flex-[1.35]">
                   <label htmlFor="room" className="sr-only">
                     Room
                   </label>
@@ -127,7 +127,7 @@ export default function Home() {
                   </span>
                 </div>
 
-                <div className="relative flex-1">
+                <div className="relative min-w-0 flex-1">
                   <label htmlFor="nickname" className="sr-only">
                     Nickname
                   </label>

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -92,19 +92,19 @@ html {
 .room-shell {
   position: relative;
   isolation: isolate;
-  background-color: #050b18 !important;
+  background-color: #020806 !important;
   background-image: radial-gradient(
       circle at 15% 12%,
-      rgba(103, 232, 249, 0.08),
+      rgba(16, 185, 129, 0.09),
       transparent 28rem
     ),
     radial-gradient(
       circle at 85% 86%,
-      rgba(167, 139, 250, 0.07),
+      rgba(103, 232, 249, 0.07),
       transparent 30rem
     ),
-    linear-gradient(rgba(103, 232, 249, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(103, 232, 249, 0.025) 1px, transparent 1px);
+    linear-gradient(rgba(16, 185, 129, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 185, 129, 0.045) 1px, transparent 1px);
   background-size: auto, auto, 32px 32px, 32px 32px;
 }
 
@@ -114,8 +114,8 @@ html {
   inset: 0;
   background: repeating-linear-gradient(
     to bottom,
-    rgba(103, 232, 249, 0.025) 0,
-    rgba(103, 232, 249, 0.025) 1px,
+    rgba(16, 185, 129, 0.045) 0,
+    rgba(16, 185, 129, 0.045) 1px,
     transparent 1px,
     transparent 4px
   );
@@ -124,33 +124,87 @@ html {
 }
 
 .room-header {
-  border-color: rgba(71, 85, 105, 0.72) !important;
-  background: rgba(3, 9, 22, 0.9);
-  box-shadow: 0 1px 0 rgba(103, 232, 249, 0.06);
+  border-color: rgba(16, 185, 129, 0.3) !important;
+  background: rgba(2, 8, 6, 0.92);
+  box-shadow: 0 1px 0 rgba(16, 185, 129, 0.12), 0 8px 22px rgba(0, 0, 0, 0.16);
+}
+
+.room-header-features {
+  width: 100%;
+}
+
+.room-header-toolbar {
+  width: 100%;
+}
+
+.room-header-toolbar > * {
+  min-width: 0;
+}
+
+.room-header-toolbar > button,
+.room-header-toolbar > div > button {
+  width: 100%;
+  white-space: nowrap;
+}
+
+@media (min-width: 1024px) {
+  .room-header-features {
+    width: auto;
+  }
+
+  .room-header-toolbar {
+    width: auto;
+    justify-content: flex-end;
+  }
+
+  .room-header-toolbar > button,
+  .room-header-toolbar > div > button {
+    width: auto;
+  }
 }
 
 .room-header h1 {
-  color: #dffaff;
+  color: #a7f3d0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   letter-spacing: 0.03em;
-  text-shadow: 0 0 14px rgba(103, 232, 249, 0.22);
+  text-shadow: 0 0 14px rgba(16, 185, 129, 0.28);
 }
 
-.room-header button {
-  border-color: rgba(100, 116, 139, 0.78) !important;
-  background: rgba(15, 23, 42, 0.86) !important;
-  color: #cbd5e1 !important;
+.room-header-toolbar > button,
+.room-header-toolbar > div > button,
+.room-header .room-header-leave {
+  border-color: rgba(16, 185, 129, 0.46) !important;
+  background: rgba(2, 20, 14, 0.88) !important;
+  color: #a7f3d0 !important;
   transition: border-color 160ms ease, color 160ms ease, box-shadow 160ms ease,
     background 160ms ease;
 }
 
-.room-header button:hover,
-.room-header button:focus-visible {
-  border-color: rgba(103, 232, 249, 0.82) !important;
-  background: rgba(8, 47, 73, 0.62) !important;
-  box-shadow: 0 0 14px rgba(103, 232, 249, 0.12);
-  color: #ecfeff !important;
+.room-header-toolbar > button:hover,
+.room-header-toolbar > button:focus-visible,
+.room-header-toolbar > div > button:hover,
+.room-header-toolbar > div > button:focus-visible,
+.room-header .room-header-leave:hover,
+.room-header .room-header-leave:focus-visible {
+  border-color: rgba(52, 211, 153, 0.88) !important;
+  background: rgba(6, 78, 59, 0.58) !important;
+  box-shadow: 0 0 14px rgba(16, 185, 129, 0.18);
+  color: #ecfdf5 !important;
   outline: none;
+}
+
+.room-header .room-header-leave {
+  border-color: rgba(244, 63, 94, 0.62) !important;
+  background: rgba(76, 5, 25, 0.38) !important;
+  color: #fda4af !important;
+}
+
+.room-header .room-header-leave:hover,
+.room-header .room-header-leave:focus-visible {
+  border-color: rgba(251, 113, 133, 0.92) !important;
+  background: rgba(136, 19, 55, 0.5) !important;
+  box-shadow: 0 0 14px rgba(244, 63, 94, 0.16);
+  color: #ffe4e6 !important;
 }
 
 .room-content {
@@ -159,7 +213,19 @@ html {
 
 .room-panel {
   border-color: rgba(51, 65, 85, 0.8) !important;
-  background: rgba(3, 9, 22, 0.52);
+  background: rgba(2, 8, 6, 0.58);
+}
+
+.room-participants-panel {
+  border-bottom-color: rgba(16, 185, 129, 0.3) !important;
+  box-shadow: 0 5px 0 rgba(2, 8, 6, 0.94), 0 10px 20px rgba(0, 0, 0, 0.24);
+}
+
+@media (min-width: 768px) {
+  .room-participants-panel {
+    border-right-color: rgba(16, 185, 129, 0.3) !important;
+    box-shadow: 5px 0 0 rgba(2, 8, 6, 0.94), 10px 0 20px rgba(0, 0, 0, 0.24);
+  }
 }
 
 .room-participants-grid {
@@ -383,7 +449,7 @@ html {
 }
 
 .room-chat-panel {
-  background: rgba(2, 8, 20, 0.66);
+  background: rgba(1, 6, 5, 0.72);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Refs #258

This follow-up tightens the responsive Room presentation after the first visual refresh reached production.

On narrow screens, the participant grid left the final card column visually offset instead of centering the active set. On desktop, the same flex-wrap layout made the participant area feel left-weighted. The Room header toolbar also inherited a three-column grid at widths where intrinsic button sizes were more appropriate, making Copy link occupy disproportionate space and leaving the action row uneven. The landing page still constrained the new longer cosmic Room IDs to the old narrow entry width.

The changes keep all existing Room behavior and interaction semantics intact:

- center normal participant rows without changing card sizing or ordering;
- add a clearer participant/chat panel separation on mobile and desktop;
- give the Room toolbar an explicit responsive contract: equal-width controls on small screens and intrinsic, right-aligned controls on desktop;
- increase the desktop landing form width and give the Room field a little more space for long generated IDs;
- carry the homepage's retro terminal visual language into the Room background, grid, scanlines, header, and controls while preserving existing participant accents;
- keep Leave visually distinct from the neutral/feature controls;
- leave the local `ui-258-preview.tsx` file untracked and out of this PR.

No RoomSession, SFU, media, Agent, chat, or protocol behavior was changed.

Validation:

- `yarn prettier --check src/components/RoomContent.tsx src/components/participantCardAlignment.test.tsx src/pages/index.tsx src/styles/tailwind.css`
- `./node_modules/.bin/eslint src --max-warnings=0`
- `yarn type-check`
- `yarn test --run` (65 files, 623 tests)
- `yarn cf-build`
- `git diff --check`
