### PR TITLE
chore(agent): bump runtime version to 0.5.22

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.21"
+var Version = "0.5.22"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Source-version step of the Free4Chat Agent Runtime release

- Advances `agent/internal/doctor/doctor.go` `Version` to **0.5.22** (next unused version above the current live 0.5.21).
- No `app/public/agent.md` / `app/public/llms-full.txt` / `app/src/common/agentInvite.ts` changes: the live bootstrap stays pinned to the verified 0.5.21 native Release until the 0.5.22 Release artifacts are published and verified (release skill phase 3).

## Validation run locally
```
cd agent
go test ./...                    ✅
go vet ./...                     ✅
go build ./cmd/free4chat-agent   ✅
bash scripts/test-install-agent.sh         ✅ 19/19
bash scripts/test-bootstrap-contract.sh    ✅
git diff --check                 ✅
```

Release branch: `codex/release-agent-0.5.22`

Refs #276