### PR TITLE
fix(home): frame-driven signal collapse with hard finalize budget

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 .wrangler/
 *.tsbuildinfo
+test-results/

--- a/app/e2e/README.md
+++ b/app/e2e/README.md
@@ -11,15 +11,18 @@ actual page in Chromium/WebKit and observes:
 
 ## Run
 
+The dev dependency (`@playwright/test`) and the `e2e:homepage` script are
+committed. From a clean checkout:
+
 ```bash
-npm i -D playwright
-npx playwright install chromium   # one-time browser download
-npx playwright test e2e/signal-collapse.spec.ts
+yarn install                       # restores @playwright/test
+npx playwright install             # one-time browser download (chromium + webkit)
+yarn e2e:homepage
 ```
 
-The config starts `next dev -p 3780` automatically (or reuses an existing
-server). This is an optional manual regression path; it is intentionally not
-wired into CI.
+`yarn e2e:homepage` runs `playwright test e2e/signal-collapse.spec.ts
+--config=e2e/playwright.config.ts`. This is an optional manual regression
+path; it is intentionally not wired into CI.
 
 ## Why it exists
 
@@ -27,3 +30,9 @@ Previous fixes relied on unit/PWAs + class assertions. This suite pins the
 observable behavior in a real engine, including recovery from throttled or
 frozen timers (the component hard-finalizes within ~FINIALIZE_MS regardless
 of environment).
+
+## Production parity
+
+The config builds and serves the app with `next build && next start`
+(production bundle), and runs the spec on BOTH Chromium and WebKit —
+matching the engines used for the investigation evidence.

--- a/app/e2e/README.md
+++ b/app/e2e/README.md
@@ -1,0 +1,29 @@
+# Homepage signal-collapse browser smoke
+
+`signal-collapse.spec.ts` is the real-browser regression test for the
+homepage slogan animation. jsdom cannot prove rendering; this test loads the
+actual page in Chromium/WebKit and observes:
+
+- the final slogan is initially present and accessible (SSR + aria-label);
+- the animated span deviates into high-entropy noise shortly after mount;
+- it converges back to the EXACT deterministic slogan within a bounded
+  timeout on every engine.
+
+## Run
+
+```bash
+npm i -D playwright
+npx playwright install chromium   # one-time browser download
+npx playwright test e2e/signal-collapse.spec.ts
+```
+
+The config starts `next dev -p 3780` automatically (or reuses an existing
+server). This is an optional manual regression path; it is intentionally not
+wired into CI.
+
+## Why it exists
+
+Previous fixes relied on unit/PWAs + class assertions. This suite pins the
+observable behavior in a real engine, including recovery from throttled or
+frozen timers (the component hard-finalizes within ~FINIALIZE_MS regardless
+of environment).

--- a/app/e2e/playwright.config.ts
+++ b/app/e2e/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test"
+
+/**
+ * Real-browser regression for the homepage signal-collapse headline.
+ * Deliberately NOT wired into CI: the suite is a manually/optionally run
+ * production-behavior check. To run:
+ *   npm i -D playwright && npx playwright install chromium
+ *   npx playwright test e2e/signal-collapse.spec.ts
+ */
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/signal-collapse.spec.ts",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://127.0.0.1:3780",
+  },
+  webServer: {
+    command: "yarn dev -p 3780",
+    url: "http://127.0.0.1:3780",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+})

--- a/app/e2e/playwright.config.ts
+++ b/app/e2e/playwright.config.ts
@@ -14,11 +14,17 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:3780",
   },
+  // Production-validation parity: the smoke runs against a real
+  // `next build && next start` server, exactly like the investigation that
+  // produced the evidence in the PR description — not dev mode.
   webServer: {
-    command: "yarn dev -p 3780",
+    command: "yarn next build && yarn start -p 3780",
     url: "http://127.0.0.1:3780",
     reuseExistingServer: true,
-    timeout: 120_000,
+    timeout: 300_000,
   },
-  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  projects: [
+    { name: "chromium", use: { browserName: "chromium" } },
+    { name: "webkit", use: { browserName: "webkit" } },
+  ],
 })

--- a/app/e2e/signal-collapse.spec.ts
+++ b/app/e2e/signal-collapse.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test"
+
+/**
+ * Real-browser smoke test for the homepage signal-collapse headline.
+ *
+ * Proves the OBSERVABLE contract in a real engine (not jsdom):
+ *  1. the final slogan is present and accessible (aria-label on the h1);
+ *  2. the animated span goes through an "active" phase whose text deviates
+ *     from the slogan into high-entropy noise;
+ *  3. it converges back to the EXACT deterministic slogan and the resolved
+ *     phase, guaranteed by the component's hard wall-clock finalize budget.
+ *
+ * A pre-hydration sampler (addInitScript) records the live className/text
+ * timeline so the assertions never depend on page-load timing.
+ *
+ * Run (from app/):
+ *   npm i -D playwright
+ *   npx playwright install chromium
+ *   npx playwright test e2e/signal-collapse.spec.ts
+ *
+ * See e2e/README.md.
+ */
+const SLOGAN = "Open a room.\nBring people and Agents together."
+const SLOGAN_SINGLE_LINE = "Open a room. Bring people and Agents together."
+
+test("homepage headline converges from high-entropy noise to the deterministic slogan", async ({
+  page,
+}) => {
+  const errors: string[] = []
+  page.on("pageerror", (error) => errors.push(error.message))
+
+  // Sample the animated node from before hydration so the animation window
+  // is captured regardless of load speed.
+  await page.addInitScript(() => {
+    ;(
+      window as unknown as { __sig: Array<{ cls: string; text: string }> }
+    ).__sig = []
+    const record = () => {
+      const el = document.querySelector("h1 .signal-collapse-text")
+      if (!el) return
+      ;(
+        window as unknown as { __sig: Array<{ cls: string; text: string }> }
+      ).__sig.push({ cls: el.className, text: el.textContent ?? "" })
+    }
+    const timer = window.setInterval(record, 25)
+    // Keep sampling through the whole animation (~2.5s max).
+    window.setTimeout(() => window.clearInterval(timer), 4000)
+    record()
+  })
+
+  await page.goto("/")
+
+  // 1. Final slogan is initially present and accessible.
+  const headline = page.locator("h1")
+  await expect(headline).toHaveAttribute("aria-label", /Open a room\./)
+  const span = page.locator("h1 .signal-collapse-text")
+  await expect(span).toBeVisible()
+
+  // 2+3. Sampled timeline: active noise phase, then exact convergence.
+  await page.waitForFunction(() => {
+    const sig = (
+      window as unknown as { __sig?: Array<{ cls: string; text: string }> }
+    ).__sig
+    if (!sig || sig.length === 0) return false
+    return sig[sig.length - 1].cls.includes("signal-collapse-text--resolved")
+  })
+  const timeline = await page.evaluate(
+    () =>
+      (window as unknown as { __sig: Array<{ cls: string; text: string }> })
+        .__sig
+  )
+
+  const activeSamples = timeline.filter((sample) =>
+    sample.cls.includes("signal-collapse-text--active")
+  )
+  expect(
+    activeSamples.length,
+    "the headline must spend time in the active noise phase"
+  ).toBeGreaterThan(0)
+  const deviated = activeSamples.some(
+    (sample) => sample.text.replace(/\s+/g, " ").trim() !== SLOGAN_SINGLE_LINE
+  )
+  expect(deviated, "active phase must deviate from the final slogan").toBe(true)
+
+  const last = timeline[timeline.length - 1]
+  expect(last.cls).toContain("signal-collapse-text--resolved")
+  expect(last.text).toBe(SLOGAN)
+  expect(errors).toEqual([])
+})

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run",
     "docs:generate": "node scripts/generate-docs-assets.mjs",
     "docs:check": "node scripts/generate-docs-assets.mjs --check",
-    "prepare": "husky"
+    "prepare": "husky",
+    "e2e:homepage": "playwright test e2e/signal-collapse.spec.ts --config=e2e/playwright.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260811.1",
     "@opennextjs/cloudflare": "^1.19.1",
+    "@playwright/test": "1.48.2",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.5.0",
     "@tailwindcss/typography": "^0.5.2",

--- a/app/src/components/SignalCollapseText.test.tsx
+++ b/app/src/components/SignalCollapseText.test.tsx
@@ -8,19 +8,30 @@ const SLOGAN = "Open a room.\nBring people and Agents together."
 // jsdom has no requestAnimationFrame; drive the rAF loop manually so the
 // convergence state machine is tested deterministically in real time.
 type RafCallback = (now: number) => void
+type IntervalCallback = () => void
 let rafCallbacks: Array<RafCallback>
 let rafNextId: number
 let nowMs: number
+// Controlled interval scheduler for the no-rAF fallback path.
+let intervalCallbacks: Array<IntervalCallback>
+let intervalNextId: number
 
 beforeEach(() => {
   rafCallbacks = []
   rafNextId = 1
   nowMs = 0
+  intervalCallbacks = []
+  intervalNextId = 1
   vi.stubGlobal("requestAnimationFrame", (cb: (now: number) => void) => {
     rafCallbacks.push(cb)
     return rafNextId++
   })
   vi.stubGlobal("cancelAnimationFrame", () => undefined)
+  vi.stubGlobal("setInterval", (cb: IntervalCallback) => {
+    intervalCallbacks.push(cb)
+    return intervalNextId++
+  })
+  vi.stubGlobal("clearInterval", () => undefined)
   // jsdom's window.performance is an accessor; spy on the callable instead.
   vi.spyOn(window.performance, "now").mockImplementation(() => nowMs)
 })
@@ -37,6 +48,16 @@ function advanceFrames(deltaMs: number, frames: number) {
     act(() => {
       // rAF callbacks receive the frame timestamp (DOMHighResTimeStamp).
       for (const cb of callbacks) cb(nowMs)
+    })
+  }
+}
+
+function advanceIntervalTicks(tickMs: number, ticks: number) {
+  // Real intervals keep firing the SAME registered callback; keep it queued.
+  for (let tick = 0; tick < ticks; tick += 1) {
+    nowMs += tickMs
+    act(() => {
+      for (const cb of intervalCallbacks) cb()
     })
   }
 }
@@ -92,5 +113,48 @@ describe("SignalCollapseText lifecycle", () => {
     expect(span.className).toContain("signal-collapse-text--idle")
     expect(span.textContent).toBe(SLOGAN)
     expect(rafCallbacks.length).toBe(0)
+  })
+
+  it("uses the interval fallback end-to-end when rAF is unavailable, without touching rAF APIs", () => {
+    // No requestAnimationFrame at all: the component must drive the whole
+    // convergence through its own bounded interval and never call
+    // requestAnimationFrame/cancelAnimationFrame.
+    const rafCalls: Array<string> = []
+    vi.stubGlobal("requestAnimationFrame", undefined)
+    vi.stubGlobal("cancelAnimationFrame", () => rafCalls.push("cancel"))
+
+    render(<SignalCollapseText text={SLOGAN} className="psy-headline" />)
+    const span = screen.getByText((content) => content.length > 0, {
+      selector: ".signal-collapse-text",
+    })
+    expect(span.className).toContain("signal-collapse-text--active")
+    expect(intervalCallbacks.length).toBe(1)
+    expect(rafCalls).toEqual([])
+    // Drive ticks past the hard finalize budget.
+    advanceIntervalTicks(40, 60) // 2.4s > FINALIZE_MS
+    expect(span.className).toContain("signal-collapse-text--resolved")
+    expect(span.textContent).toBe(SLOGAN)
+    advanceIntervalTicks(40, 30) // well past resolve; no repeated state churn
+    expect(span.textContent).toBe(SLOGAN)
+    expect(span.className).toContain("signal-collapse-text--resolved")
+    expect(rafCalls).toEqual([])
+  })
+
+  it("cleans up the interval fallback on unmount", () => {
+    // This time supply a real clearInterval spy so cleanup is observable.
+    const clearIntervalCalls: Array<unknown> = []
+    vi.stubGlobal("requestAnimationFrame", undefined)
+    vi.stubGlobal("cancelAnimationFrame", () => undefined)
+    vi.stubGlobal(
+      "clearInterval",
+      (timer: number) => void clearIntervalCalls.push(timer)
+    )
+
+    const { unmount } = render(
+      <SignalCollapseText text={SLOGAN} className="psy-headline" />
+    )
+    expect(intervalCallbacks.length).toBe(1)
+    unmount()
+    expect(clearIntervalCalls.length).toBe(1)
   })
 })

--- a/app/src/components/SignalCollapseText.test.tsx
+++ b/app/src/components/SignalCollapseText.test.tsx
@@ -1,0 +1,96 @@
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import SignalCollapseText from "./SignalCollapseText"
+
+const SLOGAN = "Open a room.\nBring people and Agents together."
+
+// jsdom has no requestAnimationFrame; drive the rAF loop manually so the
+// convergence state machine is tested deterministically in real time.
+type RafCallback = (now: number) => void
+let rafCallbacks: Array<RafCallback>
+let rafNextId: number
+let nowMs: number
+
+beforeEach(() => {
+  rafCallbacks = []
+  rafNextId = 1
+  nowMs = 0
+  vi.stubGlobal("requestAnimationFrame", (cb: (now: number) => void) => {
+    rafCallbacks.push(cb)
+    return rafNextId++
+  })
+  vi.stubGlobal("cancelAnimationFrame", () => undefined)
+  // jsdom's window.performance is an accessor; spy on the callable instead.
+  vi.spyOn(window.performance, "now").mockImplementation(() => nowMs)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function advanceFrames(deltaMs: number, frames: number) {
+  for (let frame = 0; frame < frames; frame += 1) {
+    const callbacks = rafCallbacks.splice(0)
+    nowMs += deltaMs
+    act(() => {
+      // rAF callbacks receive the frame timestamp (DOMHighResTimeStamp).
+      for (const cb of callbacks) cb(nowMs)
+    })
+  }
+}
+
+describe("SignalCollapseText lifecycle", () => {
+  it("starts from the final slogan, swaps to noise, then converges back to the exact slogan", () => {
+    render(<SignalCollapseText text={SLOGAN} className="psy-headline" />)
+    const span = screen.getByText((content) => content.length > 0, {
+      selector: ".signal-collapse-text",
+    })
+
+    // The layout effect immediately swaps to noise and marks active.
+    expect(span.className).toContain("signal-collapse-text--active")
+    expect(span.textContent).not.toBe(SLOGAN)
+
+    // Phase 2: drive ~1.1s of frames; glyphs converge.
+    advanceFrames(34, 34)
+
+    // Phase 3: after the hard budget the exact slogan is guaranteed.
+    advanceFrames(60, 40) // total > FINALIZE_MS
+    expect(span.className).toContain("signal-collapse-text--resolved")
+    expect(span.textContent).toBe(SLOGAN)
+    expect(span.className).toContain("signal-collapse-text--resolved")
+    expect(span.textContent).toBe(SLOGAN)
+  })
+
+  it("resolves within the absolute budget even if frames stall (frozen-timer recovery)", () => {
+    render(<SignalCollapseText text={SLOGAN} className="psy-headline" />)
+    const span = screen.getByText((content) => content.length > 0, {
+      selector: ".signal-collapse-text",
+    })
+
+    // Simulate a long freeze: the next frame arrives a very long time later.
+    const frozen = rafCallbacks.splice(0)
+    nowMs += 20_000 // e.g. iOS timer clamp / background freeze / bfcache restore
+    act(() => {
+      for (const cb of frozen) cb(nowMs)
+    })
+    expect(span.className).toContain("signal-collapse-text--resolved")
+    expect(span.textContent).toBe(SLOGAN)
+  })
+
+  it("shows the final slogan immediately for reduced-motion users", () => {
+    const matchMedia = vi.fn().mockReturnValue({ matches: true })
+    vi.stubGlobal("matchMedia", matchMedia)
+
+    render(<SignalCollapseText text={SLOGAN} className="psy-headline" />)
+    const span = screen.getByText((content) => content.length > 0, {
+      selector: ".signal-collapse-text",
+    })
+
+    // Still idle: no active/noise phase ever happens.
+    expect(span.className).toContain("signal-collapse-text--idle")
+    expect(span.textContent).toBe(SLOGAN)
+    expect(rafCallbacks.length).toBe(0)
+  })
+})

--- a/app/src/components/SignalCollapseText.tsx
+++ b/app/src/components/SignalCollapseText.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useLayoutEffect, useState } from "react"
 
 const NOISE_GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#%&*+-=/<>?[]{}:;@|_"
-const TICK_MS = 34
+const FALLBACK_TICK_MS = 34
+const MAX_FRAME_DELTA_MS = 80
 const COLLAPSE_MS = 1180
 const LINE_DELAY_MS = 90
+// Absolute wall-clock budget: whatever the environment does to rAF or
+// timers (iOS Low Power Mode clamping, background freeze, bfcache restore),
+// the headline ALWAYS lands on the final deterministic slogan inside this
+// bound. Progress-driven locking alone can stall visually while a timer is
+// paused; this hard caps the worst case.
+const FINALIZE_MS = COLLAPSE_MS * 1.9
 const UINT32_RANGE = 0x100000000
 
 const useClientLayoutEffect =
@@ -81,10 +88,18 @@ export default function SignalCollapseText({
 
     const startedAt = window.performance.now()
     let previousAt = startedAt
+    let animationFrame = 0
 
-    const timer = window.setInterval(() => {
-      const now = window.performance.now()
-      const deltaSeconds = Math.min(0.08, (now - previousAt) / 1000)
+    // Frame-driven loop. requestAnimationFrame is naturally throttled with
+    // the display (including iOS Low Power Mode), and unlike setInterval it
+    // keeps firing on every rendered frame, so convergence stays smooth and
+    // never appears as "a few sudden jumps". Progress is computed from real
+    // elapsed time, so cadence never changes the final message.
+    const tick = (now: number) => {
+      const deltaSeconds = Math.min(
+        MAX_FRAME_DELTA_MS / 1000,
+        (now - previousAt) / 1000
+      )
       previousAt = now
 
       // Three independent samples per glyph: lock, transient target glimpse,
@@ -134,17 +149,33 @@ export default function SignalCollapseText({
         return NOISE_GLYPHS[randomWords[sampleOffset + 2] % NOISE_GLYPHS.length]
       })
 
-      if (locked.every(Boolean)) {
-        window.clearInterval(timer)
+      if (locked.every(Boolean) || now - startedAt >= FINALIZE_MS) {
+        window.cancelAnimationFrame(animationFrame)
         setDisplayText(text)
         setPhase("resolved")
         return
       }
 
       setDisplayText(next.join(""))
-    }, TICK_MS)
+      animationFrame = window.requestAnimationFrame(tick)
+    }
 
-    return () => window.clearInterval(timer)
+    if (typeof window.requestAnimationFrame === "function") {
+      animationFrame = window.requestAnimationFrame(tick)
+    } else {
+      // Ancient environments fall back to a bounded interval loop with the
+      // same delta-time progress; FINALIZE_MS still guarantees the endpoint.
+      const timer = window.setInterval(
+        () => tick(window.performance.now()),
+        FALLBACK_TICK_MS
+      )
+      return () => {
+        window.clearInterval(timer)
+        window.cancelAnimationFrame(animationFrame)
+      }
+    }
+
+    return () => window.cancelAnimationFrame(animationFrame)
   }, [text])
 
   const classes = [

--- a/app/src/components/SignalCollapseText.tsx
+++ b/app/src/components/SignalCollapseText.tsx
@@ -88,13 +88,25 @@ export default function SignalCollapseText({
 
     const startedAt = window.performance.now()
     let previousAt = startedAt
+    // The loop is driven by ONE mechanism only. requestAnimationFrame is
+    // naturally throttled with the display (including iOS Low Power Mode)
+    // and keeps firing on every rendered frame, so convergence stays smooth
+    // and never appears as "a few sudden jumps". For environments without
+    // rAF the loop is driven by a genuinely independent bounded interval —
+    // each driver owns its own schedule and cleanup, and tick never touches
+    // the other driver's APIs.
+    const usingRaf = typeof window.requestAnimationFrame === "function"
     let animationFrame = 0
+    let fallbackTimer = 0
 
-    // Frame-driven loop. requestAnimationFrame is naturally throttled with
-    // the display (including iOS Low Power Mode), and unlike setInterval it
-    // keeps firing on every rendered frame, so convergence stays smooth and
-    // never appears as "a few sudden jumps". Progress is computed from real
-    // elapsed time, so cadence never changes the final message.
+    const stopLoop = () => {
+      if (usingRaf) {
+        window.cancelAnimationFrame(animationFrame)
+      } else {
+        window.clearInterval(fallbackTimer)
+      }
+    }
+
     const tick = (now: number) => {
       const deltaSeconds = Math.min(
         MAX_FRAME_DELTA_MS / 1000,
@@ -150,32 +162,30 @@ export default function SignalCollapseText({
       })
 
       if (locked.every(Boolean) || now - startedAt >= FINALIZE_MS) {
-        window.cancelAnimationFrame(animationFrame)
+        stopLoop()
         setDisplayText(text)
         setPhase("resolved")
         return
       }
 
       setDisplayText(next.join(""))
-      animationFrame = window.requestAnimationFrame(tick)
-    }
-
-    if (typeof window.requestAnimationFrame === "function") {
-      animationFrame = window.requestAnimationFrame(tick)
-    } else {
-      // Ancient environments fall back to a bounded interval loop with the
-      // same delta-time progress; FINALIZE_MS still guarantees the endpoint.
-      const timer = window.setInterval(
-        () => tick(window.performance.now()),
-        FALLBACK_TICK_MS
-      )
-      return () => {
-        window.clearInterval(timer)
-        window.cancelAnimationFrame(animationFrame)
+      if (usingRaf) {
+        animationFrame = window.requestAnimationFrame(tick)
       }
     }
 
-    return () => window.cancelAnimationFrame(animationFrame)
+    if (usingRaf) {
+      animationFrame = window.requestAnimationFrame(tick)
+    } else {
+      // Bounded interval fallback with the same delta-time progress;
+      // FINALIZE_MS still guarantees the endpoint and stopLoop clears it.
+      fallbackTimer = window.setInterval(
+        () => tick(window.performance.now()),
+        FALLBACK_TICK_MS
+      )
+    }
+
+    return stopLoop
   }, [text])
 
   const classes = [

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2265,6 +2265,13 @@
     ts-tqdm "^0.8.6"
     yargs "^18.0.0"
 
+"@playwright/test@1.48.2":
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.2.tgz#87dd40633f980872283404c8142a65744d3f13d6"
+  integrity sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==
+  dependencies:
+    playwright "1.48.2"
+
 "@poppinss/colors@^4.1.5":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@poppinss/colors/-/colors-4.1.6.tgz#bf8546e30cfc5ee8dfe68988ce58eb0ad9d7c21b"
@@ -4949,6 +4956,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -6903,6 +6915,20 @@ planet-avatar@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/planet-avatar/-/planet-avatar-0.1.0.tgz#ba6d923ef183b405c7c682ba070403f4a45097b8"
   integrity sha512-FtRx2rbbuuas5mA6WHA1LeTJORJqHG2FNEJKTvU4hGJ43ZWFVFDyGCeoTZKBd5AC+stgZ24Wrkvrm367rcfZOw==
+
+playwright-core@1.48.2:
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.2.tgz#cd76ed8af61690edef5c05c64721c26a8db2f3d7"
+  integrity sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==
+
+playwright@1.48.2:
+  version "1.48.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.2.tgz#fca45ae8abdc34835c715718072aaff7e305167e"
+  integrity sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==
+  dependencies:
+    playwright-core "1.48.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Closes the homepage signal-collapse production regression (#270/#272/#273 follow-up).

## Actual root cause

Two findings, both proven with real browsers, not assumptions:

1. **The animation itself was already healthy in Chromium and WebKit** — the production build's JS lifecycle, SSR, hydration, `crypto.getRandomValues`, `matchMedia`, and the state machine (idle → active noise → resolved) all ran correctly with zero console errors. So #272/#273's CSS/rendering theories were not the primary failure on desktop, and deployment is not the cause (the same deployment animates fine in desktop browsers).

2. **`prefers-reduced-motion: reduce` intentionally produces no animation** — reproduced in both Chromium and WebKit with `emulateMedia({ reducedMotion: "reduce" })`: the headline immediately shows the final slogan, `phase` stays `idle`, no noise ever appears. On iOS, the system **Settings → Accessibility → Motion → Reduce Motion** toggle drives exactly this media query. This is the designed accessible contract and #274 PRESERVES it: it does NOT claim to fix the zero-animation case caused by reduced motion. If the originally reported production device has Reduce Motion enabled, it will still intentionally show the final slogan immediately — that is expected behavior, not a regression of this PR.

   Secondary, equally reproducible contributor: **iOS Low Power Mode clamps `setInterval` to ~1s**. The old `setInterval(34ms)` loop then renders noise as a few 1s-apart jumps and takes ~3s instead of 1.2s — visually "not animating". Reproduced by clamping timers in a real browser. THIS is the path this PR fixes (for users who allow motion): smooth frame-driven convergence that cannot be degraded by timer clamping, plus a hard wall-clock finalize budget so it always lands on the slogan.

## Concrete reproduction evidence

Real engines against the local production build (`next build` + `next start`), sampled from before hydration:

| Scenario | Engine | Result |
| --- | --- | --- |
| default desktop | Chromium | idle → active noise → resolved in ~1.1s, no errors |
| desktop | WebKit | idle → active → resolved, no errors |
| `reducedMotion: reduce` | Chromium + WebKit | **zero animation**: stays idle, final slogan shown — exact "no animation" symptom |
| iOS Low Power clamp (setInterval→1s) | Chromium | old loop: ~3s, 3 visible jumps, then sudden resolve |
| short page reload | any | animation replays normally |

Also detected on my machine while iterating: if a served HTML references a chunk that 404s (stale server vs new build), hydration never runs and the headline stays statically `idle` forever — a deployment/building-state failure mode worth keeping in mind, but NOT what the production desktop browsers show (they animate).

## Why #272/#273 did not solve it

- #272 moved the gradient/filter animation off the changing glyph node (CSS repaint), #273 removed nested animated parents. Both were plausible WebKit render theories and they did help desktop Safari rendering, but neither addresses the two real iOS mechanisms above: the system reduced-motion media query short-circuits the JS **before any CSS matters**, and the interval-based loop is throttled to ~1s by Low Power Mode. CSS-only fixes cannot fix a timer-clamped JS loop.

## The smallest reliable fix

`app/src/components/SignalCollapseText.tsx` only (plus tests):

1. **Frame-driven loop**: the per-glyph convergence now runs on `requestAnimationFrame` with real-delta progress instead of `setInterval(34ms)`. rAF keeps firing on every rendered frame even when the platform throttles timers (iOS Low Power Mode), so convergence stays smooth on the systems that matter and never looks like "a few jumps".
2. **Genuinely independent no-rAF fallback**: environments without `requestAnimationFrame` get a bounded `setInterval` loop that owns its own schedule and cleanup; `tick` never touches rAF/cancelAnimationFrame APIs in that mode (previous version called them unconditionally and would throw). Covered by unit tests that execute the interval path to completion and prove no repeated ticks/state changes after resolve, plus a cleanup-on-unmount test.
3. **Hard wall-clock finalize budget** (`FINALIZE_MS ≈ 2.24s`): regardless of throttling, frozen timers, background freeze, or bfcache restore, the component always lands on the exact deterministic slogan within a bounded time.
4. **Reduced-motion behavior preserved unchanged** (immediate final slogan) — the correct accessibility contract; no attempt to circumvent it. See the root-cause note above.

The mathematical design (per-character lock hazard, target glimpses, line-based stagger) is unchanged. No CSS changes; no changes to `index.tsx`, analytics, room, or protocol.

## Real-browser validation evidence (committed regression test)

- The committed Playwright smoke (`app/e2e/signal-collapse.spec.ts`) loads the ACTUAL application served by `next build && next start` (production bundle) and asserts: aria-label present → active noise phase observed (text deviates from slogan) → exact slogan + `resolved` within timeout → zero page errors. It runs on **BOTH Chromium and WebKit** (configured projects), matching the engines used for the investigation evidence. **Passed locally: `2 passed (32.9s)`** (chromium + webkit).
- Run from a clean checkout: `yarn install && npx playwright install && yarn e2e:homepage` — `@playwright/test` is a committed devDependency and `e2e:homepage` is a committed script; no package.json edits required.
- Manual engine probes (desktop + 390×844 viewport, reduced-motion, timer-clamp simulation) — tables above; full sampled timelines captured in the investigation.

Note: jsdom cannot prove rendering, so a jsdom lifecycle test (`SignalCollapseText.test.tsx`) pins the deterministic state machine (idle→active→resolved, freeze recovery, no-rAF fallback to completion, cleanup, reduced-motion) and the Playwright spec pins real-browser behavior.

## Tests run

- `yarn vitest run` — **66 files / 628 tests passed** (incl. new `SignalCollapseText.test.tsx`: convergence, frozen-frame finalize, reduced-motion, no-rAF interval fallback to completion with no post-resolve churn, interval cleanup on unmount)
- `yarn type-check` — clean
- `yarn eslint src --max-warnings 0` — clean
- `npx prettier --check .` — clean
- `HOME=/tmp/fakehome yarn next build` — successful production build
- `git diff --check` — clean
- `yarn e2e:homepage` (production build/start, Chromium + WebKit) — **2 passed (32.9s)**

## What this does NOT change

Room creation/join, WARP IN, nickname generation, analytics, routing, Agent Runtime, MCP, SFU, protocol, Room UI. No deployment was performed; production verification after merge should re-run `yarn e2e:homepage` and, on an iPhone, confirm whether Reduce Motion is enabled (Settings → Accessibility → Motion); if it is, the headline intentionally shows the final slogan immediately, and the timer-throttled path fixed here still applies to users who allow motion.

