### PR TITLE
ux(agent): safely inherit selected local Harness environment

### DIFF
--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -17,6 +17,7 @@ import (
 	"github.com/i365dev/free4chat/agent/internal/daemon"
 	"github.com/i365dev/free4chat/agent/internal/doctor"
 	"github.com/i365dev/free4chat/agent/internal/free4chat"
+	"github.com/i365dev/free4chat/agent/internal/harness"
 	"github.com/i365dev/free4chat/agent/internal/types"
 )
 
@@ -33,13 +34,6 @@ const agentEnvMaxTotalBytes = 32 * 1024
 
 // agentEnvNamePattern matches conventional environment variable names.
 var agentEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
-
-// reservedAgentEnvNames are variables that Free4Chat intentionally owns or
-// filters for security/lifecycle semantics. Explicit inheritance is forbidden.
-var reservedAgentEnvNames = map[string]struct{}{
-	"CODEX_CONFIG":       {},
-	"INITIAL_AGENT_MODE": {},
-}
 
 func usageText() string {
 	return `Usage:
@@ -178,6 +172,16 @@ func keyValueOption(args []string, name string) (map[string]string, error) {
 // It resolves each NAME from the current CLI process environment and
 // validates against bounds, reserved names, and conventional grammar.
 func agentEnvOption(args []string) (map[string]string, error) {
+	// A bare trailing --agent-env (or one followed by another flag) has no
+	// NAME at all and must fail rather than being silently ignored.
+	for index, candidate := range args {
+		if candidate != "--agent-env" {
+			continue
+		}
+		if index+1 >= len(args) || strings.HasPrefix(args[index+1], "--") {
+			return nil, fmt.Errorf("--agent-env requires a variable NAME")
+		}
+	}
 	names := repeatedOption(args, "--agent-env")
 	if len(names) == 0 {
 		return nil, nil
@@ -197,12 +201,10 @@ func agentEnvOption(args []string) (map[string]string, error) {
 		if !agentEnvNamePattern.MatchString(name) {
 			return nil, fmt.Errorf("invalid environment variable name: %s", name)
 		}
-		// Forbid reserved Free4Chat lifecycle/security variables.
-		if _, reserved := reservedAgentEnvNames[name]; reserved {
-			return nil, fmt.Errorf("Harness environment variable %s is reserved by Free4Chat and cannot be inherited explicitly", name)
-		}
-		// Forbid arbitrary FREE4CHAT_* variables (Runtime controls, not provider config).
-		if strings.HasPrefix(name, "FREE4CHAT_") {
+		// Forbid Free4Chat-owned lifecycle/security variables. The shared
+		// rule (harness.ForbiddenExplicitEnv) is also enforced authoritatively
+		// at the daemon IPC boundary for direct requests.
+		if harness.ForbiddenExplicitEnv(name) {
 			return nil, fmt.Errorf("Harness environment variable %s is reserved by Free4Chat and cannot be inherited explicitly", name)
 		}
 		// Deduplicate: first occurrence wins (deterministic).

--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -25,17 +25,33 @@ const maxSurfaceBytes = attachments.MaxSurfaceBytes
 
 const mcpEndpointDefault = "https://www.free4.chat/mcp"
 
+// agentEnvMaxCount is the maximum number of --agent-env entries allowed.
+const agentEnvMaxCount = 16
+
+// agentEnvMaxTotalBytes is the maximum total size of all inherited values.
+const agentEnvMaxTotalBytes = 32 * 1024
+
+// agentEnvNamePattern matches conventional environment variable names.
+var agentEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// reservedAgentEnvNames are variables that Free4Chat intentionally owns or
+// filters for security/lifecycle semantics. Explicit inheritance is forbidden.
+var reservedAgentEnvNames = map[string]struct{}{
+	"CODEX_CONFIG":       {},
+	"INITIAL_AGENT_MODE": {},
+}
+
 func usageText() string {
 	return `Usage:
-  free4chat-agent room create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
-  free4chat-agent room create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
-  free4chat-agent room join <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
-  free4chat-agent room join <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
-  free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
-  free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>]
+  free4chat-agent room create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--agent-env <NAME>]...
+  free4chat-agent room create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--agent-env <NAME>]...
+  free4chat-agent room join <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>] [--agent-env <NAME>]...
+  free4chat-agent room join <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>] [--agent-env <NAME>]...
+  free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--provider-claim <opaque-secret>] [--agent-env <NAME>]...
+  free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--provider-claim <opaque-secret>] [--agent-env <NAME>]...
   free4chat-agent connect --room <room-id> --provider-claim <opaque-secret>
-  free4chat-agent create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
-  free4chat-agent create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
+  free4chat-agent create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]... [--agent-env <NAME>]...
+  free4chat-agent create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]... [--agent-env <NAME>]...
   free4chat-agent capabilities [--instance <id>] [--set <token>,<token>,...]
   free4chat-agent peers --room <room-id>
   free4chat-agent collab request --target <participant-id> --summary <text> [--request-id <id>] [--detail key=value]... [--attach <attachment-id>]... [--instance <id>]
@@ -156,6 +172,61 @@ func keyValueOption(args []string, name string) (map[string]string, error) {
 		details[entry[:separator]] = entry[separator+1:]
 	}
 	return details, nil
+}
+
+// agentEnvOption parses --agent-env NAME flags (repeatable, names only).
+// It resolves each NAME from the current CLI process environment and
+// validates against bounds, reserved names, and conventional grammar.
+func agentEnvOption(args []string) (map[string]string, error) {
+	names := repeatedOption(args, "--agent-env")
+	if len(names) == 0 {
+		return nil, nil
+	}
+	if len(names) > agentEnvMaxCount {
+		return nil, fmt.Errorf("too many --agent-env entries (max %d)", agentEnvMaxCount)
+	}
+	env := make(map[string]string, len(names))
+	totalBytes := 0
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		// Reject NAME=value syntax explicitly.
+		if strings.Contains(name, "=") {
+			return nil, fmt.Errorf("--agent-env takes a variable NAME only, not NAME=value")
+		}
+		// Validate conventional environment variable grammar.
+		if !agentEnvNamePattern.MatchString(name) {
+			return nil, fmt.Errorf("invalid environment variable name: %s", name)
+		}
+		// Forbid reserved Free4Chat lifecycle/security variables.
+		if _, reserved := reservedAgentEnvNames[name]; reserved {
+			return nil, fmt.Errorf("Harness environment variable %s is reserved by Free4Chat and cannot be inherited explicitly", name)
+		}
+		// Forbid arbitrary FREE4CHAT_* variables (Runtime controls, not provider config).
+		if strings.HasPrefix(name, "FREE4CHAT_") {
+			return nil, fmt.Errorf("Harness environment variable %s is reserved by Free4Chat and cannot be inherited explicitly", name)
+		}
+		// Deduplicate: first occurrence wins (deterministic).
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		// Resolve value from CURRENT CLI process environment, not daemon.
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			return nil, fmt.Errorf("Requested Harness environment variable %s is not set locally", name)
+		}
+		// Validate NUL-free (OS subprocess constraint).
+		if strings.Contains(value, "\x00") {
+			return nil, fmt.Errorf("environment variable %s contains invalid NUL byte", name)
+		}
+		valueBytes := len(value)
+		if totalBytes+valueBytes > agentEnvMaxTotalBytes {
+			return nil, fmt.Errorf("total inherited environment value size exceeds %d bytes", agentEnvMaxTotalBytes)
+		}
+		totalBytes += valueBytes
+		env[name] = value
+	}
+	return env, nil
 }
 
 func errUsage() error { return &exitError{code: 2, err: errors.New(usageText())} }
@@ -503,6 +574,10 @@ func joinRequest(rest []string) (*daemon.IpcRequest, error) {
 		(agent != "" && agentCommand != "") {
 		return nil, errUsage()
 	}
+	agentEnv, err := agentEnvOption(rest)
+	if err != nil {
+		return nil, err
+	}
 	return &daemon.IpcRequest{
 		Op:            "join",
 		Room:          room,
@@ -512,6 +587,7 @@ func joinRequest(rest []string) (*daemon.IpcRequest, error) {
 		AgentArgs:     repeatedOption(rest, "--agent-arg"),
 		Capabilities:  repeatedOption(rest, "--capability"),
 		ProviderClaim: providerClaim,
+		AgentEnv:      agentEnv,
 	}, nil
 }
 
@@ -526,6 +602,10 @@ func createRequest(rest []string) (*daemon.IpcRequest, error) {
 		(agent == "" && agentCommand == "") || (agent != "" && agentCommand != "") {
 		return nil, errUsage()
 	}
+	agentEnv, err := agentEnvOption(rest)
+	if err != nil {
+		return nil, err
+	}
 	return &daemon.IpcRequest{
 		Op:           "create",
 		Name:         name,
@@ -533,6 +613,7 @@ func createRequest(rest []string) (*daemon.IpcRequest, error) {
 		AgentCommand: agentCommand,
 		AgentArgs:    repeatedOption(rest, "--agent-arg"),
 		Capabilities: repeatedOption(rest, "--capability"),
+		AgentEnv:     agentEnv,
 	}, nil
 }
 

--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -897,3 +897,314 @@ func TestFormatCliErrorClassifier(t *testing.T) {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+// TestAgentEnvParsing validates the --agent-env CLI flag parsing contract.
+func TestAgentEnvParsing(t *testing.T) {
+	// 1. repeatable flag
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
+	})
+	_ = os.Setenv("CUSTOM_VAR1", "value1")
+	_ = os.Setenv("CUSTOM_VAR2", "value2")
+	defer os.Unsetenv("CUSTOM_VAR1")
+	defer os.Unsetenv("CUSTOM_VAR2")
+	_, code := runCliWithFakeDaemon(t, fixture,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "CUSTOM_VAR1",
+		"--agent-env", "CUSTOM_VAR2",
+	)
+	if code != 0 {
+		t.Fatalf("multiple --agent-env should succeed")
+	}
+	// Skip preflight requests
+	nextFakeRequest(t, fixture)        // status
+	nextFakeRequest(t, fixture)        // daemon-info
+	req := nextFakeRequest(t, fixture) // join
+	if req.AgentEnv == nil {
+		t.Fatalf("AgentEnv should be present in IPC request")
+	}
+	if req.AgentEnv["CUSTOM_VAR1"] != "value1" || req.AgentEnv["CUSTOM_VAR2"] != "value2" {
+		t.Fatalf("AgentEnv values should be populated from current shell: %v", req.AgentEnv)
+	}
+}
+
+// TestAgentEnvMissingFailsBeforeJoin ensures missing env vars fail locally.
+func TestAgentEnvMissingFailsBeforeJoin(t *testing.T) {
+	// Unset the variable first
+	_ = os.Unsetenv("MISSING_VAR_FOR_TEST_276")
+	output, code := runCli(t,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "MISSING_VAR_FOR_TEST_276",
+	)
+	if code == 0 {
+		t.Fatalf("missing --agent-env should fail before daemon join")
+	}
+	if !strings.Contains(output, "MISSING_VAR_FOR_TEST_276") ||
+		!strings.Contains(output, "not set locally") {
+		t.Fatalf("error should mention the variable name only: %s", output)
+	}
+}
+
+// TestAgentEnvInvalidNameRejected validates environment variable name grammar.
+func TestAgentEnvInvalidNameRejected(t *testing.T) {
+	for _, invalid := range []string{
+		"123INVALID",   // starts with digit
+		"INVALID-NAME", // contains hyphen
+		"INVALID.NAME", // contains dot
+		"=VALUE",       // NAME=value syntax
+		"",             // empty
+	} {
+		output, code := runCli(t,
+			"join", "--room", "test-room",
+			"--agent", "opencode",
+			"--name", "Test",
+			"--agent-env", invalid,
+		)
+		if code == 0 {
+			t.Fatalf("invalid name %q should be rejected", invalid)
+		}
+		if !strings.Contains(output, "invalid environment variable name") {
+			t.Fatalf("error should mention invalid name: %s", output)
+		}
+	}
+}
+
+// TestAgentEnvReservedNamesRejected validates reserved Free4Chat variables.
+func TestAgentEnvReservedNamesRejected(t *testing.T) {
+	for _, reserved := range []string{
+		"CODEX_CONFIG",
+		"INITIAL_AGENT_MODE",
+		"FREE4CHAT_API_KEY",
+		"FREE4CHAT_SOME_SETTING",
+	} {
+		output, code := runCli(t,
+			"join", "--room", "test-room",
+			"--agent", "opencode",
+			"--name", "Test",
+			"--agent-env", reserved,
+		)
+		if code == 0 {
+			t.Fatalf("reserved name %q should be rejected", reserved)
+		}
+		if !strings.Contains(output, "reserved by Free4Chat") {
+			t.Fatalf("error should mention reserved: %s", output)
+		}
+	}
+}
+
+// TestAgentEnvBoundsEnforced validates count and total size bounds.
+func TestAgentEnvBoundsEnforced(t *testing.T) {
+	// Too many entries
+	many := make([]string, 0, agentEnvMaxCount+2)
+	for i := 0; i < agentEnvMaxCount+2; i++ {
+		many = append(many, "--agent-env", fmt.Sprintf("VAR%d", i))
+		_ = os.Setenv(fmt.Sprintf("VAR%d", i), "value")
+	}
+	args := append([]string{"join", "--room", "test-room", "--agent", "opencode", "--name", "Test"}, many...)
+	output, code := runCli(t, args...)
+	if code == 0 {
+		t.Fatalf("too many --agent-env should fail")
+	}
+	if !strings.Contains(output, "too many --agent-env entries") {
+		t.Fatalf("error should mention count limit: %s", output)
+	}
+
+	// Clean up
+	for i := 0; i < agentEnvMaxCount+2; i++ {
+		_ = os.Unsetenv(fmt.Sprintf("VAR%d", i))
+	}
+
+	// Total size limit
+	largeVal := strings.Repeat("x", agentEnvMaxTotalBytes+1)
+	_ = os.Setenv("LARGE_VAR_TEST", largeVal)
+	output, code = runCli(t,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "LARGE_VAR_TEST",
+	)
+	_ = os.Unsetenv("LARGE_VAR_TEST")
+	if code == 0 {
+		t.Fatalf("too large --agent-env value should fail")
+	}
+	if !strings.Contains(output, "exceeds") && !strings.Contains(output, "bytes") {
+		t.Fatalf("error should mention size limit: %s", output)
+	}
+}
+
+// TestAgentEnvWorksOnAllEntryPaths validates --agent-env on create, join, room create, room join.
+func TestAgentEnvWorksOnAllEntryPaths(t *testing.T) {
+	// We only test that the flag is accepted and parsed on all four paths.
+	// The fake daemon will accept any request.
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
+	})
+
+	_ = os.Setenv("TEST_VAR_ENTRY", "entry-value")
+	defer os.Unsetenv("TEST_VAR_ENTRY")
+
+	for _, cmd := range [][]string{
+		{"create", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
+		{"join", "--room", "test-room", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
+		{"room", "create", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
+		{"room", "join", "test-room", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
+	} {
+		_, code := runCliWithFakeDaemon(t, fixture, cmd...)
+		if code != 0 {
+			t.Fatalf("--agent-env should work on %v: %v", cmd[0], code)
+		}
+		req := nextFakeRequest(t, fixture)
+		if req.AgentEnv == nil || req.AgentEnv["TEST_VAR_ENTRY"] != "entry-value" {
+			t.Fatalf("AgentEnv not passed correctly for %v: %v", cmd[0], req.AgentEnv)
+		}
+	}
+}
+
+// TestAgentEnvDeduplication validates deterministic duplicate handling.
+func TestAgentEnvDeduplication(t *testing.T) {
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
+	})
+	_ = os.Setenv("DUP_VAR_TEST", "first-value")
+	defer os.Unsetenv("DUP_VAR_TEST")
+
+	_, code := runCliWithFakeDaemon(t, fixture,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "DUP_VAR_TEST",
+		"--agent-env", "DUP_VAR_TEST", // duplicate
+	)
+	if code != 0 {
+		t.Fatalf("duplicate --agent-env should not fail")
+	}
+	req := nextFakeRequest(t, fixture)
+	if len(req.AgentEnv) != 1 || req.AgentEnv["DUP_VAR_TEST"] != "first-value" {
+		t.Fatalf("duplicate should be deduplicated (first wins): %v", req.AgentEnv)
+	}
+}
+
+// TestAgentEnvStaleDaemonRegression ensures current-shell values win over stale daemon env.
+func TestAgentEnvStaleDaemonRegression(t *testing.T) {
+	// This test validates that the CLI resolves values from its own process environment,
+	// not from the daemon's potentially stale environment.
+	// We simulate by setting a value in the test process, then verifying it reaches the IPC.
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
+	})
+
+	// Set a value in the CURRENT test process (simulating current shell)
+	_ = os.Setenv("STALE_TEST_VAR", "current-shell-value")
+	defer os.Unsetenv("STALE_TEST_VAR")
+
+	_, code := runCliWithFakeDaemon(t, fixture,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "STALE_TEST_VAR",
+	)
+	if code != 0 {
+		t.Fatalf("stale daemon regression test failed: %v", code)
+	}
+	req := nextFakeRequest(t, fixture)
+	if req.AgentEnv["STALE_TEST_VAR"] != "current-shell-value" {
+		t.Fatalf("current shell value should win, got: %v", req.AgentEnv["STALE_TEST_VAR"])
+	}
+}
+
+// TestAgentEnvSecretHygiene ensures secret values don't leak into responses/logs.
+func TestAgentEnvSecretHygiene(t *testing.T) {
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		// Include the secret in the response to verify it's NOT in the CLI output
+		return daemon.IpcResponse{OK: true, Result: map[string]any{
+			"roomId":     "test-room",
+			"secretEcho": "sentinel-super-secret-276",
+		}}
+	})
+
+	_ = os.Setenv("SECRET_HYGIENE_VAR", "sentinel-super-secret-276")
+	defer os.Unsetenv("SECRET_HYGIENE_VAR")
+
+	output, code := runCliWithFakeDaemon(t, fixture,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "SECRET_HYGIENE_VAR",
+	)
+	if code != 0 {
+		t.Fatalf("secret hygiene test failed: %v", code)
+	}
+	// The secret value must NOT appear in CLI output
+	if strings.Contains(output, "sentinel-super-secret-276") {
+		t.Fatalf("secret value leaked into CLI output: %s", output)
+	}
+	// The secret value must NOT appear in daemon response (we verify by checking
+	// the response we crafted doesn't accidentally contain it - the daemon
+	// response should not include AgentEnv)
+	if strings.Contains(output, "SECRET_HYGIENE_VAR") {
+		t.Fatalf("secret name leaked into CLI output: %s", output)
+	}
+}
+
+// TestAgentEnvWorksWithCustomLauncher validates --agent-env works with --agent-command.
+func TestAgentEnvWorksWithCustomLauncher(t *testing.T) {
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op == "status" {
+			return daemon.IpcResponse{OK: true, Result: []any{}}
+		}
+		if request.Op == "daemon-info" {
+			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		}
+		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
+	})
+	_ = os.Setenv("CUSTOM_LAUNCHER_VAR", "custom-value")
+	defer os.Unsetenv("CUSTOM_LAUNCHER_VAR")
+
+	_, code := runCliWithFakeDaemon(t, fixture,
+		"join", "--room", "test-room",
+		"--agent-command", "custom-acp",
+		"--name", "Test",
+		"--agent-env", "CUSTOM_LAUNCHER_VAR",
+	)
+	if code != 0 {
+		t.Fatalf("--agent-env should work with --agent-command")
+	}
+	req := nextFakeRequest(t, fixture)
+	if req.AgentEnv == nil || req.AgentEnv["CUSTOM_LAUNCHER_VAR"] != "custom-value" {
+		t.Fatalf("AgentEnv not passed with custom launcher: %v", req.AgentEnv)
+	}
+}

--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -898,23 +898,67 @@ type errString string
 
 func (e errString) Error() string { return string(e) }
 
-// TestAgentEnvParsing validates the --agent-env CLI flag parsing contract.
-func TestAgentEnvParsing(t *testing.T) {
-	// 1. repeatable flag
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
+// agentEnvFixture is a fake daemon that answers the standard join/create
+// preflight handshakes and the join/create operation itself.
+func agentEnvFixture(t *testing.T, result map[string]any) *fakeDaemon {
+	t.Helper()
+	return newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		switch request.Op {
+		case "status":
 			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
+		case "daemon-info":
 			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
+		case "join":
+			return daemon.IpcResponse{OK: true, Result: result}
+		case "create":
+			// The room create human-facing printer requires the public invite.
+			return daemon.IpcResponse{OK: true, Result: map[string]any{
+				"roomId": "test-room",
+				"invite": map[string]any{
+					"kind":    "free4chat.room-invite",
+					"version": 1,
+					"roomId":  "test-room",
+					"roomUrl": "https://www.free4.chat/room?id=test-room",
+				},
+			}}
+		default:
+			return daemon.IpcResponse{OK: false, Error: "unexpected fake daemon operation " + request.Op}
 		}
-		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
 	})
+}
+
+// nextFakeRequestOp drains preflight handshakes until the requested operation
+// arrives. join goes through daemon-info/version; create goes through
+// EnsureDaemon/status. Hard-coding the exact preflight sequence per command is
+// the source of earlier failures, so tests wait for the actual operation
+// instead of assuming a fixed request order.
+func nextFakeRequestOp(t *testing.T, fixture *fakeDaemon, op string) daemon.IpcRequest {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case request := <-fixture.requests:
+			if request.Op == op {
+				return request
+			}
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+	t.Fatalf("timed out waiting for fake daemon operation %q", op)
+	return daemon.IpcRequest{}
+}
+
+// TestAgentEnvParsing validates the --agent-env CLI flag parsing contract:
+// repeatable names are resolved from the CURRENT CLI environment and reach
+// the daemon IPC request.
+func TestAgentEnvParsing(t *testing.T) {
+	fixture := agentEnvFixture(t, map[string]any{"roomId": "test-room"})
 	_ = os.Setenv("CUSTOM_VAR1", "value1")
 	_ = os.Setenv("CUSTOM_VAR2", "value2")
 	defer os.Unsetenv("CUSTOM_VAR1")
 	defer os.Unsetenv("CUSTOM_VAR2")
-	_, code := runCliWithFakeDaemon(t, fixture,
+
+	output, code := runCliWithFakeDaemon(t, fixture,
 		"join", "--room", "test-room",
 		"--agent", "opencode",
 		"--name", "Test",
@@ -922,23 +966,20 @@ func TestAgentEnvParsing(t *testing.T) {
 		"--agent-env", "CUSTOM_VAR2",
 	)
 	if code != 0 {
-		t.Fatalf("multiple --agent-env should succeed")
+		t.Fatalf("multiple --agent-env should succeed, got %d (%s)", code, output)
 	}
-	// Skip preflight requests
-	nextFakeRequest(t, fixture)        // status
-	nextFakeRequest(t, fixture)        // daemon-info
-	req := nextFakeRequest(t, fixture) // join
-	if req.AgentEnv == nil {
-		t.Fatalf("AgentEnv should be present in IPC request")
+	request := nextFakeRequestOp(t, fixture, "join")
+	if len(request.AgentEnv) != 2 {
+		t.Fatalf("AgentEnv should carry both names, got %v", request.AgentEnv)
 	}
-	if req.AgentEnv["CUSTOM_VAR1"] != "value1" || req.AgentEnv["CUSTOM_VAR2"] != "value2" {
-		t.Fatalf("AgentEnv values should be populated from current shell: %v", req.AgentEnv)
+	if request.AgentEnv["CUSTOM_VAR1"] != "value1" || request.AgentEnv["CUSTOM_VAR2"] != "value2" {
+		t.Fatalf("AgentEnv values should be populated from current shell: %v", request.AgentEnv)
 	}
 }
 
-// TestAgentEnvMissingFailsBeforeJoin ensures missing env vars fail locally.
+// TestAgentEnvMissingFailsBeforeJoin ensures a requested NAME that is absent
+// from the CURRENT CLI environment fails locally before any daemon operation.
 func TestAgentEnvMissingFailsBeforeJoin(t *testing.T) {
-	// Unset the variable first
 	_ = os.Unsetenv("MISSING_VAR_FOR_TEST_276")
 	output, code := runCli(t,
 		"join", "--room", "test-room",
@@ -955,13 +996,13 @@ func TestAgentEnvMissingFailsBeforeJoin(t *testing.T) {
 	}
 }
 
-// TestAgentEnvInvalidNameRejected validates environment variable name grammar.
+// TestAgentEnvInvalidNameRejected validates environment variable name grammar
+// and the explicit rejection of NAME=value syntax.
 func TestAgentEnvInvalidNameRejected(t *testing.T) {
 	for _, invalid := range []string{
 		"123INVALID",   // starts with digit
 		"INVALID-NAME", // contains hyphen
 		"INVALID.NAME", // contains dot
-		"=VALUE",       // NAME=value syntax
 		"",             // empty
 	} {
 		output, code := runCli(t,
@@ -974,18 +1015,48 @@ func TestAgentEnvInvalidNameRejected(t *testing.T) {
 			t.Fatalf("invalid name %q should be rejected", invalid)
 		}
 		if !strings.Contains(output, "invalid environment variable name") {
-			t.Fatalf("error should mention invalid name: %s", output)
+			t.Fatalf("error should mention invalid name for %q: %s", invalid, output)
+		}
+	}
+
+	// NAME=value syntax is forbidden with its own message.
+	output, code := runCli(t,
+		"join", "--room", "test-room",
+		"--agent", "opencode",
+		"--name", "Test",
+		"--agent-env", "SOME_KEY=secret-value",
+	)
+	if code == 0 {
+		t.Fatal("NAME=value --agent-env syntax should be rejected")
+	}
+	if !strings.Contains(output, "--agent-env takes a variable NAME only, not NAME=value") {
+		t.Fatalf("NAME=value error message missing: %s", output)
+	}
+}
+
+// TestAgentEnvMissingValueRejected ensures a bare --agent-env with no
+// following NAME fails cleanly.
+func TestAgentEnvMissingValueRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"join", "--room", "test-room", "--agent", "opencode", "--name", "Test", "--agent-env"},
+		{"join", "--room", "test-room", "--agent", "opencode", "--name", "Test", "--agent-env", "--capability", "x"},
+	} {
+		output, code := runCli(t, args...)
+		if code == 0 || !strings.Contains(output, "--agent-env requires a variable NAME") {
+			t.Fatalf("%v must fail with the missing-NAME error, got code=%d output=%q", args, code, output)
 		}
 	}
 }
 
-// TestAgentEnvReservedNamesRejected validates reserved Free4Chat variables.
+// TestAgentEnvReservedNamesRejected validates Free4Chat-owned lifecycle and
+// security variables are rejected at the CLI.
 func TestAgentEnvReservedNamesRejected(t *testing.T) {
 	for _, reserved := range []string{
 		"CODEX_CONFIG",
 		"INITIAL_AGENT_MODE",
 		"FREE4CHAT_API_KEY",
 		"FREE4CHAT_SOME_SETTING",
+		"FREE4CHAT_AGENT_DIR",
 	} {
 		output, code := runCli(t,
 			"join", "--room", "test-room",
@@ -996,20 +1067,25 @@ func TestAgentEnvReservedNamesRejected(t *testing.T) {
 		if code == 0 {
 			t.Fatalf("reserved name %q should be rejected", reserved)
 		}
-		if !strings.Contains(output, "reserved by Free4Chat") {
-			t.Fatalf("error should mention reserved: %s", output)
+		if !strings.Contains(output, "reserved by Free4Chat") ||
+			strings.Contains(output, "=") {
+			t.Fatalf("reserved error should be name-only for %q: %s", reserved, output)
 		}
 	}
 }
 
-// TestAgentEnvBoundsEnforced validates count and total size bounds.
+// TestAgentEnvBoundsEnforced validates count and total value size bounds.
 func TestAgentEnvBoundsEnforced(t *testing.T) {
-	// Too many entries
 	many := make([]string, 0, agentEnvMaxCount+2)
 	for i := 0; i < agentEnvMaxCount+2; i++ {
 		many = append(many, "--agent-env", fmt.Sprintf("VAR%d", i))
 		_ = os.Setenv(fmt.Sprintf("VAR%d", i), "value")
 	}
+	defer func() {
+		for i := 0; i < agentEnvMaxCount+2; i++ {
+			_ = os.Unsetenv(fmt.Sprintf("VAR%d", i))
+		}
+	}()
 	args := append([]string{"join", "--room", "test-room", "--agent", "opencode", "--name", "Test"}, many...)
 	output, code := runCli(t, args...)
 	if code == 0 {
@@ -1019,43 +1095,27 @@ func TestAgentEnvBoundsEnforced(t *testing.T) {
 		t.Fatalf("error should mention count limit: %s", output)
 	}
 
-	// Clean up
-	for i := 0; i < agentEnvMaxCount+2; i++ {
-		_ = os.Unsetenv(fmt.Sprintf("VAR%d", i))
-	}
-
-	// Total size limit
 	largeVal := strings.Repeat("x", agentEnvMaxTotalBytes+1)
 	_ = os.Setenv("LARGE_VAR_TEST", largeVal)
+	defer os.Unsetenv("LARGE_VAR_TEST")
 	output, code = runCli(t,
 		"join", "--room", "test-room",
 		"--agent", "opencode",
 		"--name", "Test",
 		"--agent-env", "LARGE_VAR_TEST",
 	)
-	_ = os.Unsetenv("LARGE_VAR_TEST")
 	if code == 0 {
-		t.Fatalf("too large --agent-env value should fail")
+		t.Fatalf("over-size --agent-env value should fail")
 	}
 	if !strings.Contains(output, "exceeds") && !strings.Contains(output, "bytes") {
 		t.Fatalf("error should mention size limit: %s", output)
 	}
 }
 
-// TestAgentEnvWorksOnAllEntryPaths validates --agent-env on create, join, room create, room join.
+// TestAgentEnvWorksOnAllEntryPaths validates --agent-env on create, join,
+// room create, and room join.
 func TestAgentEnvWorksOnAllEntryPaths(t *testing.T) {
-	// We only test that the flag is accepted and parsed on all four paths.
-	// The fake daemon will accept any request.
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
-			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
-			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
-		}
-		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
-	})
-
+	fixture := agentEnvFixture(t, map[string]any{"roomId": "test-room"})
 	_ = os.Setenv("TEST_VAR_ENTRY", "entry-value")
 	defer os.Unsetenv("TEST_VAR_ENTRY")
 
@@ -1065,146 +1125,89 @@ func TestAgentEnvWorksOnAllEntryPaths(t *testing.T) {
 		{"room", "create", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
 		{"room", "join", "test-room", "--agent", "opencode", "--name", "Test", "--agent-env", "TEST_VAR_ENTRY"},
 	} {
-		_, code := runCliWithFakeDaemon(t, fixture, cmd...)
+		output, code := runCliWithFakeDaemon(t, fixture, cmd...)
 		if code != 0 {
-			t.Fatalf("--agent-env should work on %v: %v", cmd[0], code)
+			t.Fatalf("--agent-env should work on %v: %d %s", cmd, code, output)
 		}
-		req := nextFakeRequest(t, fixture)
-		if req.AgentEnv == nil || req.AgentEnv["TEST_VAR_ENTRY"] != "entry-value" {
-			t.Fatalf("AgentEnv not passed correctly for %v: %v", cmd[0], req.AgentEnv)
+		op := "create"
+		if cmd[0] == "join" || (cmd[0] == "room" && cmd[1] == "join") {
+			op = "join"
+		}
+		request := nextFakeRequestOp(t, fixture, op)
+		if request.AgentEnv == nil || request.AgentEnv["TEST_VAR_ENTRY"] != "entry-value" {
+			t.Fatalf("AgentEnv not passed for %v: %v", cmd, request.AgentEnv)
 		}
 	}
 }
 
-// TestAgentEnvDeduplication validates deterministic duplicate handling.
+// TestAgentEnvDeduplication validates deterministic duplicate handling: first
+// occurrence wins and the map holds exactly one entry.
 func TestAgentEnvDeduplication(t *testing.T) {
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
-			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
-			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
-		}
-		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
-	})
+	fixture := agentEnvFixture(t, map[string]any{"roomId": "test-room"})
 	_ = os.Setenv("DUP_VAR_TEST", "first-value")
 	defer os.Unsetenv("DUP_VAR_TEST")
 
-	_, code := runCliWithFakeDaemon(t, fixture,
+	output, code := runCliWithFakeDaemon(t, fixture,
 		"join", "--room", "test-room",
 		"--agent", "opencode",
 		"--name", "Test",
 		"--agent-env", "DUP_VAR_TEST",
-		"--agent-env", "DUP_VAR_TEST", // duplicate
+		"--agent-env", "DUP_VAR_TEST",
 	)
 	if code != 0 {
-		t.Fatalf("duplicate --agent-env should not fail")
+		t.Fatalf("duplicate --agent-env should not fail, got %d (%s)", code, output)
 	}
-	req := nextFakeRequest(t, fixture)
-	if len(req.AgentEnv) != 1 || req.AgentEnv["DUP_VAR_TEST"] != "first-value" {
-		t.Fatalf("duplicate should be deduplicated (first wins): %v", req.AgentEnv)
+	request := nextFakeRequestOp(t, fixture, "join")
+	if len(request.AgentEnv) != 1 || request.AgentEnv["DUP_VAR_TEST"] != "first-value" {
+		t.Fatalf("duplicate should be deduplicated (first wins): %v", request.AgentEnv)
 	}
 }
 
-// TestAgentEnvStaleDaemonRegression ensures current-shell values win over stale daemon env.
+// TestAgentEnvStaleDaemonRegression proves the CLI resolves values from its
+// own CURRENT environment: a value set after the daemon might have started
+// still reaches the IPC request, and the daemon never gets a chance to use an
+// older ambient copy for an explicitly inherited name.
 func TestAgentEnvStaleDaemonRegression(t *testing.T) {
-	// This test validates that the CLI resolves values from its own process environment,
-	// not from the daemon's potentially stale environment.
-	// We simulate by setting a value in the test process, then verifying it reaches the IPC.
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
-			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
-			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
-		}
-		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
-	})
+	fixture := agentEnvFixture(t, map[string]any{"roomId": "test-room"})
 
-	// Set a value in the CURRENT test process (simulating current shell)
+	// Simulate the stale-daemon setup: a value that existed "before" the CLI
+	// invocation. The explicit request must carry the CURRENT value.
 	_ = os.Setenv("STALE_TEST_VAR", "current-shell-value")
 	defer os.Unsetenv("STALE_TEST_VAR")
 
-	_, code := runCliWithFakeDaemon(t, fixture,
+	output, code := runCliWithFakeDaemon(t, fixture,
 		"join", "--room", "test-room",
 		"--agent", "opencode",
 		"--name", "Test",
 		"--agent-env", "STALE_TEST_VAR",
 	)
 	if code != 0 {
-		t.Fatalf("stale daemon regression test failed: %v", code)
+		t.Fatalf("stale daemon regression CLI run failed: %d (%s)", code, output)
 	}
-	req := nextFakeRequest(t, fixture)
-	if req.AgentEnv["STALE_TEST_VAR"] != "current-shell-value" {
-		t.Fatalf("current shell value should win, got: %v", req.AgentEnv["STALE_TEST_VAR"])
-	}
-}
-
-// TestAgentEnvSecretHygiene ensures secret values don't leak into responses/logs.
-func TestAgentEnvSecretHygiene(t *testing.T) {
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
-			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
-			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
-		}
-		// Include the secret in the response to verify it's NOT in the CLI output
-		return daemon.IpcResponse{OK: true, Result: map[string]any{
-			"roomId":     "test-room",
-			"secretEcho": "sentinel-super-secret-276",
-		}}
-	})
-
-	_ = os.Setenv("SECRET_HYGIENE_VAR", "sentinel-super-secret-276")
-	defer os.Unsetenv("SECRET_HYGIENE_VAR")
-
-	output, code := runCliWithFakeDaemon(t, fixture,
-		"join", "--room", "test-room",
-		"--agent", "opencode",
-		"--name", "Test",
-		"--agent-env", "SECRET_HYGIENE_VAR",
-	)
-	if code != 0 {
-		t.Fatalf("secret hygiene test failed: %v", code)
-	}
-	// The secret value must NOT appear in CLI output
-	if strings.Contains(output, "sentinel-super-secret-276") {
-		t.Fatalf("secret value leaked into CLI output: %s", output)
-	}
-	// The secret value must NOT appear in daemon response (we verify by checking
-	// the response we crafted doesn't accidentally contain it - the daemon
-	// response should not include AgentEnv)
-	if strings.Contains(output, "SECRET_HYGIENE_VAR") {
-		t.Fatalf("secret name leaked into CLI output: %s", output)
+	request := nextFakeRequestOp(t, fixture, "join")
+	if request.AgentEnv["STALE_TEST_VAR"] != "current-shell-value" {
+		t.Fatalf("current shell value should be carried over IPC, got %q", request.AgentEnv["STALE_TEST_VAR"])
 	}
 }
 
-// TestAgentEnvWorksWithCustomLauncher validates --agent-env works with --agent-command.
+// TestAgentEnvWorksWithCustomLauncher validates --agent-env works with the
+// --agent-command custom launcher path.
 func TestAgentEnvWorksWithCustomLauncher(t *testing.T) {
-	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
-		if request.Op == "status" {
-			return daemon.IpcResponse{OK: true, Result: []any{}}
-		}
-		if request.Op == "daemon-info" {
-			return daemon.IpcResponse{OK: true, Result: daemon.DaemonInfo{DaemonVersion: doctor.Version}}
-		}
-		return daemon.IpcResponse{OK: true, Result: map[string]any{"roomId": "test-room"}}
-	})
+	fixture := agentEnvFixture(t, map[string]any{"roomId": "test-room"})
 	_ = os.Setenv("CUSTOM_LAUNCHER_VAR", "custom-value")
 	defer os.Unsetenv("CUSTOM_LAUNCHER_VAR")
 
-	_, code := runCliWithFakeDaemon(t, fixture,
+	output, code := runCliWithFakeDaemon(t, fixture,
 		"join", "--room", "test-room",
 		"--agent-command", "custom-acp",
 		"--name", "Test",
 		"--agent-env", "CUSTOM_LAUNCHER_VAR",
 	)
 	if code != 0 {
-		t.Fatalf("--agent-env should work with --agent-command")
+		t.Fatalf("--agent-env should work with --agent-command, got %d (%s)", code, output)
 	}
-	req := nextFakeRequest(t, fixture)
-	if req.AgentEnv == nil || req.AgentEnv["CUSTOM_LAUNCHER_VAR"] != "custom-value" {
-		t.Fatalf("AgentEnv not passed with custom launcher: %v", req.AgentEnv)
+	request := nextFakeRequestOp(t, fixture, "join")
+	if request.AgentEnv == nil || request.AgentEnv["CUSTOM_LAUNCHER_VAR"] != "custom-value" {
+		t.Fatalf("AgentEnv not passed with custom launcher: %v", request.AgentEnv)
 	}
 }

--- a/agent/internal/daemon/daemon.go
+++ b/agent/internal/daemon/daemon.go
@@ -456,6 +456,7 @@ func (d *Daemon) prepareRuntime(
 		Adapter: harness.NewACPAdapter(launcher, workspace, harness.AdapterOptions{
 			TurnTimeoutMs: turnTimeoutMs,
 			CancelGraceMs: cancelGraceMs,
+			AgentEnv:      request.AgentEnv,
 		}),
 		Capabilities:        request.Capabilities,
 		SiteOrigin:          siteOrigin,
@@ -466,6 +467,7 @@ func (d *Daemon) prepareRuntime(
 		ProviderClaim:       request.ProviderClaim,
 		ProviderHandles:     d.providerHandles,
 		TranscriptProducers: d.transcriptProducers,
+		AgentEnv:            request.AgentEnv,
 		// Natural room expiry must release the resident registry entry and
 		// its private workspace, matching the Node reference's onRoomExpired
 		// wiring — otherwise status keeps showing a ghost instance and the

--- a/agent/internal/daemon/daemon.go
+++ b/agent/internal/daemon/daemon.go
@@ -374,6 +374,13 @@ func (d *Daemon) prepareRuntime(
 	isCreate bool,
 	request *IpcRequest,
 ) (*runtime.ResidentRuntime, string, string, error) {
+	// Authoritative reserved-name enforcement at the local IPC boundary: a
+	// direct daemon request (not just the CLI) must not be able to reintroduce
+	// Free4Chat-owned lifecycle/security variables through AgentEnv. The
+	// harness environment builder is a second, defense-in-depth drop layer.
+	if err := harness.ValidateExplicitEnv(request.AgentEnv); err != nil {
+		return nil, "", "", err
+	}
 	var launcher types.AgentLauncher
 	switch {
 	case request.AgentCommand != "" && request.Agent != "":
@@ -456,7 +463,10 @@ func (d *Daemon) prepareRuntime(
 		Adapter: harness.NewACPAdapter(launcher, workspace, harness.AdapterOptions{
 			TurnTimeoutMs: turnTimeoutMs,
 			CancelGraceMs: cancelGraceMs,
-			AgentEnv:      request.AgentEnv,
+			// Ephemeral per-resident Harness launch material transferred from
+			// the CLI. Never returned in responses, never persisted to status,
+			// workspace, or logs; dropped with the resident.
+			AgentEnv: request.AgentEnv,
 		}),
 		Capabilities:        request.Capabilities,
 		SiteOrigin:          siteOrigin,
@@ -467,7 +477,6 @@ func (d *Daemon) prepareRuntime(
 		ProviderClaim:       request.ProviderClaim,
 		ProviderHandles:     d.providerHandles,
 		TranscriptProducers: d.transcriptProducers,
-		AgentEnv:            request.AgentEnv,
 		// Natural room expiry must release the resident registry entry and
 		// its private workspace, matching the Node reference's onRoomExpired
 		// wiring — otherwise status keeps showing a ghost instance and the

--- a/agent/internal/daemon/daemon_test.go
+++ b/agent/internal/daemon/daemon_test.go
@@ -1343,3 +1343,284 @@ func TestStatusProjectsRuntimeHost(t *testing.T) {
 		t.Fatalf("speech readiness mismatch: %v", view["speech"])
 	}
 }
+
+// TestAgentEnvDirectIPCRejectsForbidden proves reserved-name enforcement is
+// authoritative beyond the CLI: a direct daemon IPC request carrying
+// Free4Chat-owned lifecycle/security variables is rejected at the daemon
+// boundary before any room/Harness work happens.
+func TestAgentEnvDirectIPCRejectsForbidden(t *testing.T) {
+	d, _ := startDaemon(t)
+
+	for _, forbidden := range []string{
+		"CODEX_CONFIG",
+		"INITIAL_AGENT_MODE",
+		"FREE4CHAT_OVERRIDE",
+	} {
+		_, err := SendIPC(&IpcRequest{
+			Op:           "join",
+			Room:         "forbidden-room",
+			Name:         "Forbidden",
+			AgentCommand: fakeAgentBinary,
+			AgentEnv:     map[string]string{forbidden: "bypass-value"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "reserved by Free4Chat") ||
+			strings.Contains(err.Error(), "bypass-value") {
+			t.Fatalf("direct IPC with %s must be rejected name-only, got %v", forbidden, err)
+		}
+	}
+	if count := d.InstanceCount(); count != 0 {
+		t.Fatalf("forbidden join must not create a resident: %d", count)
+	}
+
+	// An ordinary operator variable still passes the boundary; the join then
+	// fails later on the dead Harness, never on env validation.
+	_, err := SendIPC(&IpcRequest{
+		Op:           "join",
+		Room:         "clean-room",
+		Name:         "Clean",
+		AgentCommand: "nonexistent-acp-binary-xyz",
+		AgentEnv:     map[string]string{"CUSTOM_PROVIDER_KEY": "ok"},
+	})
+	if err == nil || strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("ordinary AgentEnv must pass the boundary validation: %v", err)
+	}
+}
+
+// scriptLauncherForEnv builds a shell wrapper around the fake agent that sets
+// FAKE_MODE and FAKE_ENV_NAME, so the ACP subprocess observes the chosen env
+// variable without weakening the production environment filter.
+func scriptLauncherForEnv(mode, envName string) string {
+	dir, err := os.MkdirTemp("", "fcagent-env-launcher-")
+	if err != nil {
+		panic(err)
+	}
+	script := "#!/bin/sh\nexport FAKE_MODE=" + mode + "\nexport FAKE_ENV_NAME=" + envName + "\nexec \"" + fakeAgentBinary + "\"\n"
+	path := filepath.Join(dir, "env-agent")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		panic(err)
+	}
+	return path
+}
+
+// envEchoMCPServer scripts the MCP layer for a join + one addressed room
+// event. The fake Harness runs in mode "env" and echoes the observed value of
+// the FAKE_ENV_NAME variable as its reply, which the Runtime publishes via
+// send_text. Returns the server plus a recorder of sent room texts.
+func envEchoMCPServer(t *testing.T, room string) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var sentTexts []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveResidentEventSocket(w, r, map[string]any{
+			"type": "events",
+			"events": []any{map[string]any{
+				"sequence": float64(1), "type": "text",
+				"participant": map[string]any{
+					"id": "human-1", "name": "Ada", "kind": "human",
+				},
+				"text": "reveal", "addressed": true,
+				"createdAt": float64(1700000000000),
+			}},
+			"cursor":    float64(1),
+			"expiresAt": float64(time.Now().Add(time.Hour).UnixMilli()),
+		}) {
+			return
+		}
+		var body struct {
+			Method string `json:"method"`
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		switch body.Method {
+		case "tools/list":
+			writeModernMCPTools(w)
+		case "tools/call":
+			w.Header().Set("Content-Type", "application/json")
+			switch body.Params.Name {
+			case "join_room":
+				writeJSONRPC(w, callToolResult(map[string]any{
+					"participantHandle": residentTestHandle(room, "agent-env", "env-token"),
+					"participant":       map[string]any{"id": "agent-env"},
+					"cursor":            float64(0),
+					"expiresAt":         float64(time.Now().Add(time.Hour).UnixMilli()),
+				}))
+			case "wait_for_events":
+				http.Error(w, "resident Runtime must use the event stream", http.StatusInternalServerError)
+			case "send_text":
+				text, _ := body.Params.Arguments["text"].(string)
+				mu.Lock()
+				sentTexts = append(sentTexts, text)
+				mu.Unlock()
+				writeJSONRPC(w, callToolResult(map[string]any{"sequence": float64(1)}))
+			case "leave_room":
+				writeJSONRPC(w, callToolResult(map[string]any{}))
+			default:
+				writeJSONRPC(w, callToolResult(map[string]any{}))
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), sentTexts...)
+	}
+}
+
+// TestAgentEnvStaleDaemonMeaningful proves the stale-daemon regression end to
+// end: the daemon process environment holds an OLD ambient value for a safe
+// allow-list key, while the explicit transfer carries the NEW value. The ACP
+// Harness subprocess must observe the NEW explicitly transferred value, never
+// the stale daemon ambient copy.
+func TestAgentEnvStaleDaemonMeaningful(t *testing.T) {
+	// Seed the daemon ambient environment with the OLD value BEFORE it starts;
+	// OPENAI_API_KEY is on the safe ambient allow-list, so without explicit
+	// transfer the Harness would inherit this stale copy.
+	t.Setenv("OPENAI_API_KEY", "stale-daemon-value")
+
+	_, _ = startDaemon(t)
+	server, sent := envEchoMCPServer(t, "stale-env")
+	t.Setenv("FREE4CHAT_MCP_URL", server.URL)
+
+	launcher := scriptLauncherForEnv("env", "OPENAI_API_KEY")
+	joined, err := SendIPC(&IpcRequest{
+		Op:           "join",
+		Room:         "stale-env",
+		Name:         "Stale",
+		AgentCommand: launcher,
+		// The explicit transfer carries the NEW value resolved from the
+		// current CLI environment (simulated here as the direct IPC value).
+		AgentEnv: map[string]string{"OPENAI_API_KEY": "new-cli-value"},
+	})
+	if err != nil {
+		t.Fatalf("join failed: %v", err)
+	}
+	var view struct {
+		InstanceID string `json:"instanceId"`
+		State      string `json:"state"`
+	}
+	if err := json.Unmarshal(joined, &view); err != nil || view.State != "waiting" {
+		t.Fatalf("join view mismatch: %s", joined)
+	}
+
+	// The fake Harness echoes the environment value it actually observes. It
+	// must be the NEW transferred value, never the stale daemon ambient copy.
+	deadline := time.Now().Add(10 * time.Second)
+	var texts []string
+	for time.Now().Before(deadline) {
+		texts = sent()
+		if len(texts) > 0 {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if len(texts) == 0 {
+		t.Fatal("fake Harness never answered the addressed turn")
+	}
+	foundNew, foundOld := false, false
+	for _, text := range texts {
+		if text == "new-cli-value" {
+			foundNew = true
+		}
+		if text == "stale-daemon-value" {
+			foundOld = true
+		}
+	}
+	if foundOld {
+		t.Fatalf("stale daemon ambient value won over explicit transfer: %v", texts)
+	}
+	if !foundNew {
+		t.Fatalf("Harness did not receive the explicitly transferred value: %v", texts)
+	}
+}
+
+// TestAgentEnvSecretNonPersistence proves explicitly inherited values survive
+// only in (a) the transient IPC request and (b) the Harness subprocess env:
+// the daemon response, status projection, bounded daemon logs, and resident
+// workspace files never contain the inherited VALUE.
+func TestAgentEnvSecretNonPersistence(t *testing.T) {
+	const sentinel = "sentinel-super-secret-276"
+	_, _ = startDaemon(t)
+
+	server, sent := envEchoMCPServer(t, "secret-room")
+	t.Setenv("FREE4CHAT_MCP_URL", server.URL)
+
+	launcher := scriptLauncherForEnv("env", "CUSTOM_PROVIDER_VAR")
+	joined, err := SendIPC(&IpcRequest{
+		Op:           "join",
+		Room:         "secret-room",
+		Name:         "Secret",
+		AgentCommand: launcher,
+		AgentEnv:     map[string]string{"CUSTOM_PROVIDER_VAR": sentinel},
+	})
+	if err != nil {
+		t.Fatalf("join failed: %v", err)
+	}
+	// The join RESPONSE must never echo the inherited value.
+	if strings.Contains(string(joined), sentinel) {
+		t.Fatalf("join response leaked the inherited value: %s", joined)
+	}
+	var view struct {
+		InstanceID string `json:"instanceId"`
+		State      string `json:"state"`
+	}
+	if err := json.Unmarshal(joined, &view); err != nil || view.InstanceID == "" {
+		t.Fatalf("join payload mismatch: %s", joined)
+	}
+
+	// The turn IS answered (proving the value reached the Harness subprocess),
+	// then the value must appear in NO daemon-visible surface.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && len(sent()) == 0 {
+		time.Sleep(25 * time.Millisecond)
+	}
+	if len(sent()) == 0 {
+		t.Fatal("fake Harness never answered the addressed turn")
+	}
+
+	for _, surface := range []string{string(joined), string(mustStatus(t))} {
+		if strings.Contains(surface, sentinel) {
+			t.Fatalf("inherited value leaked into a daemon surface: %s", surface)
+		}
+	}
+
+	// Bounded daemon logs must not contain the value.
+	log := NewBoundedLog(RuntimeDirectory())
+	if strings.Contains(strings.Join(log.Tail(2000, ""), "\n"), sentinel) {
+		t.Fatalf("daemon logs leaked the inherited value")
+	}
+
+	// Resident workspace files must not contain the value.
+	workspace := filepath.Join(WorkspacesRoot(), view.InstanceID)
+	if err := filepath.Walk(workspace, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr == nil && strings.Contains(string(data), sentinel) {
+			t.Fatalf("workspace file %s leaked the inherited value", path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("workspace walk failed: %v", err)
+	}
+
+	if _, err := SendIPC(&IpcRequest{Op: "leave", InstanceID: view.InstanceID}); err != nil {
+		t.Fatalf("leave failed: %v", err)
+	}
+}
+
+// mustStatus snapshots daemon status, failing the test on transport errors.
+func mustStatus(t *testing.T) json.RawMessage {
+	t.Helper()
+	status, err := SendIPC(&IpcRequest{Op: "status"})
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	return status
+}

--- a/agent/internal/daemon/ipc.go
+++ b/agent/internal/daemon/ipc.go
@@ -76,6 +76,11 @@ type IpcRequest struct {
 	BeforeTranscriptSequence *int64            `json:"beforeTranscriptSequence,omitempty"`
 	AfterTranscriptSequence  *int64            `json:"afterTranscriptSequence,omitempty"`
 	TranscriptLimit          int               `json:"transcriptLimit,omitempty"`
+	// AgentEnv is a map of explicitly authorized Harness environment variable
+	// NAMES -> VALUES resolved from the CLI process at join/create time.
+	// It is ephemeral launch material: never returned in daemon responses,
+	// never persisted to workspace/status/logs, never enters Room/MCP/ACP.
+	AgentEnv map[string]string `json:"agentEnv,omitempty"`
 }
 
 // IpcResponse is the single-line reply envelope.

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -38,6 +38,11 @@ func (e *TurnTimeoutError) Error() string {
 type AdapterOptions struct {
 	TurnTimeoutMs int64
 	CancelGraceMs int64
+	// AgentEnv is a map of explicitly authorized Harness environment variable
+	// NAMES -> VALUES resolved from the CLI process at join/create time.
+	// It is ephemeral launch material: never returned in daemon responses,
+	// never persisted to workspace/status/logs, never enters Room/MCP/ACP.
+	AgentEnv map[string]string
 }
 
 // ACPCapabilities is the parsed initialize response projection.
@@ -246,7 +251,7 @@ func (a *ACPAdapter) EnsureSession() error {
 
 	command := exec.Command(a.launcher.Command, a.launcher.Args...)
 	command.Dir = a.workingDir
-	command.Env = environmentSlice(BuildHarnessEnvironment(a.launcher, nil))
+	command.Env = environmentSlice(BuildHarnessEnvironment(a.launcher, nil, a.options.AgentEnv))
 	stdinPipe, err := command.StdinPipe()
 	if err != nil {
 		a.mu.Unlock()

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -458,6 +458,143 @@ func TestBuildHarnessEnvironmentIsAllowListed(t *testing.T) {
 	}
 }
 
+// TestBuildHarnessEnvironmentAppliesExplicitEnv proves the three-layer
+// precedence: safe ambient environment first, then explicitly inherited names
+// from the operator, with unrelated ambient variables still filtered out.
+func TestBuildHarnessEnvironmentAppliesExplicitEnv(t *testing.T) {
+	launcher := types.AgentLauncher{ID: "fake"}
+	explicit := map[string]string{
+		"CUSTOM_PROVIDER_KEY": "operator-secret",
+	}
+	environment := BuildHarnessEnvironment(launcher, map[string]string{
+		"PATH":                  "/safe/bin",
+		"CUSTOM_PROVIDER_KEY":   "ambient-must-not-win",
+		"AWS_SECRET_ACCESS_KEY": "must-not-pass",
+	}, explicit)
+	if environment["PATH"] != "/safe/bin" {
+		t.Fatalf("safe ambient key lost: %v", environment)
+	}
+	if environment["CUSTOM_PROVIDER_KEY"] != "operator-secret" {
+		t.Fatalf("explicitly inherited value must win over ambient: %v", environment["CUSTOM_PROVIDER_KEY"])
+	}
+	if _, present := environment["AWS_SECRET_ACCESS_KEY"]; present {
+		t.Fatal("unrelated ambient secret must stay filtered")
+	}
+}
+
+// TestBuildHarnessEnvironmentLauncherPolicyWins proves Free4Chat launcher-owned
+// explicit policy overrides operator-inherited environment.
+func TestBuildHarnessEnvironmentLauncherPolicyWins(t *testing.T) {
+	launcher := types.AgentLauncher{
+		ID: "fake",
+		Environment: map[string]string{
+			"MODE_LOCK": "launcher-policy",
+		},
+	}
+	environment := BuildHarnessEnvironment(launcher, nil, map[string]string{
+		"MODE_LOCK": "operator-attempt",
+	})
+	if environment["MODE_LOCK"] != "launcher-policy" {
+		t.Fatalf("launcher-owned policy must win, got %q", environment["MODE_LOCK"])
+	}
+}
+
+// TestBuildHarnessEnvironmentDropsForbiddenExplicit proves defense-in-depth:
+// even a direct internal explicitEnv map cannot reintroduce Free4Chat-owned
+// lifecycle/security variables into the Harness subprocess environment.
+func TestBuildHarnessEnvironmentDropsForbiddenExplicit(t *testing.T) {
+	launcher := types.AgentLauncher{
+		ID: "fake",
+		Environment: map[string]string{
+			"INITIAL_AGENT_MODE": "read-only",
+		},
+	}
+	environment := BuildHarnessEnvironment(launcher, nil, map[string]string{
+		"CODEX_CONFIG":       "/bypass/config",
+		"INITIAL_AGENT_MODE": "full-access",
+		"FREE4CHAT_OVERRIDE": "bypass",
+		"OK_PROVIDER_VAR":    "allowed",
+	})
+	if _, present := environment["CODEX_CONFIG"]; present {
+		t.Fatal("explicit CODEX_CONFIG must be dropped")
+	}
+	if environment["INITIAL_AGENT_MODE"] != "read-only" {
+		t.Fatalf("explicit INITIAL_AGENT_MODE must not override launcher policy, got %q", environment["INITIAL_AGENT_MODE"])
+	}
+	if _, present := environment["FREE4CHAT_OVERRIDE"]; present {
+		t.Fatal("explicit FREE4CHAT_* must be dropped")
+	}
+	if environment["OK_PROVIDER_VAR"] != "allowed" {
+		t.Fatalf("allowed operator variable lost: %v", environment["OK_PROVIDER_VAR"])
+	}
+}
+
+// TestValidateExplicitEnvRejectsForbidden proves the authoritative IPC-boundary
+// validation: a direct daemon request carrying forbidden names fails closed.
+func TestValidateExplicitEnvRejectsForbidden(t *testing.T) {
+	for _, env := range []map[string]string{
+		{"CODEX_CONFIG": "x"},
+		{"INITIAL_AGENT_MODE": "x"},
+		{"FREE4CHAT_ANYTHING": "x"},
+	} {
+		if err := ValidateExplicitEnv(env); err == nil ||
+			!strings.Contains(err.Error(), "reserved by Free4Chat") {
+			t.Fatalf("forbidden env %v must be rejected, got %v", env, err)
+		}
+	}
+	if err := ValidateExplicitEnv(map[string]string{"CUSTOM_PROVIDER_KEY": "x"}); err != nil {
+		t.Fatalf("ordinary operator variable must pass validation: %v", err)
+	}
+}
+
+// TestACPSubprocessReceivesExplicitEnv proves the whole path end to end: an
+// operator-authorized variable resolved from the current shell reaches the ACP
+// Harness subprocess environment through the adapter's explicit env.
+func TestACPSubprocessReceivesExplicitEnv(t *testing.T) {
+	const sentinel = "sentinel-explicit-env-276"
+	launcher := scriptLauncher("env", map[string]string{
+		"FAKE_ENV_NAME": "CUSTOM_PROVIDER_VAR",
+	})
+	adapter, _ := newTestAdapter(t, launcher, AdapterOptions{
+		AgentEnv: map[string]string{"CUSTOM_PROVIDER_VAR": sentinel},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("reveal"), adapter.SessionGeneration())
+	if err != nil {
+		t.Fatalf("turn failed: %v", err)
+	}
+	if result.Text != sentinel {
+		t.Fatalf("Harness did not receive explicit env value, got %q", result.Text)
+	}
+}
+
+// TestACPSubprocessLauncherPolicyWins proves that when the launcher itself
+// owns a variable, the operator's inherited value cannot override it in the
+// ACP subprocess.
+func TestACPSubprocessLauncherPolicyWins(t *testing.T) {
+	launcher := scriptLauncher("env", map[string]string{
+		"FAKE_ENV_NAME": "MODE_LOCK",
+		"MODE_LOCK":     "launcher-policy",
+	})
+	adapter, _ := newTestAdapter(t, launcher, AdapterOptions{
+		AgentEnv: map[string]string{"MODE_LOCK": "operator-attempt"},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("reveal"), adapter.SessionGeneration())
+	if err != nil {
+		t.Fatalf("turn failed: %v", err)
+	}
+	if result.Text != "launcher-policy" {
+		t.Fatalf("launcher-owned policy must win in the subprocess, got %q", result.Text)
+	}
+}
+
 func TestACPSubprocessReceivesExplicitRuntimeRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "runtime-root")
 	t.Setenv("FREE4CHAT_AGENT_DIR", root)

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -432,7 +432,7 @@ func TestBuildHarnessEnvironmentIsAllowListed(t *testing.T) {
 		"GITHUB_TOKEN":          "must-not-pass",
 		"CODEX_CONFIG":          "/unsafe/config",
 		"INITIAL_AGENT_MODE":    "full-access",
-	})
+	}, map[string]string{})
 	if environment["PATH"] != "/safe/bin" || environment["HOME"] != "/home/test" {
 		t.Fatalf("safe keys lost: %v", environment)
 	}

--- a/agent/internal/harness/env.go
+++ b/agent/internal/harness/env.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/i365dev/free4chat/agent/internal/types"
 )
@@ -45,6 +46,36 @@ var doctorEnvironmentKeys = []string{
 	"PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "NO_COLOR",
 }
 
+// ForbiddenExplicitEnv reports whether an explicitly inherited environment
+// NAME is Free4Chat-owned lifecycle/security policy that must never be
+// overridable through operator-authorized named inheritance.
+//
+// CODEX_CONFIG and INITIAL_AGENT_MODE are intentionally removed from every
+// Harness environment and may only be set by a built-in launcher's own
+// explicit policy. Arbitrary FREE4CHAT_* names are Runtime control variables,
+// not generic provider configuration; FREE4CHAT_AGENT_DIR remains propagated
+// by the ambient allow-list (never through explicit inheritance).
+func ForbiddenExplicitEnv(name string) bool {
+	return name == "CODEX_CONFIG" || name == "INITIAL_AGENT_MODE" ||
+		strings.HasPrefix(name, "FREE4CHAT_")
+}
+
+// ValidateExplicitEnv rejects a whole explicitly inherited environment map
+// when it contains any Free4Chat-owned lifecycle/security variable. The
+// daemon calls this at the IPC boundary so a direct daemon request — not just
+// the CLI — cannot reintroduce a forbidden policy override.
+func ValidateExplicitEnv(env map[string]string) error {
+	for name := range env {
+		if ForbiddenExplicitEnv(name) {
+			return fmt.Errorf(
+				"Harness environment variable %s is reserved by Free4Chat and cannot be inherited explicitly",
+				name,
+			)
+		}
+	}
+	return nil
+}
+
 // BuildHarnessEnvironment filters the ambient environment down to the safe
 // allow-list, applies explicitly authorized named environment from the
 // operator (CLI --agent-env), and finally applies the launcher's explicit
@@ -66,7 +97,13 @@ func BuildHarnessEnvironment(launcher types.AgentLauncher, base map[string]strin
 	delete(environment, "INITIAL_AGENT_MODE")
 	// Apply explicitly authorized named environment from operator (CLI --agent-env).
 	// These are resolved from the CURRENT CLI process, not the daemon.
+	// Defense in depth: even if a forbidden name slipped past the daemon's
+	// ValidateExplicitEnv boundary, it is dropped here and can never reach
+	// the Harness subprocess or override launcher-owned policy.
 	for key, value := range explicitEnv {
+		if ForbiddenExplicitEnv(key) {
+			continue
+		}
 		environment[key] = value
 	}
 	// Launcher-owned explicit policy wins (e.g., Codex INITIAL_AGENT_MODE=read-only).

--- a/agent/internal/harness/env.go
+++ b/agent/internal/harness/env.go
@@ -46,13 +46,15 @@ var doctorEnvironmentKeys = []string{
 }
 
 // BuildHarnessEnvironment filters the ambient environment down to the safe
-// allow-list, never inherits ambient Codex privilege/configuration policy,
-// and finally applies the launcher's explicit overrides.
-func BuildHarnessEnvironment(launcher types.AgentLauncher, base map[string]string) map[string]string {
+// allow-list, applies explicitly authorized named environment from the
+// operator (CLI --agent-env), and finally applies the launcher's explicit
+// overrides. Precedence: safe ambient -> operator authorized -> launcher policy.
+// launcher-owned policy always wins.
+func BuildHarnessEnvironment(launcher types.AgentLauncher, base map[string]string, explicitEnv map[string]string) map[string]string {
 	if base == nil {
 		base = osEnviron()
 	}
-	environment := make(map[string]string, len(safeEnvironmentKeys)+len(launcher.Environment))
+	environment := make(map[string]string, len(safeEnvironmentKeys)+len(launcher.Environment)+len(explicitEnv))
 	for _, key := range safeEnvironmentKeys {
 		if value, ok := base[key]; ok {
 			environment[key] = value
@@ -62,6 +64,12 @@ func BuildHarnessEnvironment(launcher types.AgentLauncher, base map[string]strin
 	// built-in launcher may opt into an explicit safe value below.
 	delete(environment, "CODEX_CONFIG")
 	delete(environment, "INITIAL_AGENT_MODE")
+	// Apply explicitly authorized named environment from operator (CLI --agent-env).
+	// These are resolved from the CURRENT CLI process, not the daemon.
+	for key, value := range explicitEnv {
+		environment[key] = value
+	}
+	// Launcher-owned explicit policy wins (e.g., Codex INITIAL_AGENT_MODE=read-only).
 	for key, value := range launcher.Environment {
 		environment[key] = value
 	}

--- a/agent/internal/harness/testdata/fakeagent/main.go
+++ b/agent/internal/harness/testdata/fakeagent/main.go
@@ -223,7 +223,14 @@ func main() {
 			prompt := promptText(message.Params)
 			switch a.mode {
 			case "env":
-				updateChunk(sessionID, os.Getenv("FREE4CHAT_AGENT_DIR"))
+				// FAKE_ENV_NAME selects which environment variable the Harness
+				// observes (defaults to the Runtime root contract). The value is
+				// echoed as the reply, never leaked into logs.
+				name := os.Getenv("FAKE_ENV_NAME")
+				if name == "" {
+					name = "FREE4CHAT_AGENT_DIR"
+				}
+				updateChunk(sessionID, os.Getenv(name))
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "context_read":
 				output, err := exec.Command("free4chat-agent", "context", "read", "--before-sequence", "2", "--limit", "10").CombinedOutput()

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -96,11 +96,6 @@ type Options struct {
 	// Room-selected Live Transcript Runtime Host. Nil disables the optional
 	// producer path fail-closed while preserving text and legacy media.
 	TranscriptProducers media.LiveTranscriptCoordinator
-	// AgentEnv is a map of explicitly authorized Harness environment variable
-	// NAMES -> VALUES resolved from the CLI process at join/create time.
-	// It is ephemeral launch material: never returned in daemon responses,
-	// never persisted to workspace/status/logs, never enters Room/MCP/ACP.
-	AgentEnv map[string]string
 }
 
 // ResidentRuntime owns exactly one Free4Chat participant across many Harness

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -96,6 +96,11 @@ type Options struct {
 	// Room-selected Live Transcript Runtime Host. Nil disables the optional
 	// producer path fail-closed while preserving text and legacy media.
 	TranscriptProducers media.LiveTranscriptCoordinator
+	// AgentEnv is a map of explicitly authorized Harness environment variable
+	// NAMES -> VALUES resolved from the CLI process at join/create time.
+	// It is ephemeral launch material: never returned in daemon responses,
+	// never persisted to workspace/status/logs, never enters Room/MCP/ACP.
+	AgentEnv map[string]string
 }
 
 // ResidentRuntime owns exactly one Free4Chat participant across many Harness


### PR DESCRIPTION
## Summary

Implements **safe named local environment inheritance** for Harness launch (Refs #276).

A locally working Harness may depend on operator-specific environment variables that Free4Chat's safe allow-list doesn't know about. This feature lets the setup Agent/operator explicitly authorize selected variable **names** for one Harness launch:

```bash
free4chat-agent room join <room-id> \
  --agent codex \
  --name Codex \
  --agent-env CUSTOM_PROVIDER_KEY \
  --agent-env CUSTOM_PROVIDER_BASE_URL
```

## Key Design Decisions

### CLI Contract (`--agent-env <NAME>`)
- Repeatable flag on all entry paths: `room create`, `room join`, `create`, `join`
- Names only — never `NAME=value` syntax; bare `--agent-env` with no NAME is rejected
- Conventional env var grammar: `^[A-Za-z_][A-Za-z0-9_]*$`
- Values resolved from **current CLI process environment** (`os.LookupEnv`), not the resident daemon's stale environment
- Bounds: max 16 entries, max 32KB total value size
- Deterministic deduplication (first occurrence wins)
- Name-only errors for missing / invalid / reserved names — never values

### Reserved-Name Enforcement Is Authoritative Beyond the CLI (review #1)
- The daemon validates `AgentEnv` at the local IPC boundary (`harness.ValidateExplicitEnv`) — a **direct daemon IPC request** cannot reintroduce `CODEX_CONFIG`, `INITIAL_AGENT_MODE`, or arbitrary `FREE4CHAT_*`
- `BuildHarnessEnvironment` drops forbidden names as defense in depth before the ACP subprocess is spawned
- `FREE4CHAT_AGENT_DIR`'s existing **ambient allow-list** propagation is preserved (it is only forbidden via explicit `--agent-env`)

### Environment Precedence (security-sensitive)
1. Default safe ambient allow-list
2. Operator-authorized named environment (this feature)
3. **Launcher-owned explicit policy (always wins)** — e.g. Codex `INITIAL_AGENT_MODE=read-only` cannot be overridden

### Data Flow
```
CLI --agent-env NAME
→ CLI validates NAME, reads VALUE from current shell os.LookupEnv()
→ CLI sends NAME→VALUE map via local Unix-socket IPC (IpcRequest.AgentEnv)
→ Daemon validates reserved names, passes to harness.AdapterOptions.AgentEnv
→ ACPAdapter.EnsureSession() merges via BuildHarnessEnvironment()
→ Harness subprocess receives the value
```

`runtime.Options.AgentEnv` was removed (review #6): `AdapterOptions.AgentEnv` is the sole owner of per-resident Harness launch material.

### Works With Both Launchers
- Built-in (`--agent codex`, `--agent opencode`, etc.)
- Custom trusted (`--agent-command ./my-acp-wrapper`)

## Testing

All checks pass in the local CI-equivalent environment:

```
gofmt check                                  ✅
go vet ./...                                 ✅
go test ./... -count=1 -timeout 300s         ✅ (all packages pass)
go build ./cmd/free4chat-agent               ✅
git diff --check                             ✅
```

### New Regression Coverage
- **CLI parsing / current-shell resolution**: repeatable flag on all four entry paths; missing NAME fails locally before daemon contact; invalid names and `NAME=value` rejected; duplicate names deduplicated deterministically; count/size bounds enforced; bare `--agent-env` rejected
- **Reserved names beyond CLI**: direct daemon IPC with `CODEX_CONFIG` / `INITIAL_AGENT_MODE` / `FREE4CHAT_*` in `AgentEnv` is rejected name-only and creates no resident; ordinary operator variables pass
- **Harness environment precedence**: explicit env reaches the fake ACP subprocess; unrelated ambient secrets stay filtered; launcher-owned policy wins over operator-inherited values; forbidden explicit names are dropped and cannot override policy
- **Meaningful stale-daemon regression**: `OPENAI_API_KEY` seeded in the daemon ambient environment with an old value is overridden in the Harness subprocess by the explicitly transferred new value
- **Secret non-persistence**: with a sentinel secret in `AgentEnv`, the join response, daemon status, bounded daemon logs, and resident workspace files never contain the value — while the fake Harness subprocess proves the value did reach it

### Test Infrastructure Notes
- Tests wait for the actual `join`/`create` operation via a helper instead of hard-coding preflight ordering (`join` = daemon-info/version handshake; `create` = EnsureDaemon/status)

## Files Changed
- `agent/internal/cli/cli.go` — `--agent-env` parsing, validation, name-only errors, missing-NAME rejection
- `agent/internal/cli/cli_test.go` — CLI regression tests + op-focused fake-daemon helper
- `agent/internal/daemon/ipc.go` — `AgentEnv` field on `IpcRequest`
- `agent/internal/daemon/daemon.go` — IPC-boundary reserved-name validation; pass `AgentEnv` to adapter only
- `agent/internal/daemon/daemon_test.go` — direct-IPC forbidden-name, stale-daemon, and secret non-persistence tests
- `agent/internal/harness/env.go` — `ForbiddenExplicitEnv` / `ValidateExplicitEnv`; defense-in-depth drop layer in `BuildHarnessEnvironment`
- `agent/internal/harness/acp.go` — `AdapterOptions.AgentEnv` flows into `BuildHarnessEnvironment`
- `agent/internal/harness/acp_test.go` — harness env precedence + ACP-subprocess regressions
- `agent/internal/harness/testdata/fakeagent/main.go` — `FAKE_ENV_NAME` echo mode for env regressions
- `agent/internal/runtime/runtime.go` — removed redundant `Options.AgentEnv`

## Release Sequencing (Per #276)
This PR implements the feature only. The live `/agent.md` bootstrap contract will be updated in a **separate activation/docs PR** after:
1. Implementation PR merged
2. Version/release PR
3. Native GitHub Release published
4. Activation PR updates live `/agent.md` to teach setup-agent self-repair

**Refs #276** (not "Fixes" — release sequencing required)
