### PR TITLE
fix(home): restore signal-collapse headline rendering

### DIFF
--- a/app/src/__tests__/pages/index.test.tsx
+++ b/app/src/__tests__/pages/index.test.tsx
@@ -11,11 +11,17 @@ describe("Home page", () => {
   it("renders real product content immediately, with no Turnstile challenge blocking the view", () => {
     render(<Home />)
 
-    expect(
-      screen.getByRole("heading", {
-        name: /open a room\. bring people and agents together\./i,
-      })
-    ).toBeInTheDocument()
+    const heroHeading = screen.getByRole("heading", {
+      name: /open a room\. bring people and agents together\./i,
+    })
+    expect(heroHeading).toBeInTheDocument()
+    const signalText = heroHeading.querySelector(".signal-collapse-text")
+    expect(signalText).toHaveClass(
+      "bg-gradient-to-r",
+      "bg-clip-text",
+      "text-transparent"
+    )
+    expect(heroHeading).not.toHaveClass("bg-clip-text", "text-transparent")
     expect(
       screen.getByText("FREE4CHAT://RELAY — LINK READY")
     ).toBeInTheDocument()

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -80,10 +80,11 @@ export default function Home() {
             </p>
             <h1
               aria-label="Open a room. Bring people and Agents together."
-              className="psy-headline mt-5 bg-gradient-to-r from-emerald-300 via-fuchsia-400 to-cyan-300 bg-clip-text text-3xl font-extrabold uppercase tracking-tight text-transparent sm:text-4xl"
+              className="psy-headline mt-5 text-3xl font-extrabold uppercase tracking-tight sm:text-4xl"
             >
               <SignalCollapseText
                 text={"Open a room.\nBring people and Agents together."}
+                className="bg-gradient-to-r from-emerald-300 via-fuchsia-400 to-cyan-300 bg-clip-text text-transparent"
               />
             </h1>
 

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -58,6 +58,7 @@ html {
    resolves into one deterministic message. Text replacement is driven by JS;
    CSS supplies only the restrained CRT/glitch surface treatment. */
 .signal-collapse-text {
+  display: inline-block;
   white-space: pre-line;
 }
 


### PR DESCRIPTION
## Summary

Hotfix for the homepage headline regression introduced by #270.

The animated glyphs live in a child `SignalCollapseText` span, but the gradient/background clipping and transparent text color were left on the parent `h1`. During the child's opacity/glitch animation this relies on fragile cross-element `background-clip: text` masking and can leave the visual headline missing or unstable even though the accessible heading still exists.

This moves the gradient, `bg-clip-text`, and transparent text color onto the animated span itself and makes that span an inline block. The semantic `h1` and accessible name remain unchanged.

A focused homepage assertion now pins that visual contract so the previous CI blind spot cannot silently return.

No Room, join, routing, analytics, Runtime, SFU, or protocol behavior changes.

Do not merge automatically until CI is green.
