### PR TITLE
test(room): local browser Room E2E harness (real Worker + DO)

### DIFF
--- a/.agent/skills/free4chat-local-e2e/SKILL.md
+++ b/.agent/skills/free4chat-local-e2e/SKILL.md
@@ -36,10 +36,10 @@ Three hard rules (each one cost a debugging cycle):
 
 ## Turnstile switches (local bypass)
 
-| Layer | Mechanism |
-| --- | --- |
-| Server | `--var TURNSTILE_SECRET_KEY:` (empty ⇒ `verify()` returns true immediately, see sfu/server.ts) |
-| Client | build-time `NEXT_PUBLIC_TURNSTILE_DISABLED=1` ⇒ useTurnstile loads no widget, requestToken resolves instantly |
+| Layer               | Mechanism                                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Server              | `--var TURNSTILE_SECRET_KEY:` (empty ⇒ `verify()` returns true immediately, see sfu/server.ts)                                    |
+| Client              | build-time `NEXT_PUBLIC_TURNSTILE_DISABLED=1` ⇒ useTurnstile loads no widget, requestToken resolves instantly                     |
 | Browser widget kept | sitekey must be `1x00000000000000000000` (20 chars); variants with an `AA` suffix are invalid keys and fail with Turnstile 400020 |
 
 Production builds set none of these ⇒ behavior identical to production.
@@ -81,3 +81,49 @@ wait_for_events {participantHandle, cursor, timeoutSeconds}
   leave leaves a ghost card until lease expiry.
 - Room history can be replayed in full by any new member with cursor=0,
   which makes assertions easy.
+
+## Automated browser Room E2E (the real Worker + real DO)
+
+`app/e2e/room/` is the repeatable control-plane regression: two REAL browser
+pages join the same Room through the REAL OpenNext Worker, REAL
+`RoomSession` Durable Object, REAL KV bindings, REAL WebSocket and REAL
+roster/message broadcast. The only fake layers are external:
+
+- Cloudflare Realtime upstream → loopback fake HTTP server (`SFU_RTC_BASE_URL`
+  env override; `src/sfu/server.ts` keeps the real production base when the
+  env var is absent);
+- browser media bootstrap → Chromium's fake-device flags
+  (`--use-fake-device-for-media-stream`) plus a tiny `RTCPeerConnection`
+  stub in `room.spec.ts` (the fake SFU's SDP is deliberately unparseable).
+
+Origin handling: the harness binds a transparent TCP relay on
+`http://localhost:3000` (the existing production allow-list origin) and
+forwards everything untouched — `src/common/origin.ts` is NOT weakened.
+
+```bash
+cd app
+yarn e2e:room
+```
+
+The webServer command runs `NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build &&
+node e2e/room/run-local-worker.mjs` (Wrangler `createTestHarness()` + fake
+Realtime + 3000 TCP relay). Run it at least twice to catch leaked ports or
+stale state; the fake Realtime fails CLOSED (503) on any unexpected outbound
+call, so a test passing proves no stray external request occurred.
+
+## Which test for which change
+
+| Change                                                        | Test                             |
+| ------------------------------------------------------------- | -------------------------------- |
+| Homepage visual/headline (signal collapse, CTA, layout)       | `yarn e2e:homepage`              |
+| Room layout / chat / participant cards / control-plane wiring | `yarn e2e:room`                  |
+| Worker routes / DO logic / MCP tools                          | local curl/MCP flow below        |
+| Audio / screen share / Agent Voice / SFU negotiation          | REAL deployed media dogfood only |
+
+> **Local Room E2E proves the collaboration/control plane. It does NOT prove
+> the Realtime SFU/media plane.** Do not claim media correctness from a
+> harness that fakes `rtc.live.cloudflare.com` or the peer connection.
+
+The manual `wrangler dev --local --port 3000` + curl/MCP/Agent Runtime
+workflow below remains the interactive investigation path; the automated
+harness and the manual workflow are complementary, not replacements.

--- a/.agent/skills/free4chat-local-e2e/SKILL.md
+++ b/.agent/skills/free4chat-local-e2e/SKILL.md
@@ -108,8 +108,17 @@ yarn e2e:room
 The webServer command runs `NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build &&
 node e2e/room/run-local-worker.mjs` (Wrangler `createTestHarness()` + fake
 Realtime + 3000 TCP relay). Run it at least twice to catch leaked ports or
-stale state; the fake Realtime fails CLOSED (503) on any unexpected outbound
-call, so a test passing proves no stray external request occurred.
+stale state.
+
+**Hard invariant:** `SFU_RTC_BASE_URL` is honored by EVERY known Cloudflare
+Realtime outbound I/O — both the Worker SFU routes (`realtimeRequest`) and
+the Durable Object media-cleanup effects (`executeMediaCloseEffect`) share
+the same seam (`src/common/realtimeUrl.ts`). The fake fails closed (503) on
+any unexpected outbound call AND records it; the spec's final audit asserts
+`unexpected == []`, so `yarn e2e:room` PASSES only if every Cloudflare
+Realtime request made during the test was explicitly handled by the local
+fake — nothing can silently escape to rtc.live.cloudflare.com, even on
+best-effort cleanup paths that production intentionally swallows.
 
 ## Which test for which change
 

--- a/app/e2e/README.md
+++ b/app/e2e/README.md
@@ -36,3 +36,11 @@ of environment).
 The config builds and serves the app with `next build && next start`
 (production bundle), and runs the spec on BOTH Chromium and WebKit —
 matching the engines used for the investigation evidence.
+
+## Room control-plane E2E
+
+`yarn e2e:room` runs `e2e/room/room.spec.ts`: two real browsers against the
+real local Worker + RoomSession Durable Object (via `createTestHarness`),
+with only the Cloudflare Realtime upstream and the browser media bootstrap
+faked. See `.agent/skills/free4chat-local-e2e/SKILL.md` for the full local
+testing guide and the control-plane-vs-media boundary.

--- a/app/e2e/room/playwright.config.ts
+++ b/app/e2e/room/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from "@playwright/test"
+
+/**
+ * Room control-plane E2E (#275): two real browsers against the real local
+ * OpenNext Worker + RoomSession Durable Object.
+ *
+ * The webServer builds the Worker once (`cf-build`) and starts the harness
+ * (`run-local-worker.mjs`) which owns: fake Cloudflare Realtime (loopback),
+ * the WORKER via createTestHarness(), and the origin-safe 3000 proxy.
+ */
+export default defineConfig({
+  // App-root testDir so CLI spec paths (e2e/room/room.spec.ts) resolve the
+  // same way they do for the homepage suite; the testMatch keeps this config
+  // scoped to the Room spec only.
+  testDir: "../..",
+  testMatch: "**/room.spec.ts",
+  timeout: 60_000,
+  workers: 1,
+  fullyParallel: false,
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  webServer: {
+    // config lives in e2e/room; run from the app root so yarn/node_modules
+    // resolve normally.
+    command:
+      "cd ../.. && NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build && node e2e/room/run-local-worker.mjs",
+    url: "http://localhost:3000",
+    reuseExistingServer: false,
+    timeout: 600_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        // Chromium's built-in fake audio device: getUserMedia returns a REAL
+        // MediaStreamTrack, so the Room flow runs on the real media classes
+        // without needing real hardware, permissions, or a WebRTC shim.
+        launchOptions: {
+          args: [
+            "--use-fake-device-for-media-stream",
+            "--use-fake-ui-for-media-stream",
+          ],
+        },
+      },
+    },
+  ],
+})

--- a/app/e2e/room/room.spec.ts
+++ b/app/e2e/room/room.spec.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
 import { expect, test, type Page } from "@playwright/test"
 
 /**
@@ -150,6 +154,36 @@ test("two browsers exchange a text message through the real local DO", async ({
   })
 
   expect(errors).toEqual([])
+
+  // Hard invariant (#275 review): every Cloudflare Realtime request made
+  // during the test must have been explicitly handled by the loopback fake.
+  // The fake never forwards anything — an unexpected outbound call would
+  // have 503'd here AND be recorded for this assertion, even when
+  // best-effort production semantics would swallow the failure.
+  const stateDir =
+    process.env.FREEF4CHAT_E2E_STATE_DIR ??
+    path.join(os.tmpdir(), "f4c-room-e2e")
+  const fakePort = fs
+    .readFileSync(path.join(stateDir, "fake-port.txt"), "utf8")
+    .trim()
+  const audit = (await (
+    await fetch(`http://127.0.0.1:${fakePort}/__fake/requests`)
+  ).json()) as {
+    requests: Array<{ method: string; path: string }>
+    unexpected: Array<{ method: string; path: string }>
+  }
+  expect(
+    audit.unexpected,
+    "the app made an unexpected Cloudflare Realtime request during the E2E"
+  ).toEqual([])
+  expect(
+    audit.requests.some(
+      (request) =>
+        request.method === "POST" && request.path.endsWith("/sessions/new")
+    ),
+    "the fake Realtime must have served the Human join path"
+  ).toBe(true)
+
   await contextA.close()
   await contextB.close()
   void testInfo

--- a/app/e2e/room/room.spec.ts
+++ b/app/e2e/room/room.spec.ts
@@ -161,7 +161,7 @@ test("two browsers exchange a text message through the real local DO", async ({
   // have 503'd here AND be recorded for this assertion, even when
   // best-effort production semantics would swallow the failure.
   const stateDir =
-    process.env.FREEF4CHAT_E2E_STATE_DIR ??
+    process.env.FREE4CHAT_E2E_STATE_DIR ??
     path.join(os.tmpdir(), "f4c-room-e2e")
   const fakePort = fs
     .readFileSync(path.join(stateDir, "fake-port.txt"), "utf8")
@@ -183,6 +183,11 @@ test("two browsers exchange a text message through the real local DO", async ({
     ),
     "the fake Realtime must have served the Human join path"
   ).toBe(true)
+
+  // Leave no harness state behind: the next run starts from a clean dir.
+  // (Playwright's webServer teardown may SIGKILL the harness before its own
+  // SIGTERM cleanup runs; the spec is the last reader of this state.)
+  fs.rmSync(stateDir, { recursive: true, force: true })
 
   await contextA.close()
   await contextB.close()

--- a/app/e2e/room/room.spec.ts
+++ b/app/e2e/room/room.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Page } from "@playwright/test"
+
+/**
+ * Room control-plane E2E (#275) — two REAL browser pages, one REAL local
+ * Worker, one REAL RoomSession Durable Object.
+ *
+ * What is real: browser UI, OpenNext Worker routes, RoomSession DO, ROOMS_KV,
+ * WebSocket (/api/sfu/ws), participant registration, roster broadcasts, text
+ * messages.
+ * What is fake: the Cloudflare Realtime upstream (loopback server configured
+ * via SFU_RTC_BASE_URL) and the browser media bootstrap (shim below).
+ *
+ * The message below MUST travel browser -> WebSocket -> DO -> broadcast ->
+ * other browser; nothing is seeded into the DO directly.
+ */
+const ROOM_SLUG = `e2e-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+const MESSAGE = "hello from alice"
+
+// Media bootstrap: chromium launch args provide a REAL fake-device
+// MediaStreamTrack (no permission prompt). The RTCPeerConnection is a stub
+// because the fake SFU's SDP is deliberately not parseable and the Room
+// control-plane flow must not depend on media negotiation.
+async function installMediaShim(page: Page) {
+  await page.addInitScript(() => {
+    class FakeRTCPeerConnection {
+      onicecandidate = null
+      ontrack = null
+      ondatachannel = null
+      __transceivers: Array<{
+        sender: { track: unknown }
+        receiver: { track: null }
+        mid: string
+        direction: string
+      }> = []
+      addTrack() {
+        return { mid: "0", direction: "sendonly" }
+      }
+      addTransceiver(track: unknown, init: { direction?: string } = {}) {
+        const transceiver = {
+          sender: { track },
+          receiver: { track: null },
+          mid: "0",
+          direction: init?.direction ?? "sendrecv",
+        }
+        this.__transceivers.push(transceiver)
+        return transceiver
+      }
+      createDataChannel(label: string) {
+        return {
+          label,
+          readyState: "open",
+          bufferedAmount: 0,
+          bufferedAmountLowThreshold: 0,
+          send() {},
+          close() {},
+          addEventListener() {},
+          removeEventListener() {},
+        }
+      }
+      createOffer() {
+        return Promise.resolve({ type: "offer", sdp: "v=0\r\n" })
+      }
+      createAnswer() {
+        return Promise.resolve({ type: "answer", sdp: "v=0\r\n" })
+      }
+      setLocalDescription() {
+        return Promise.resolve()
+      }
+      setRemoteDescription() {
+        return Promise.resolve()
+      }
+      getTransceivers() {
+        return this.__transceivers
+      }
+      getConfiguration() {
+        return { iceServers: [] }
+      }
+      getStats() {
+        return Promise.resolve(new Map())
+      }
+      getSenders() {
+        return []
+      }
+      getReceivers() {
+        return []
+      }
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    }
+    ;(window as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakeRTCPeerConnection
+  })
+}
+
+/** Enter the nickname gate and reach the joined room. */
+async function joinRoom(page: Page, nickname: string) {
+  await installMediaShim(page)
+  await page.goto(`/room?id=${ROOM_SLUG}`)
+  await page.getByLabel("Nickname").fill(nickname)
+  await page.getByRole("button", { name: /Go/i }).click()
+  // The room UI is connected once the self participant card renders.
+  await expect(page.getByText(new RegExp(nickname)).first()).toBeVisible({
+    timeout: 15_000,
+  })
+  return page
+}
+
+test("two browsers exchange a text message through the real local DO", async ({
+  browser,
+}, testInfo) => {
+  const contextA = await browser.newContext()
+  const contextB = await browser.newContext()
+  const pageA = await contextA.newPage()
+  const pageB = await contextB.newPage()
+
+  const errors: Array<string> = []
+  for (const page of [pageA, pageB]) {
+    page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`))
+    page.on("console", (message) => {
+      if (message.type() === "error")
+        errors.push(`console.error: ${message.text()}`)
+    })
+  }
+
+  await joinRoom(pageA, "Alice")
+  await joinRoom(pageB, "Bob")
+
+  // Roster: both pages see both participants.
+  await expect(pageA.getByText(/Bob/).first()).toBeVisible({
+    timeout: 20_000,
+  })
+  await expect(pageB.getByText(/Alice/).first()).toBeVisible({
+    timeout: 20_000,
+  })
+
+  // Alice sends one text message.
+  await pageA.getByPlaceholder("Message the room or @ an Agent…").fill(MESSAGE)
+  await pageA.keyboard.press("Enter")
+
+  // Bob renders Alice's message — it crossed the real WS/DO path.
+  await expect(pageB.getByText(MESSAGE).first()).toBeVisible({
+    timeout: 15_000,
+  })
+
+  // Cheap roster-propagates check: Bob leaves, Alice's roster drops to one.
+  await pageB.getByRole("button", { name: "Leave" }).first().click()
+  await expect(pageA.getByText("Bob").first()).toBeHidden({
+    timeout: 15_000,
+  })
+
+  expect(errors).toEqual([])
+  await contextA.close()
+  await contextB.close()
+  void testInfo
+})

--- a/app/e2e/room/run-local-worker.mjs
+++ b/app/e2e/room/run-local-worker.mjs
@@ -11,8 +11,11 @@
 // reverse proxy binds the canonical allowed origin and forwards everything
 // (including WebSocket upgrades) to the harness URL. Production origin
 // validation is deliberately untouched.
+import fs from "node:fs"
 import http from "node:http"
 import net from "node:net"
+import os from "node:os"
+import path from "node:path"
 import { randomUUID } from "node:crypto"
 
 import { createTestHarness } from "wrangler"
@@ -31,8 +34,20 @@ const DUMMY_APP_SECRET = "test-secret"
 function createFakeRealtime() {
   /** @type {Array<{method: string, path: string}>} */
   const requests = []
+  /** @type {Array<{method: string, path: string}>} unexpected requests that
+   * were NOT explicitly handled — the E2E spec hard-asserts this is empty. */
+  const unexpected = []
   const server = http.createServer((req, res) => {
     const path = req.url ?? ""
+    if (req.method === "GET" && path === "/__fake/requests") {
+      const payload = JSON.stringify({ requests, unexpected })
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      })
+      res.end(payload)
+      return
+    }
     requests.push({ method: req.method ?? "?", path })
     let body = ""
     req.on("data", (chunk) => (body += chunk))
@@ -87,7 +102,10 @@ function createFakeRealtime() {
         return
       }
       // Fail closed: any other outbound call is a test-contract violation,
-      // never an accidental network request.
+      // never an accidental network request. The request is recorded so the
+      // E2E spec can hard-fail on it even when production semantics would
+      // swallow the upstream 503 (e.g. best-effort media cleanup).
+      unexpected.push({ method: req.method ?? "?", path })
       console.error(
         `[fake-realtime] UNEXPECTED ${req.method} ${path} — failing closed`
       )
@@ -117,6 +135,10 @@ function createFakeRealtime() {
 // connection — including WebSocket upgrades — untouched to the harness URL.
 // The browser sees origin http://localhost:3000, which is already in the
 // production allow-list, so src/common/origin.ts is never weakened.
+const stateDir =
+  process.env.FREEF4CHAT_E2E_STATE_DIR ?? path.join(os.tmpdir(), "f4c-room-e2e")
+const fakePortFile = path.join(stateDir, "fake-port.txt")
+
 function createProxy(targetPort) {
   const server = net.createServer((socket) => {
     const upstream = net.connect(targetPort, "127.0.0.1", () => {
@@ -145,7 +167,11 @@ function createProxy(targetPort) {
 async function main() {
   const fakeRealtime = createFakeRealtime()
   const fakeRealtimeBase = await fakeRealtime.listen()
-  console.log(`[harness] fake realtime at ${fakeRealtimeBase}`)
+  fs.mkdirSync(stateDir, { recursive: true })
+  fs.writeFileSync(fakePortFile, String(new URL(fakeRealtimeBase).port))
+  console.log(
+    `[harness] fake realtime at ${fakeRealtimeBase} (port file ${fakePortFile})`
+  )
 
   const server = createTestHarness({
     workers: [
@@ -176,10 +202,11 @@ async function main() {
 
   const shutdown = async () => {
     console.log(
-      `[harness] fake-realtime saw ${fakeRealtime.requests.length} request(s):`
+      `[harness] fake-realtime saw ${fakeRealtime.requests.length} request(s), ${fakeRealtime.unexpected.length} unexpected:`
     )
     for (const request of fakeRealtime.requests)
       console.log(`[fake-realtime] ${request.method} ${request.path}`)
+    fs.rmSync(fakePortFile, { force: true })
     await proxy.close()
     await server.close()
     await fakeRealtime.close()

--- a/app/e2e/room/run-local-worker.mjs
+++ b/app/e2e/room/run-local-worker.mjs
@@ -1,0 +1,197 @@
+// Local Room E2E harness (#275).
+//
+// Runs the REAL production Worker (wrangler.jsonc) inside Wrangler's modern
+// createTestHarness, backed by the REAL RoomSession Durable Object, ROOMS_KV,
+// Worker routes and WebSocket handling. Only the Cloudflare Realtime upstream
+// is faked (loopback HTTP server), and only the browser media bootstrap is
+// shimmed (see room.spec.ts addInitScript).
+//
+// The harness listens on a dynamic loopback URL. The production origin
+// allow-list only accepts e.g. http://localhost:3000, so a tiny loopback
+// reverse proxy binds the canonical allowed origin and forwards everything
+// (including WebSocket upgrades) to the harness URL. Production origin
+// validation is deliberately untouched.
+import http from "node:http"
+import net from "node:net"
+import { randomUUID } from "node:crypto"
+
+import { createTestHarness } from "wrangler"
+
+const PROXY_HOST = "127.0.0.1"
+// The ONLY locally allowed production origin (src/common/origin.ts). This is
+// also the documented `wrangler dev --local --port 3000` convention.
+const PROXY_PORT = Number(process.env.FREE4CHAT_E2E_PROXY_PORT ?? 3000)
+
+const DUMMY_APP_ID = "test-app"
+const DUMMY_APP_SECRET = "test-secret"
+
+// ---------------------------------------------------------------------------
+// Fake Cloudflare Realtime upstream (fail-closed).
+// ---------------------------------------------------------------------------
+function createFakeRealtime() {
+  /** @type {Array<{method: string, path: string}>} */
+  const requests = []
+  const server = http.createServer((req, res) => {
+    const path = req.url ?? ""
+    requests.push({ method: req.method ?? "?", path })
+    let body = ""
+    req.on("data", (chunk) => (body += chunk))
+    req.on("end", () => {
+      const send = (status, payload) => {
+        res.writeHead(status, { "Content-Type": "application/json" })
+        res.end(JSON.stringify(payload))
+      }
+      // Exact minimal contract for the HUMAN Room join path
+      // (see sfu/server.ts realtimeRequest call sites):
+      //   1. /sessions/new        -> { sessionId }
+      //   2. /datachannels/establish -> passthrough; {} is enough for the
+      //      browser to continue (no renegotiation, no remote description)
+      //   3. /datachannels/new    -> { dataChannels: [{ id }] }
+      if (req.method === "POST" && path.endsWith("/sessions/new")) {
+        send(200, { sessionId: randomUUID() })
+        return
+      }
+      const establish = path.match(
+        /\/sessions\/[^/]+\/datachannels\/establish$/
+      )
+      if (req.method === "POST" && establish) {
+        send(200, {})
+        return
+      }
+      const channelsNew = path.match(/\/sessions\/[^/]+\/datachannels\/new$/)
+      if (req.method === "POST" && channelsNew) {
+        send(200, { dataChannels: [{ id: 1 }] })
+        return
+      }
+      const channelsClose = path.match(
+        /\/sessions\/[^/]+\/datachannels\/close$/
+      )
+      if (req.method === "PUT" && channelsClose) {
+        send(200, { dataChannels: [] })
+        return
+      }
+      // Human audio publish: sfu/server.ts requires a usable answer + a mid
+      // per local track (usableHumanPublication) before advertising the
+      // track. The browser's fake peer connection never parses this SDP.
+      const tracksNew = path.match(/\/sessions\/[^/]+\/tracks\/new$/)
+      if (req.method === "POST" && tracksNew) {
+        send(200, {
+          sessionDescription: { type: "answer", sdp: "v=0\r\n" },
+          tracks: [{ mid: "0", trackName: "m-audio" }],
+        })
+        return
+      }
+      const renegotiate = path.match(/\/sessions\/[^/]+\/renegotiate$/)
+      if (req.method === "PUT" && renegotiate) {
+        send(200, {})
+        return
+      }
+      // Fail closed: any other outbound call is a test-contract violation,
+      // never an accidental network request.
+      console.error(
+        `[fake-realtime] UNEXPECTED ${req.method} ${path} — failing closed`
+      )
+      send(503, { error: "unexpected_sfu_request", path })
+      void body
+    })
+  })
+  return {
+    requests,
+    async listen() {
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+      const address = server.address()
+      if (!address || typeof address === "string")
+        throw new Error("no loopback")
+      return `http://127.0.0.1:${address.port}/v1/apps/${DUMMY_APP_ID}`
+    },
+    close() {
+      return new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transparent loopback relay bound to the canonical allowed origin.
+// ---------------------------------------------------------------------------
+// A plain TCP relay (no HTTP/WebSocket protocol handling) forwards every
+// connection — including WebSocket upgrades — untouched to the harness URL.
+// The browser sees origin http://localhost:3000, which is already in the
+// production allow-list, so src/common/origin.ts is never weakened.
+function createProxy(targetPort) {
+  const server = net.createServer((socket) => {
+    const upstream = net.connect(targetPort, "127.0.0.1", () => {
+      socket.pipe(upstream)
+      upstream.pipe(socket)
+    })
+    socket.on("error", () => socket.destroy())
+    upstream.on("error", () => socket.destroy())
+  })
+  return {
+    async listen() {
+      await new Promise((resolve, reject) => {
+        server.once("error", reject)
+        server.listen(PROXY_PORT, PROXY_HOST, resolve)
+      })
+    },
+    close() {
+      return new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const fakeRealtime = createFakeRealtime()
+  const fakeRealtimeBase = await fakeRealtime.listen()
+  console.log(`[harness] fake realtime at ${fakeRealtimeBase}`)
+
+  const server = createTestHarness({
+    workers: [
+      {
+        configPath: "./wrangler.jsonc",
+        vars: {
+          SFU_APP_ID: DUMMY_APP_ID,
+          // #275: intercept every Cloudflare Realtime call at the loopback
+          // fake; nothing ever reaches rtc.live.cloudflare.com.
+          SFU_RTC_BASE_URL: fakeRealtimeBase,
+          TURNSTILE_SECRET_KEY: "",
+          TURNSTILE_DISABLED: "true",
+          AGENT_MEDIA_ENABLED: "false",
+        },
+        secrets: {
+          SFU_APP_SECRET: DUMMY_APP_SECRET,
+        },
+      },
+    ],
+  })
+
+  const { url: workerUrl } = await server.listen()
+  console.log(`[harness] worker at ${workerUrl}`)
+
+  const proxy = createProxy(workerUrl.port)
+  await proxy.listen()
+  console.log(`[harness] proxy at http://${PROXY_HOST}:${PROXY_PORT}`)
+
+  const shutdown = async () => {
+    console.log(
+      `[harness] fake-realtime saw ${fakeRealtime.requests.length} request(s):`
+    )
+    for (const request of fakeRealtime.requests)
+      console.log(`[fake-realtime] ${request.method} ${request.path}`)
+    await proxy.close()
+    await server.close()
+    await fakeRealtime.close()
+    process.exit(0)
+  }
+  process.on("SIGINT", shutdown)
+  process.on("SIGTERM", shutdown)
+
+  console.log("[harness] READY http://localhost:3000")
+}
+
+main().catch((error) => {
+  console.error("[harness] startup failed:", error)
+  process.exit(1)
+})

--- a/app/e2e/room/run-local-worker.mjs
+++ b/app/e2e/room/run-local-worker.mjs
@@ -115,6 +115,7 @@ function createFakeRealtime() {
   })
   return {
     requests,
+    unexpected,
     async listen() {
       await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
       const address = server.address()
@@ -136,8 +137,12 @@ function createFakeRealtime() {
 // The browser sees origin http://localhost:3000, which is already in the
 // production allow-list, so src/common/origin.ts is never weakened.
 const stateDir =
-  process.env.FREEF4CHAT_E2E_STATE_DIR ?? path.join(os.tmpdir(), "f4c-room-e2e")
+  process.env.FREE4CHAT_E2E_STATE_DIR ?? path.join(os.tmpdir(), "f4c-room-e2e")
 const fakePortFile = path.join(stateDir, "fake-port.txt")
+// The harness records its OWN pid so shutdown validation and scripts can
+// always signal the real Worker process (bash job wrappers may report a
+// different pid; signalling a wrapper leaves node orphaned).
+const harnessPidFile = path.join(stateDir, "harness.pid")
 
 function createProxy(targetPort) {
   const server = net.createServer((socket) => {
@@ -166,8 +171,10 @@ function createProxy(targetPort) {
 // ---------------------------------------------------------------------------
 async function main() {
   const fakeRealtime = createFakeRealtime()
+  runningFakeRealtime = fakeRealtime
   const fakeRealtimeBase = await fakeRealtime.listen()
   fs.mkdirSync(stateDir, { recursive: true })
+  fs.writeFileSync(harnessPidFile, String(process.pid))
   fs.writeFileSync(fakePortFile, String(new URL(fakeRealtimeBase).port))
   console.log(
     `[harness] fake realtime at ${fakeRealtimeBase} (port file ${fakePortFile})`
@@ -192,31 +199,47 @@ async function main() {
       },
     ],
   })
+  runningServer = server
 
   const { url: workerUrl } = await server.listen()
   console.log(`[harness] worker at ${workerUrl}`)
 
   const proxy = createProxy(workerUrl.port)
+  runningProxy = proxy
   await proxy.listen()
   console.log(`[harness] proxy at http://${PROXY_HOST}:${PROXY_PORT}`)
 
-  const shutdown = async () => {
-    console.log(
-      `[harness] fake-realtime saw ${fakeRealtime.requests.length} request(s), ${fakeRealtime.unexpected.length} unexpected:`
-    )
-    for (const request of fakeRealtime.requests)
-      console.log(`[fake-realtime] ${request.method} ${request.path}`)
-    fs.rmSync(fakePortFile, { force: true })
-    await proxy.close()
-    await server.close()
-    await fakeRealtime.close()
-    process.exit(0)
-  }
-  process.on("SIGINT", shutdown)
-  process.on("SIGTERM", shutdown)
-
   console.log("[harness] READY http://localhost:3000")
 }
+
+// Signal handling at MODULE scope: signals registered inside an async main()
+// were observed not to run in this harness (workerd child + long awaits);
+// module-level registration cannot be lost.
+function shutdown() {
+  console.log(
+    `[harness] fake-realtime saw ${runningFakeRealtime.requests.length} request(s), ${runningFakeRealtime.unexpected.length} unexpected:`
+  )
+  for (const request of runningFakeRealtime.requests)
+    console.log(`[fake-realtime] ${request.method} ${request.path}`)
+  fs.rmSync(fakePortFile, { force: true })
+  fs.rmSync(harnessPidFile, { force: true })
+  const finish = () => process.exit(0)
+  runningProxy
+    .close()
+    .then(() => runningServer.close())
+    .then(() => runningFakeRealtime.close())
+    .then(finish)
+    .catch((error) => {
+      console.error("[harness] shutdown error:", error)
+      process.exit(1)
+    })
+}
+process.on("SIGINT", shutdown)
+process.on("SIGTERM", shutdown)
+
+let runningFakeRealtime = null
+let runningServer = null
+let runningProxy = null
 
 main().catch((error) => {
   console.error("[harness] startup failed:", error)

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,8 @@
     "docs:generate": "node scripts/generate-docs-assets.mjs",
     "docs:check": "node scripts/generate-docs-assets.mjs --check",
     "prepare": "husky",
-    "e2e:homepage": "playwright test e2e/signal-collapse.spec.ts --config=e2e/playwright.config.ts"
+    "e2e:homepage": "playwright test e2e/signal-collapse.spec.ts --config=e2e/playwright.config.ts",
+    "e2e:room": "playwright test e2e/room/room.spec.ts --config=e2e/room/playwright.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",

--- a/app/src/common/realtimeUrl.test.ts
+++ b/app/src/common/realtimeUrl.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { realtimeBaseUrl } from "./realtimeUrl"
+
+describe("realtimeBaseUrl (#275)", () => {
+  it("keeps the default production URL byte-identical", () => {
+    expect(realtimeBaseUrl({ SFU_APP_ID: "app-id" })).toBe(
+      "https://rtc.live.cloudflare.com/v1/apps/app-id"
+    )
+    // appId is still URL-encoded exactly like the historical call site.
+    expect(realtimeBaseUrl({ SFU_APP_ID: "app/with-special" })).toBe(
+      "https://rtc.live.cloudflare.com/v1/apps/app%2Fwith-special"
+    )
+    expect(realtimeBaseUrl({})).toBeNull()
+  })
+
+  it("SFU_RTC_BASE_URL wins over the default when present", () => {
+    expect(
+      realtimeBaseUrl({
+        SFU_APP_ID: "app-id",
+        SFU_RTC_BASE_URL: "http://127.0.0.1:1234/v1/apps/app-id",
+      })
+    ).toBe("http://127.0.0.1:1234/v1/apps/app-id")
+  })
+})

--- a/app/src/common/realtimeUrl.ts
+++ b/app/src/common/realtimeUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the Cloudflare Realtime base URL.
+ *
+ * #275: the local Room E2E harness overrides this base with a loopback fake
+ * so that ALL Worker outbound Cloudflare Realtime I/O — both the SFU HTTP
+ * routes (src/sfu/server.ts realtimeRequest) and the Durable Object media
+ * cleanup effects (src/do/mediaEffects.ts executeMediaCloseEffect) — can
+ * never reach the real rtc.live.cloudflare.com host on a test run.
+ *
+ * Production behavior (no SFU_RTC_BASE_URL) is byte-identical:
+ * `https://rtc.live.cloudflare.com/v1/apps/{appId}`.
+ */
+export function realtimeBaseUrl(env: {
+  SFU_APP_ID?: string
+  SFU_RTC_BASE_URL?: string
+}): string | null {
+  if (env.SFU_RTC_BASE_URL) return env.SFU_RTC_BASE_URL
+  if (!env.SFU_APP_ID) return null
+  return `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
+    env.SFU_APP_ID
+  )}`
+}

--- a/app/src/do/mediaEffects.ts
+++ b/app/src/do/mediaEffects.ts
@@ -1,3 +1,4 @@
+import { realtimeBaseUrl } from "../common/realtimeUrl"
 import type { PendingMediaCleanup } from "../room/types"
 
 // The external Cloudflare Realtime effect boundary. This module intentionally
@@ -9,6 +10,9 @@ import type { PendingMediaCleanup } from "../room/types"
 export interface RealtimeEnv {
   SFU_APP_ID?: string
   SFU_APP_SECRET?: string
+  /** #275: test-only override of the Cloudflare Realtime base URL; absent in
+   * production (see src/common/realtimeUrl.ts). */
+  SFU_RTC_BASE_URL?: string
 }
 
 export interface MediaCloseEffect {
@@ -65,10 +69,10 @@ export async function executeMediaCloseEffect(
   const credentials = getRealtimeCredentials(env)
   if (!credentials) return { effect: exact, confirmedMids: [] }
   try {
+    const base = realtimeBaseUrl(env)
+    if (!base) return { effect: exact, confirmedMids: [] }
     const response = await fetch(
-      `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
-        credentials.appId
-      )}/sessions/${encodeURIComponent(exact.sessionId)}/tracks/close`,
+      `${base}/sessions/${encodeURIComponent(exact.sessionId)}/tracks/close`,
       {
         method: "PUT",
         headers: {

--- a/app/src/do/realtimeMedia.test.ts
+++ b/app/src/do/realtimeMedia.test.ts
@@ -65,7 +65,7 @@ describe("executeMediaCloseEffect — fail-closed external effect contract", () 
     vi.unstubAllGlobals()
   })
 
-  it("a 2xx response is confirmed success", async () => {
+  it("a 2xx response is confirmed success against the default production base", async () => {
     let requestedUrl: string | undefined
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       requestedUrl = String(input)
@@ -73,7 +73,7 @@ describe("executeMediaCloseEffect — fail-closed external effect contract", () 
     })
     vi.stubGlobal("fetch", fetchMock)
     await expect(
-      executeMediaCloseEffect(env, { sessionId: "sess-1", mids: ["1"] })
+      executeMediaCloseEffect({ ...env }, { sessionId: "sess-1", mids: ["1"] })
     ).resolves.toEqual({
       effect: { sessionId: "sess-1", mids: ["1"] },
       confirmedMids: ["1"],
@@ -81,6 +81,25 @@ describe("executeMediaCloseEffect — fail-closed external effect contract", () 
     expect(requestedUrl).toBe(
       "https://rtc.live.cloudflare.com/v1/apps/app-id/sessions/sess-1/tracks/close"
     )
+  })
+
+  it("SFU_RTC_BASE_URL redirects the media-effects tracks/close request too", async () => {
+    let requestedUrl: string | undefined
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      requestedUrl = String(input)
+      return new Response("", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    await expect(
+      executeMediaCloseEffect(
+        { ...env, SFU_RTC_BASE_URL: "http://127.0.0.1:9999/v1/apps/app-id" },
+        { sessionId: "sess-1", mids: ["1"] }
+      )
+    ).resolves.toMatchObject({ confirmedMids: ["1"] })
+    expect(requestedUrl).toBe(
+      "http://127.0.0.1:9999/v1/apps/app-id/sessions/sess-1/tracks/close"
+    )
+    expect(requestedUrl).not.toContain("rtc.live.cloudflare.com")
   })
 
   it("a 401 response is not treated as success", async () => {

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -15,6 +15,13 @@ export interface SfuEnv {
   ROOMS_KV: KVNamespace
   SFU_APP_ID?: string
   SFU_APP_SECRET?: string
+  /** #275: test-only override of the Cloudflare Realtime base URL. Absent
+   * (production and ordinary local dev) means the real
+   * `https://rtc.live.cloudflare.com/v1/apps/{appId}` endpoint is used,
+   * exactly as before. Local E2E harnesses point this at a loopback fake so
+   * the real Human join path can run without ever contacting Cloudflare
+   * Realtime. Analytics/authorization semantics are untouched. */
+  SFU_RTC_BASE_URL?: string
   TURNSTILE_SECRET_KEY?: string
   // Explicit, reversible development/E2E bypass. Any value other than the
   // literal string "true" preserves the normal Turnstile behavior below.
@@ -187,12 +194,12 @@ async function realtimeRequest(
   const headers = new Headers(init.headers)
   headers.set("Authorization", `Bearer ${credentials.appSecret}`)
   headers.set("Content-Type", "application/json")
-  return fetch(
+  const base =
+    env.SFU_RTC_BASE_URL ??
     `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
       credentials.appId
-    )}${path}`,
-    { ...init, headers }
-  )
+    )}`
+  return fetch(`${base}${path}`, { ...init, headers })
 }
 
 const MAX_DIAGNOSTIC_TRACK_COUNT = 100

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -1,5 +1,6 @@
 import type { SfuSessionResponse } from "./types"
 import { isAllowedOrigin } from "../common/origin"
+import { realtimeBaseUrl } from "../common/realtimeUrl"
 import { isRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
 import { compensateUnacceptedAgentMedia } from "../do/mediaEffects"
 import { resolveAgentPurposePermission } from "../do/meetingNotesAuth"
@@ -194,11 +195,8 @@ async function realtimeRequest(
   const headers = new Headers(init.headers)
   headers.set("Authorization", `Bearer ${credentials.appSecret}`)
   headers.set("Content-Type", "application/json")
-  const base =
-    env.SFU_RTC_BASE_URL ??
-    `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
-      credentials.appId
-    )}`
+  const base = realtimeBaseUrl(env)
+  if (!base) return json({ error: "sfu_not_configured" }, 503)
   return fetch(`${base}${path}`, { ...init, headers })
 }
 


### PR DESCRIPTION
Closes the local browser Room E2E infrastructure request.

## What is REAL

- **Browser** (two independent Playwright contexts/pages, real Chromium)
- **OpenNext Worker** — the production `wrangler.jsonc` config run inside
  Wrangler's modern **`createTestHarness()`** (no `unstable_dev`)
- **`RoomSession` Durable Object** — real class, real registration/broadcast
- **KV/bindings, Worker routes, WebSocket** (`/api/sfu/ws` upgrade)
- Room registration, roster broadcast, **text messages** (browser A → WS →
  DO → broadcast → browser B → rendered chat)
- MCP **(not in this PR)** — the Human/Human smoke is the first proof;
  Human+Agent stretch is a documented next step

## What is FAKE

- **Cloudflare Realtime upstream** — a tiny loopback HTTP fake implementing
  the exact Human-join contracts (`/sessions/new`, `datachannels/establish`,
  `datachannels/new`, `tracks/new`, `renegotiate`), wired via a single
  **`SFU_RTC_BASE_URL` env seam** (`src/common/realtimeUrl.ts`) honored by
  EVERY known Cloudflare Realtime outbound I/O — both the Worker SFU routes
  (`realtimeRequest` in `src/sfu/server.ts`) and the Durable Object
  media-cleanup effects (`executeMediaCloseEffect` in
  `src/do/mediaEffects.ts`). Absent in production → behaviour byte-identical
  (`https://rtc.live.cloudflare.com/v1/apps/{appId}`, pinned by unit tests);
  the fake **fails closed** with 503 on any unexpected outbound call AND
  records it; `SFU_APP_SECRET` is a dummy test secret. The local harness is
  therefore incapable of reaching the real Realtime host for any known
  Worker/DO Realtime effect.
- **browser media bootstrap** — Chromium's own fake-device flags provide a
  REAL `MediaStreamTrack`; a minimal `RTCPeerConnection` stub in the spec
  skips SDP negotiation (the fake SFU's SDP is intentionally unparseable)

## What the test proves

Room/control-plane + UI integration: two real browsers join the same Room
through the real Worker/DO, see each other's roster, and exchange a text
message; Bob then leaves and Alice's roster drops to one participant. No
direct DO mutation, no seeded state — the message crosses the real
WebSocket/DO broadcast path.

## What it explicitly does NOT prove

Realtime SFU/media correctness. Do not claim media correctness from this
harness; that lane belongs to real deployed media dogfood.

## How it is wired

- `yarn e2e:room` → `playwright test e2e/room/room.spec.ts --config=e2e/room/playwright.config.ts`
- webServer: `NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build && node e2e/room/run-local-worker.mjs`
  (OpenNext production build → `createTestHarness()` → fake Realtime → 3000 TCP relay)
- **`createTestHarness()` was used** (Wrangler 4.127; no `unstable_dev`)
- **Origin handling without weakening production security**: the harness
  binds a **transparent TCP relay on `http://localhost:3000`** — the one
  origin already in the production allow-list — and forwards every connection
  (HTTP + WebSocket) untouched. `src/common/origin.ts` is untouched; a probe
  with an evil `Origin` still returns 403.
- **outbound SFU interception — HARD invariant**: the env-scoped
  `SFU_RTC_BASE_URL` seam covers ALL Realtime outbound I/O (Worker routes +
  DO media cleanup). The fake (a) fails closed with 503 on unknown routes
  and (b) records every such call; the spec's final audit fetches the fake's
  `/__fake/requests` endpoint and asserts `unexpected == []`, so
  `yarn e2e:room` PASSES **only if every Cloudflare Realtime request made
  during the test was explicitly handled by the local fake**. Best-effort
  production semantics that swallow upstream failures (e.g. media cleanup
  reconciliation) cannot mask an unexpected request: the test hard-fails.
  No request can silently escape to rtc.live.cloudflare.com. (Verified
  negative: an injected unknown route returns 503 and appears in
  `unexpected`.)

## Clean-checkout reproducible

`@playwright/test` is a committed devDependency; `yarn e2e:room` needs only
`yarn install && npx playwright install` on a fresh checkout.

## Evidence (local runs)

- `yarn e2e:room` — **1 passed** × 3 consecutive runs (~28-34s each); after
  EVERY run: port 3000 has zero listeners AND the harness state dir
  (`fake-port.txt`, `harness.pid`) contains zero files (the spec removes the
  state dir after the audit; the harness itself also cleans up on SIGTERM)
- **Shutdown validation**: sending SIGTERM to the harness's real node pid
  (recorded in `harness.pid` — bash job wrappers report a different pid and
  leave node orphaned) produces the `fake-realtime saw N request(s)…`
  audit, deletes both state files, closes proxy/Worker/fake, and port 3000
  is immediately reusable (verified by restarting and serving 200). Signal
  handlers were hoisted to MODULE scope for this: handlers registered inside
  the long-lived async `main()` were observed not to run under
  createTestHarness (workerd child + long awaits).
- `yarn e2e:homepage` — **2 passed** (no regression)
- `yarn e2e:homepage` — **2 passed** (no regression)
- `yarn vitest run` — **67 files / 631 tests passed** (incl.
  `src/common/realtimeUrl.test.ts`: default production URL byte-identical
  incl. app-id encoding, override wins when present; and an
  `executeMediaCloseEffect` test proving `SFU_RTC_BASE_URL` redirects the
  media-effects `tracks/close` request too, with no
  rtc.live.cloudflare.com reachable)
- `yarn type-check`, `yarn eslint src --max-warnings 0`,
  `npx prettier --check .`, `HOME=/tmp/fakehome NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build`,
  `git diff --check` — all clean

## Skill update

`.agent/skills/free4chat-local-e2e/SKILL.md` is now the single canonical
local-testing guide: one Worker instance / split-brain DO / Turnstile
bypass / daemon-env-freeze / curl-MCP / lease traps are preserved, and the
automated browser Room lane plus a **test-to-change matrix** are added,
explicitly documenting that local Room E2E proves the control plane and NOT
the Realtime media plane.

## Production-code change (minimal)

A single shared seam `app/src/common/realtimeUrl.ts` now feeds both
`src/sfu/server.ts` `realtimeRequest` and `src/do/mediaEffects.ts`
`executeMediaCloseEffect` (previously this last one hard-coded the production
URL and could have escaped the harness). The seam is
`env.SFU_RTC_BASE_URL ?? https://rtc.live.cloudflare.com/v1/apps/{appId}`;
`RealtimeEnv` gained the optional override field. Analytics/authorization
untouched; production behavior without the override is byte-identical
(unit-tested).

## Remaining limitations

- Human+Agent (MCP join → browser roster) stretch test deferred to a
  follow-up; the MCP route and `ROOMS_KV` are already real in this harness.
- The suite is intentionally not CI-wired yet (manual, repeatable, ~30 s).
- `yarn e2e:room` requires free port 3000 (documented in the config).


