### PR TITLE
perf(room): keep longer multi-participant timelines responsive

### DIFF
--- a/app/src/common/messageReconciliation.test.ts
+++ b/app/src/common/messageReconciliation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { reconcileCanonicalRoomMessages } from "./messageReconciliation"
+import type { Message } from "./types"
+
+function message(
+  messageId: string | undefined,
+  sequence: number | undefined,
+  text: string
+): Message {
+  return {
+    peerId: "agent-a",
+    name: "Agent A",
+    kind: "agent",
+    type: "text",
+    messageId,
+    sequence,
+    text,
+  }
+}
+
+describe("reconcileCanonicalRoomMessages", () => {
+  it("reuses stable messageId or sequence identities across fresh snapshots", () => {
+    const byId = message("message-1", 1, "one")
+    const bySequence = message(undefined, 2, "two")
+    const previous = [byId, bySequence]
+    const next = [
+      { ...byId },
+      { ...bySequence },
+      message("message-3", 3, "three"),
+    ]
+
+    const reconciled = reconcileCanonicalRoomMessages(previous, next)
+
+    expect(reconciled).toEqual(next)
+    expect(reconciled[0]).toBe(byId)
+    expect(reconciled[1]).toBe(bySequence)
+    expect(reconciled[2]).toBe(next[2])
+  })
+
+  it("does not reuse an object when messageId and sequence collide", () => {
+    const previousById = message("message-1", 1, "one")
+    const previousBySequence = message("message-2", 2, "two")
+    const next = message("message-1", 2, "conflicting snapshot")
+
+    const [reconciled] = reconcileCanonicalRoomMessages(
+      [previousById, previousBySequence],
+      [next]
+    )
+
+    expect(reconciled).toBe(next)
+
+    const changedId = message("message-3", 2, "different canonical message")
+    const [notReconciled] = reconcileCanonicalRoomMessages(
+      [previousBySequence],
+      [changedId]
+    )
+    expect(notReconciled).toBe(changedId)
+  })
+})

--- a/app/src/common/messageReconciliation.ts
+++ b/app/src/common/messageReconciliation.ts
@@ -1,5 +1,70 @@
 import type { Message } from "./types"
 
+function isCanonicalSequence(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+}
+
+function hasSameCanonicalIdentity(previous: Message, next: Message): boolean {
+  if (
+    previous.messageId &&
+    next.messageId &&
+    previous.messageId !== next.messageId
+  )
+    return false
+  if (
+    isCanonicalSequence(previous.sequence) &&
+    isCanonicalSequence(next.sequence) &&
+    previous.sequence !== next.sequence
+  )
+    return false
+  return true
+}
+
+/**
+ * Reuse objects for canonical Room messages that are present in both
+ * snapshots. Room messages are append-only and their messageId/sequence
+ * identity is server-assigned, so a full state refresh can preserve React
+ * row identity without a brittle field-by-field comparison.
+ */
+export function reconcileCanonicalRoomMessages(
+  previousMessages: readonly Message[],
+  nextMessages: readonly Message[]
+): Message[] {
+  const previousById = new Map<string, Message>()
+  const previousBySequence = new Map<number, Message>()
+
+  for (const message of previousMessages) {
+    if (message.messageId) previousById.set(message.messageId, message)
+    if (isCanonicalSequence(message.sequence))
+      previousBySequence.set(message.sequence, message)
+  }
+
+  return nextMessages.map((nextMessage) => {
+    const byId = nextMessage.messageId
+      ? previousById.get(nextMessage.messageId)
+      : undefined
+    const bySequence = isCanonicalSequence(nextMessage.sequence)
+      ? previousBySequence.get(nextMessage.sequence)
+      : undefined
+
+    // If both identities are available, require them to agree before
+    // reusing an object. This keeps a malformed/colliding snapshot safe.
+    if (
+      byId &&
+      hasSameCanonicalIdentity(byId, nextMessage) &&
+      (!bySequence || byId === bySequence)
+    )
+      return byId
+    if (
+      bySequence &&
+      !byId &&
+      hasSameCanonicalIdentity(bySequence, nextMessage)
+    )
+      return bySequence
+    return nextMessage
+  })
+}
+
 /**
  * RoomState is authoritative for text/actions, while file messages are
  * intentionally session-local DataChannel messages. Keep both sources in

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -10,7 +10,6 @@ import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
-import type { UserInfo } from "../common/types"
 import {
   umamiEvent,
   trackAnalyticsEvent,
@@ -21,6 +20,7 @@ import { useSfuChatRoom } from "../hooks/useSfuChatRoom"
 import { useTurnstile } from "../hooks/useTurnstile"
 
 const REACTION_EMOJIS = ["👍", "😂", "🔥", "❓"]
+const MAX_FILE_SIZE = 20 * 1024 * 1024
 
 function ScreenShareViewer({
   stream,
@@ -158,14 +158,15 @@ export default function RoomContent({
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
-  const toggleAgentVoice = (participant: UserInfo) => {
-    if (!participant.voiceAvailable) return
-    const enabled = !participant.voiceEnabled
-    setAgentVoice(participant.peerId, enabled)
-    trackAnalyticsEvent(enabled ? "AgentVoiceStarted" : "AgentVoiceStopped", {
-      roomType: resolvedRoomType,
-    })
-  }
+  const toggleAgentVoice = useCallback(
+    (participantId: string, enabled: boolean) => {
+      setAgentVoice(participantId, enabled)
+      trackAnalyticsEvent(enabled ? "AgentVoiceStarted" : "AgentVoiceStopped", {
+        roomType: resolvedRoomType,
+      })
+    },
+    [resolvedRoomType, setAgentVoice]
+  )
   const handleStartLiveTranscript = (runtimeHostId: string) => {
     startLiveTranscript(runtimeHostId)
     trackAnalyticsEvent("LiveTranscriptStarted", {
@@ -303,69 +304,79 @@ export default function RoomContent({
   }, [messages, spawnReaction])
 
   const hasSentTextRef = useRef(false)
-  const wrappedSendText = (text: string, targets: string[] = []) => {
-    if (!hasSentTextRef.current) {
-      hasSentTextRef.current = true
-      umamiEvent("ChatActivity", { type: "text", roomHash: hashRoom(roomName) })
-    }
-    sendTextMessage(text, targets)
-  }
+  const wrappedSendText = useCallback(
+    (text: string, targets: string[] = []) => {
+      if (!hasSentTextRef.current) {
+        hasSentTextRef.current = true
+        umamiEvent("ChatActivity", {
+          type: "text",
+          roomHash: hashRoom(roomName),
+        })
+      }
+      sendTextMessage(text, targets)
+    },
+    [roomName, sendTextMessage]
+  )
 
-  const MAX_FILE_SIZE = 20 * 1024 * 1024
+  const sendReaction = useCallback(
+    (emoji: string) => {
+      sendActionMessage("reaction", { emoji, ts: Date.now().toString() })
+    },
+    [sendActionMessage]
+  )
 
-  const sendReaction = (emoji: string) => {
-    sendActionMessage("reaction", { emoji, ts: Date.now().toString() })
-  }
-
-  const wrappedSendFile = async (file: File) => {
-    const id = `${Date.now()}-${file.name}`
-    if (file.size > MAX_FILE_SIZE) {
+  const wrappedSendFile = useCallback(
+    async (file: File) => {
+      const id = `${Date.now()}-${file.name}`
+      if (file.size > MAX_FILE_SIZE) {
+        setPendingFiles((prev) => [
+          ...prev,
+          {
+            id,
+            fileName: file.name,
+            isImage: file.type.startsWith("image/"),
+            error: true,
+            errorMessage: `File too large (max 20 MB)`,
+          },
+        ])
+        setTimeout(
+          () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
+          3000
+        )
+        return
+      }
+      umamiEvent("ChatActivity", {
+        type: file.type.startsWith("image/") ? "image" : "file",
+        roomHash: hashRoom(roomName),
+      })
       setPendingFiles((prev) => [
         ...prev,
-        {
-          id,
-          fileName: file.name,
-          isImage: file.type.startsWith("image/"),
-          error: true,
-          errorMessage: `File too large (max 20 MB)`,
-        },
+        { id, fileName: file.name, isImage: file.type.startsWith("image/") },
       ])
-      setTimeout(
-        () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
-        3000
-      )
-      return
-    }
-    umamiEvent("ChatActivity", {
-      type: file.type.startsWith("image/") ? "image" : "file",
-      roomHash: hashRoom(roomName),
-    })
-    setPendingFiles((prev) => [
-      ...prev,
-      { id, fileName: file.name, isImage: file.type.startsWith("image/") },
-    ])
-    try {
-      await sendFileMessage(file)
-    } catch {
-      setPendingFiles((prev) =>
-        prev.map((f) =>
-          f.id === id
-            ? { ...f, error: true, errorMessage: "Failed to send" }
-            : f
+      try {
+        await sendFileMessage(file)
+      } catch {
+        setPendingFiles((prev) =>
+          prev.map((f) =>
+            f.id === id
+              ? { ...f, error: true, errorMessage: "Failed to send" }
+              : f
+          )
         )
-      )
-      setTimeout(
-        () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
-        3000
-      )
-      return
-    }
-    setPendingFiles((prev) => prev.filter((f) => f.id !== id))
-  }
+        setTimeout(
+          () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
+          3000
+        )
+        return
+      }
+      setPendingFiles((prev) => prev.filter((f) => f.id !== id))
+    },
+    [roomName, sendFileMessage]
+  )
 
   const selfScreenShareRef = useRef(false)
   const [screenShareWarning, setScreenShareWarning] = useState("")
-  const wrappedToggleScreenShare = () => {
+  const wrappedToggleScreenShare = useCallback(() => {
     const isCurrentlySharing = participants.find(
       (p) => p.peerId === LOCAL_PEER_ID
     )?.screenShareEnabled
@@ -385,7 +396,24 @@ export default function RoomContent({
       roomHash: hashRoom(roomName),
     })
     toggleScreenShare()
-  }
+  }, [participants, roomName, toggleScreenShare])
+
+  const handleCollabRespond = useCallback(
+    (requestId: string, decision: "accepted" | "declined") => {
+      sendCollabResponse(requestId, decision)
+    },
+    [sendCollabResponse]
+  )
+  const handleReadArtifact = useCallback(
+    (attachmentId: string) => readRoomAttachment(attachmentId),
+    [readRoomAttachment]
+  )
+  const handleCollabResult = useCallback(
+    (requestId: string, status: "completed" | "failed", summary: string) => {
+      sendCollabResult(requestId, status, summary)
+    },
+    [sendCollabResult]
+  )
 
   const copyRoomLink = () => {
     if (typeof window !== "undefined") {
@@ -676,7 +704,7 @@ export default function RoomContent({
                           p.voiceAvailable && agentVoiceMediaAvailable
                         }
                         voiceEnabled={p.voiceEnabled}
-                        onToggleAgentVoice={() => toggleAgentVoice(p)}
+                        onToggleAgentVoice={toggleAgentVoice}
                         className="w-[84px]"
                         compact
                       />
@@ -706,7 +734,7 @@ export default function RoomContent({
                         p.voiceAvailable && agentVoiceMediaAvailable
                       }
                       voiceEnabled={p.voiceEnabled}
-                      onToggleAgentVoice={() => toggleAgentVoice(p)}
+                      onToggleAgentVoice={toggleAgentVoice}
                       screenshareAllowed={screenshareAllowed}
                       className="w-40 flex-none"
                     />
@@ -761,13 +789,9 @@ export default function RoomContent({
             onSendFile={wrappedSendFile}
             onSendAction={sendActionMessage}
             localParticipantId={getLocalRoomAuth()?.participantId}
-            onCollabRespond={(requestId, decision) => {
-              sendCollabResponse(requestId, decision)
-            }}
-            onReadArtifact={(attachmentId) => readRoomAttachment(attachmentId)}
-            onCollabResult={(requestId, status, summary) => {
-              sendCollabResult(requestId, status, summary)
-            }}
+            onCollabRespond={handleCollabRespond}
+            onReadArtifact={handleReadArtifact}
+            onCollabResult={handleCollabResult}
           />
         </div>
       </div>

--- a/app/src/components/TextChatCard.performance.test.tsx
+++ b/app/src/components/TextChatCard.performance.test.tsx
@@ -1,0 +1,168 @@
+import { act, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { Message, UserInfo } from "@common/types"
+
+const markdownRenderCount = vi.hoisted(() => ({ value: 0 }))
+
+// Keep this fixture focused on render counts rather than Markdown parser
+// details. The existing composer and Markdown behavior suites cover those
+// semantics separately.
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => {
+    markdownRenderCount.value += 1
+    return <div data-testid="markdown-row">{children}</div>
+  },
+}))
+
+vi.mock("./ParticipantAvatar", () => ({
+  default: ({ name }: { name: string }) => (
+    <span data-testid="avatar">{name}</span>
+  ),
+}))
+
+import TextChatCard from "./TextChatCard"
+import type { RoomAttachmentProjection } from "../room/types"
+
+const PARTICIPANTS: UserInfo[] = [
+  {
+    peerId: "agent-a",
+    name: "Agent A",
+    kind: "agent",
+    room: "room-perf-test",
+  },
+  {
+    peerId: "agent-b",
+    name: "Agent B",
+    kind: "agent",
+    room: "room-perf-test",
+  },
+]
+
+function textMessage(sequence: number): Message {
+  return {
+    peerId: sequence % 2 === 0 ? "agent-a" : "agent-b",
+    name: sequence % 2 === 0 ? "Agent A" : "Agent B",
+    kind: "agent",
+    type: "text",
+    messageId: `message-${sequence}`,
+    sequence,
+    text: `## message-${sequence}\n\nA long synthetic Markdown reply with inline code and a list.`,
+  }
+}
+
+function renderCard(
+  messages: Message[],
+  attachments: RoomAttachmentProjection[] = []
+) {
+  return render(
+    <TextChatCard
+      room="room-perf-test"
+      nickName="Human A"
+      messages={messages}
+      attachments={attachments}
+      participants={PARTICIPANTS}
+      pendingFiles={[]}
+      onSendText={vi.fn()}
+      onSendFile={vi.fn()}
+      onSendAction={vi.fn()}
+    />
+  )
+}
+
+function typeMessage(composer: HTMLTextAreaElement, value: string) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, value)
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  markdownRenderCount.value = 0
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe("long timeline render isolation (#280)", () => {
+  it("does not re-render historical Markdown rows while typing", () => {
+    const messages = [textMessage(1), textMessage(2), textMessage(3)]
+    renderCard(messages)
+    expect(markdownRenderCount.value).toBe(messages.length)
+
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    typeMessage(composer, "h")
+    typeMessage(composer, "he")
+    typeMessage(composer, "hey")
+
+    expect(markdownRenderCount.value).toBe(messages.length)
+  })
+
+  it("only renders the appended Markdown row when one message arrives", () => {
+    const firstMessages = [textMessage(1), textMessage(2)]
+    const attachments: RoomAttachmentProjection[] = []
+    const onSendText = vi.fn()
+    const onSendFile = vi.fn()
+    const onSendAction = vi.fn()
+    const view = render(
+      <TextChatCard
+        room="room-perf-test"
+        nickName="Human A"
+        messages={firstMessages}
+        attachments={attachments}
+        participants={PARTICIPANTS}
+        pendingFiles={[]}
+        onSendText={onSendText}
+        onSendFile={onSendFile}
+        onSendAction={onSendAction}
+      />
+    )
+    expect(markdownRenderCount.value).toBe(2)
+
+    view.rerender(
+      <TextChatCard
+        room="room-perf-test"
+        nickName="Human A"
+        messages={[...firstMessages, textMessage(3)]}
+        attachments={attachments}
+        participants={PARTICIPANTS}
+        pendingFiles={[]}
+        onSendText={onSendText}
+        onSendFile={onSendFile}
+        onSendAction={onSendAction}
+      />
+    )
+
+    expect(markdownRenderCount.value).toBe(3)
+  })
+
+  it("renders a few hundred mixed synthetic entries with the same visible rows", () => {
+    const messages = Array.from({ length: 260 }, (_, index) =>
+      textMessage(index + 1)
+    )
+    const attachments: RoomAttachmentProjection[] = Array.from(
+      { length: 20 },
+      (_, index) => ({
+        id: `attachment-${index}`,
+        senderId: "agent-a",
+        senderName: "Agent A",
+        senderKind: "agent" as const,
+        fileName: `artifact-${index}.txt`,
+        mimeType: "text/plain",
+        size: 128,
+        sequence: 261 + index,
+        createdAt: 1000 + index,
+      })
+    )
+
+    renderCard(messages, attachments)
+
+    expect(markdownRenderCount.value).toBe(messages.length)
+    expect(screen.getByText("artifact-19.txt")).toBeInTheDocument()
+    expect(screen.getByText(/message-260/)).toBeInTheDocument()
+  })
+})

--- a/app/src/components/TextChatCard.performance.test.tsx
+++ b/app/src/components/TextChatCard.performance.test.tsx
@@ -1,9 +1,11 @@
 import { act, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { reconcileCanonicalRoomMessages } from "@common/messageReconciliation"
 import type { Message, UserInfo } from "@common/types"
 
 const markdownRenderCount = vi.hoisted(() => ({ value: 0 }))
+const historicalRowRenderCount = vi.hoisted(() => ({ value: 0 }))
 
 // Keep this fixture focused on render counts rather than Markdown parser
 // details. The existing composer and Markdown behavior suites cover those
@@ -16,9 +18,10 @@ vi.mock("react-markdown", () => ({
 }))
 
 vi.mock("./ParticipantAvatar", () => ({
-  default: ({ name }: { name: string }) => (
-    <span data-testid="avatar">{name}</span>
-  ),
+  default: ({ name }: { name: string }) => {
+    historicalRowRenderCount.value += 1
+    return <span data-testid="avatar">{name}</span>
+  },
 }))
 
 import TextChatCard from "./TextChatCard"
@@ -83,14 +86,18 @@ function typeMessage(composer: HTMLTextAreaElement, value: string) {
 
 beforeEach(() => {
   markdownRenderCount.value = 0
+  historicalRowRenderCount.value = 0
   Element.prototype.scrollIntoView = vi.fn()
 })
 
 describe("long timeline render isolation (#280)", () => {
   it("does not re-render historical Markdown rows while typing", () => {
-    const messages = [textMessage(1), textMessage(2), textMessage(3)]
+    const messages = Array.from({ length: 120 }, (_, index) =>
+      textMessage(index + 1)
+    )
     renderCard(messages)
     expect(markdownRenderCount.value).toBe(messages.length)
+    expect(historicalRowRenderCount.value).toBe(messages.length)
 
     const composer = screen.getByLabelText(
       "Message the room or @ an Agent"
@@ -100,10 +107,67 @@ describe("long timeline render isolation (#280)", () => {
     typeMessage(composer, "hey")
 
     expect(markdownRenderCount.value).toBe(messages.length)
+    expect(historicalRowRenderCount.value).toBe(messages.length)
   })
 
-  it("only renders the appended Markdown row when one message arrives", () => {
-    const firstMessages = [textMessage(1), textMessage(2)]
+  it("does not re-render historical rows across a fresh muted Room state", () => {
+    const messages = Array.from({ length: 120 }, (_, index) =>
+      textMessage(index + 1)
+    )
+    const onSendText = vi.fn()
+    const onSendFile = vi.fn()
+    const onSendAction = vi.fn()
+    const view = render(
+      <TextChatCard
+        room="room-perf-test"
+        nickName="Human A"
+        messages={messages}
+        participants={PARTICIPANTS}
+        pendingFiles={[]}
+        onSendText={onSendText}
+        onSendFile={onSendFile}
+        onSendAction={onSendAction}
+      />
+    )
+    expect(historicalRowRenderCount.value).toBe(messages.length)
+
+    const freshServerSnapshot = messages.map((message) => ({ ...message }))
+    const reconciledMessages = reconcileCanonicalRoomMessages(
+      messages,
+      freshServerSnapshot
+    )
+    expect(reconciledMessages).toEqual(freshServerSnapshot)
+    expect(
+      reconciledMessages.every((message, index) => message === messages[index])
+    ).toBe(true)
+
+    // This models applyRoomState after a participant mute update: participant
+    // projections and the server message objects are fresh, but reconciliation
+    // supplies the existing canonical Message references to the timeline.
+    const mutedParticipants = PARTICIPANTS.map((participant, index) => ({
+      ...participant,
+      muteState: index === 0,
+    }))
+    view.rerender(
+      <TextChatCard
+        room="room-perf-test"
+        nickName="Human A"
+        messages={reconciledMessages}
+        participants={mutedParticipants}
+        pendingFiles={[]}
+        onSendText={onSendText}
+        onSendFile={onSendFile}
+        onSendAction={onSendAction}
+      />
+    )
+
+    expect(historicalRowRenderCount.value).toBe(messages.length)
+  })
+
+  it("only renders the new historical row when one message arrives", () => {
+    const firstMessages = Array.from({ length: 120 }, (_, index) =>
+      textMessage(index + 1)
+    )
     const attachments: RoomAttachmentProjection[] = []
     const onSendText = vi.fn()
     const onSendFile = vi.fn()
@@ -121,7 +185,8 @@ describe("long timeline render isolation (#280)", () => {
         onSendAction={onSendAction}
       />
     )
-    expect(markdownRenderCount.value).toBe(2)
+    expect(markdownRenderCount.value).toBe(firstMessages.length)
+    expect(historicalRowRenderCount.value).toBe(firstMessages.length)
 
     view.rerender(
       <TextChatCard
@@ -137,7 +202,8 @@ describe("long timeline render isolation (#280)", () => {
       />
     )
 
-    expect(markdownRenderCount.value).toBe(3)
+    expect(markdownRenderCount.value).toBe(firstMessages.length + 1)
+    expect(historicalRowRenderCount.value).toBe(firstMessages.length + 1)
   })
 
   it("renders a few hundred mixed synthetic entries with the same visible rows", () => {

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useRef, useEffect, memo } from "react"
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+  memo,
+} from "react"
 
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -10,9 +17,8 @@ import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
 import CollabArtifactViewer from "./CollabArtifactViewer"
 import {
-  hasCollabTerminalResult,
-  isCollabRequestAccepted,
-  isCollabRequestAnswered,
+  buildCollabLifecycleIndex,
+  type CollabLifecycleProjection,
 } from "./collabUi"
 import HumanCollabResultComposer from "./HumanCollabResultComposer"
 import ParticipantAvatar from "./ParticipantAvatar"
@@ -30,6 +36,11 @@ interface PendingFile {
   error?: boolean
   errorMessage?: string
 }
+
+const EMPTY_ATTACHMENTS: RoomAttachmentProjection[] = []
+const EMPTY_MESSAGES: Message[] = []
+const EMPTY_PENDING_FILES: PendingFile[] = []
+const NOOP_PREVIEW = () => undefined
 
 interface TextChatCardProps {
   room: string
@@ -351,13 +362,13 @@ function getOrCreateWhiteboardUrl(room: string): string {
 function PollCard({
   msg,
   isSelf,
-  allMessages,
+  votes,
   myPeerId,
   onVote,
 }: {
   msg: Message
   isSelf: boolean
-  allMessages: Message[]
+  votes: Message[]
   myPeerId: string
   onVote: (pollId: string, option: string) => void
 }) {
@@ -365,12 +376,6 @@ function PollCard({
   const question = msg.actionPayload?.question ?? ""
   const options = (msg.actionPayload?.options ?? "").split("||")
 
-  const votes = allMessages.filter(
-    (m) =>
-      m.type === "action" &&
-      m.actionType === "vote" &&
-      m.actionPayload?.pollId === pollId
-  )
   const myVote = votes.find((v) => v.peerId === myPeerId)?.actionPayload?.option
 
   const containerClass = isSelf
@@ -463,9 +468,10 @@ function GameCard({ msg, isSelf }: { msg: Message; isSelf: boolean }) {
 function ActionCard({
   msg,
   isSelf,
-  allMessages,
+  pollVotes,
   myPeerId,
   onVote,
+  collabLifecycle,
   localParticipantId,
   onCollabRespond,
   onViewArtifact,
@@ -474,9 +480,10 @@ function ActionCard({
 }: {
   msg: Message
   isSelf: boolean
-  allMessages: Message[]
+  pollVotes: Message[]
   myPeerId: string
   onVote: (pollId: string, option: string) => void
+  collabLifecycle?: CollabLifecycleProjection
   localParticipantId?: string
   onCollabRespond?: (
     requestId: string,
@@ -497,16 +504,12 @@ function ActionCard({
 
   if (msg.actionType === "collab" && msg.collab) {
     const collab = msg.collab
-    // #115: lifecycle-derived answered state — the message log IS the
-    // record. A later accepted/declined for the same requestId means the
-    // decision is made; never keep authoritative state in React.
-    const answered = isCollabRequestAnswered(allMessages, collab.requestId)
-    const accepted = isCollabRequestAccepted(allMessages, collab.requestId)
-    const terminal = hasCollabTerminalResult(allMessages, collab.requestId)
-    const declinedPresent = allMessages.some(
-      (m) =>
-        m.collab?.requestId === collab.requestId && m.collab.kind === "declined"
-    )
+    // #115/#280: lifecycle is projected once from the canonical message log;
+    // an individual card never rescans all messages.
+    const answered = collabLifecycle?.answered ?? false
+    const accepted = collabLifecycle?.accepted ?? false
+    const terminal = collabLifecycle?.terminal ?? false
+    const declinedPresent = collabLifecycle?.declined ?? false
     // #121: terminal controls appear ONLY when THIS Human is the target,
     // the request came from someone else, it was ACCEPTED, and no terminal
     // result exists yet — lifecycle derived from canonical messages.
@@ -669,7 +672,7 @@ function ActionCard({
       <PollCard
         msg={msg}
         isSelf={isSelf}
-        allMessages={allMessages}
+        votes={pollVotes}
         myPeerId={myPeerId}
         onVote={onVote}
       />
@@ -775,6 +778,384 @@ function FileMessageBubble({ msg, isSelf }: { msg: Message; isSelf: boolean }) {
     </div>
   )
 }
+
+interface TimelineMessageRowProps {
+  message: Message
+  isSelf: boolean
+  recipientCues: RecipientCue[]
+  pollVotes: Message[]
+  collabLifecycle?: CollabLifecycleProjection
+  onVote: (pollId: string, option: string) => void
+  localParticipantId?: string
+  onCollabRespond?: (
+    requestId: string,
+    decision: "accepted" | "declined"
+  ) => void
+  onViewArtifact?: (attachmentId: string) => void
+  onCollabResult?: (
+    requestId: string,
+    status: "completed" | "failed",
+    summary: string
+  ) => void
+  onOpenResultComposer: (target: {
+    requestId: string
+    status: "completed" | "failed"
+  }) => void
+}
+
+function sameRecipientCues(
+  left: RecipientCue[],
+  right: RecipientCue[]
+): boolean {
+  if (left.length !== right.length) return false
+  return left.every(
+    (cue, index) =>
+      cue.label === right[index]?.label && cue.isName === right[index]?.isName
+  )
+}
+
+function sameMessages(left: Message[], right: Message[]): boolean {
+  if (left.length !== right.length) return false
+  return left.every((message, index) => message === right[index])
+}
+
+function sameCollabLifecycle(
+  left: CollabLifecycleProjection | undefined,
+  right: CollabLifecycleProjection | undefined
+): boolean {
+  return (
+    left?.answered === right?.answered &&
+    left?.accepted === right?.accepted &&
+    left?.declined === right?.declined &&
+    left?.terminal === right?.terminal
+  )
+}
+
+const TimelineMessageRow = memo(
+  function TimelineMessageRow({
+    message,
+    isSelf,
+    recipientCues,
+    pollVotes,
+    collabLifecycle,
+    onVote,
+    localParticipantId,
+    onCollabRespond,
+    onViewArtifact,
+    onCollabResult,
+    onOpenResultComposer,
+  }: TimelineMessageRowProps) {
+    if (message.type === "action" && message.actionType === "reaction")
+      return null
+
+    return (
+      <div
+        className={`mb-4 flex w-full items-end ${
+          isSelf ? "flex-row-reverse" : "flex-row"
+        }`}
+      >
+        <div className={`flex-shrink-0 ${isSelf ? "ml-2" : "mr-2"}`}>
+          <ParticipantAvatar
+            name={message.name}
+            size="compact"
+            className="text-chat-avatar"
+          />
+        </div>
+        <div className="min-w-0 flex-1">
+          {!isSelf && (
+            <p className="mb-1 ml-1 text-xs text-gray-400">
+              {message.name}
+              {message.kind === "agent" && (
+                <span className="ml-1 text-[10px] text-blue-300">🤖 Agent</span>
+              )}
+            </p>
+          )}
+          {message.type === "text" ? (
+            <div
+              className={
+                isSelf
+                  ? "ml-auto w-fit max-w-[88%] rounded-2xl rounded-br-md bg-blue-600 px-4 py-2.5 text-white"
+                  : "w-fit max-w-full rounded-2xl rounded-tl-md border border-white/10 bg-gray-800/80 px-4 py-2.5 text-gray-100"
+              }
+            >
+              {recipientCues.length > 0 && (
+                <p className="mb-1 flex flex-wrap items-center gap-x-1 text-[11px] font-medium text-white/75">
+                  <span>→</span>
+                  {recipientCues.map((cue, index) => (
+                    <span key={index}>
+                      {cue.isName ? `@${cue.label}` : cue.label}
+                    </span>
+                  ))}
+                </p>
+              )}
+              <MessageMarkdown text={message.text ?? ""} />
+            </div>
+          ) : message.type === "action" ? (
+            <ActionCard
+              msg={message}
+              isSelf={isSelf}
+              pollVotes={pollVotes}
+              myPeerId={LOCAL_PEER_ID}
+              onVote={onVote}
+              collabLifecycle={collabLifecycle}
+              localParticipantId={localParticipantId}
+              onCollabRespond={onCollabRespond}
+              onViewArtifact={onViewArtifact}
+              onCollabResult={onCollabResult}
+              onOpenResultComposer={onOpenResultComposer}
+            />
+          ) : (
+            <FileMessageBubble msg={message} isSelf={isSelf} />
+          )}
+        </div>
+      </div>
+    )
+  },
+  (left, right) => {
+    return (
+      left.message === right.message &&
+      left.isSelf === right.isSelf &&
+      sameRecipientCues(left.recipientCues, right.recipientCues) &&
+      sameMessages(left.pollVotes, right.pollVotes) &&
+      sameCollabLifecycle(left.collabLifecycle, right.collabLifecycle) &&
+      left.onVote === right.onVote &&
+      left.localParticipantId === right.localParticipantId &&
+      left.onCollabRespond === right.onCollabRespond &&
+      left.onViewArtifact === right.onViewArtifact &&
+      left.onCollabResult === right.onCollabResult &&
+      left.onOpenResultComposer === right.onOpenResultComposer
+    )
+  }
+)
+
+const TimelineAttachmentRow = memo(function TimelineAttachmentRow({
+  attachment,
+  onPreview,
+}: {
+  attachment: RoomAttachmentProjection
+  onPreview: (attachmentId: string) => void
+}) {
+  return (
+    <div className="mb-4 flex w-full items-end">
+      <div className="mr-2 flex-shrink-0">
+        <ParticipantAvatar
+          name={attachment.senderName}
+          size="compact"
+          className="text-chat-avatar"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="mb-1 ml-1 text-xs text-gray-400">
+          {attachment.senderName}
+          <span className="ml-1 text-[10px] text-blue-300">🤖 Agent</span>
+        </p>
+        <AgentAttachmentCard attachment={attachment} onPreview={onPreview} />
+      </div>
+    </div>
+  )
+})
+
+function timelineItemKey(item: TimelineItem): string {
+  if (item.type === "attachment") return `attachment:${item.attachment!.id}`
+  const message = item.message!
+  if (message.messageId) return `message:${message.messageId}`
+  if (Number.isFinite(item.seq)) return `message:sequence:${item.seq}`
+  return `message:ephemeral:${message.peerId}:${message.createdAt ?? "unknown"}`
+}
+
+function buildPollVoteIndex(messages: Message[]): Map<string, Message[]> {
+  const index = new Map<string, Message[]>()
+  for (const message of messages) {
+    if (message.type !== "action" || message.actionType !== "vote") continue
+    const pollId = message.actionPayload?.pollId
+    if (!pollId) continue
+    const votes = index.get(pollId)
+    if (votes) votes.push(message)
+    else index.set(pollId, [message])
+  }
+  return index
+}
+
+interface RoomTimelineProps {
+  messages: Message[]
+  attachments: RoomAttachmentProjection[]
+  participants: UserInfo[]
+  pendingFiles: PendingFile[]
+  nickName: string
+  localParticipantId?: string
+  onVote: (pollId: string, option: string) => void
+  onCollabRespond?: (
+    requestId: string,
+    decision: "accepted" | "declined"
+  ) => void
+  onViewArtifact?: (attachmentId: string) => void
+  onCollabResult?: (
+    requestId: string,
+    status: "completed" | "failed",
+    summary: string
+  ) => void
+  onOpenResultComposer: (target: {
+    requestId: string
+    status: "completed" | "failed"
+  }) => void
+}
+
+const RoomTimeline = memo(function RoomTimeline({
+  messages,
+  attachments,
+  participants,
+  pendingFiles,
+  nickName,
+  localParticipantId,
+  onVote,
+  onCollabRespond,
+  onViewArtifact,
+  onCollabResult,
+  onOpenResultComposer,
+}: RoomTimelineProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages, pendingFiles])
+
+  const timeline = useMemo(
+    () => buildRoomTimeline(messages, attachments),
+    [messages, attachments]
+  )
+  const collabLifecycleIndex = useMemo(
+    () => buildCollabLifecycleIndex(messages),
+    [messages]
+  )
+  const pollVoteIndex = useMemo(() => buildPollVoteIndex(messages), [messages])
+  const timelineKeys = useMemo(() => {
+    const seen = new Map<string, number>()
+    return timeline.map((item) => {
+      const base = timelineItemKey(item)
+      const occurrence = seen.get(base) ?? 0
+      seen.set(base, occurrence + 1)
+      return occurrence === 0 ? base : `${base}:duplicate:${occurrence}`
+    })
+  }, [timeline])
+  const recipientCuesByMessage = useMemo(() => {
+    const result = new Map<Message, RecipientCue[]>()
+    for (const item of timeline) {
+      if (item.type === "message") {
+        const message = item.message!
+        result.set(message, messageRecipientCues(message, participants))
+      }
+    }
+    return result
+  }, [participants, timeline])
+
+  return (
+    <div className="scrollbar-thin flex-1 overflow-y-auto p-4 text-sm">
+      {messages.length === 0 && attachments.length === 0 && (
+        <p className="mt-4 text-center text-xs text-gray-500">
+          No messages yet
+        </p>
+      )}
+      {timeline.map((item, index) => {
+        const key = timelineKeys[index]
+        if (item.type === "attachment") {
+          return (
+            <TimelineAttachmentRow
+              key={key}
+              attachment={item.attachment!}
+              onPreview={onViewArtifact ?? NOOP_PREVIEW}
+            />
+          )
+        }
+
+        const message = item.message!
+        if (message.type === "action" && message.actionType === "reaction")
+          return null
+        const pollId = message.actionPayload?.pollId
+        return (
+          <TimelineMessageRow
+            key={key}
+            message={message}
+            isSelf={message.peerId === LOCAL_PEER_ID}
+            recipientCues={recipientCuesByMessage.get(message) ?? []}
+            pollVotes={
+              message.type === "action" &&
+              message.actionType === "poll" &&
+              pollId
+                ? pollVoteIndex.get(pollId) ?? EMPTY_MESSAGES
+                : EMPTY_MESSAGES
+            }
+            collabLifecycle={
+              message.collab
+                ? collabLifecycleIndex.get(message.collab.requestId)
+                : undefined
+            }
+            onVote={onVote}
+            localParticipantId={localParticipantId}
+            onCollabRespond={onCollabRespond}
+            onViewArtifact={onViewArtifact}
+            onCollabResult={onCollabResult}
+            onOpenResultComposer={onOpenResultComposer}
+          />
+        )
+      })}
+      {pendingFiles.map((file) => (
+        <div
+          key={file.id}
+          className="mb-4 flex w-full flex-row-reverse items-end"
+        >
+          <div className="ml-2 flex-shrink-0">
+            <ParticipantAvatar
+              name={nickName}
+              size="compact"
+              className="text-chat-avatar"
+            />
+          </div>
+          <div style={{ maxWidth: "72%" }}>
+            <div
+              className={`flex items-center gap-2 rounded-bl-3xl rounded-tl-3xl rounded-tr-xl px-4 py-3 ${
+                file.error ? "bg-red-700/60" : "bg-blue-600/60"
+              }`}
+            >
+              {file.error ? (
+                <span className="text-xs text-white/80">
+                  {file.errorMessage ?? "Failed to send"}
+                </span>
+              ) : (
+                <>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    className="h-4 w-4 animate-spin text-white/70"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                  <span className="max-w-[140px] truncate text-xs text-white/70">
+                    {file.fileName}
+                  </span>
+                  <span className="text-xs text-white/40">Sending…</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+      <div ref={messagesEndRef} />
+    </div>
+  )
+})
 
 function PollCreator({
   onSend,
@@ -890,13 +1271,13 @@ function GamesMenu({
   )
 }
 
-export default function TextChatCard({
+const TextChatCard = memo(function TextChatCard({
   room,
   nickName,
   messages,
-  attachments = [],
+  attachments = EMPTY_ATTACHMENTS,
   participants,
-  pendingFiles = [],
+  pendingFiles = EMPTY_PENDING_FILES,
   onSendText,
   onSendFile,
   onSendAction,
@@ -921,11 +1302,19 @@ export default function TextChatCard({
   const [pickerDismissed, setPickerDismissed] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const textRef = useRef<HTMLTextAreaElement>(null)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   const moreBtnRef = useRef<HTMLDivElement>(null)
   const moreMenuRef = useRef<HTMLDivElement>(null)
   const gamesMenuRef = useRef<HTMLDivElement>(null)
   const isComposingRef = useRef(false)
+  const handlePreviewArtifact = useCallback((attachmentId: string) => {
+    setArtifactId(attachmentId)
+  }, [])
+  const handleOpenResultComposer = useCallback(
+    (target: { requestId: string; status: "completed" | "failed" }) => {
+      setResultTarget(target)
+    },
+    []
+  )
   // Coarse pointers (touch) keep Enter as a newline so multiline editing
   // stays natural on mobile keyboards; sending uses the send button.
   const [isCoarsePointer] = useState<boolean>(() =>
@@ -933,10 +1322,6 @@ export default function TextChatCard({
       ? window.matchMedia("(pointer: coarse)").matches
       : false
   )
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages, pendingFiles])
 
   // Auto-grow the textarea with content up to a bounded height, then let it
   // scroll internally instead of consuming the whole Room.
@@ -1049,10 +1434,13 @@ export default function TextChatCard({
     onSendAction("game", { gameId })
   }
 
-  const handleVote = (pollId: string, option: string) => {
-    umamiEvent("ChatAction", { type: "vote", roomHash: hashRoom(room) })
-    onSendAction("vote", { pollId, option })
-  }
+  const handleVote = useCallback(
+    (pollId: string, option: string) => {
+      umamiEvent("ChatAction", { type: "vote", roomHash: hashRoom(room) })
+      onSendAction("vote", { pollId, option })
+    },
+    [onSendAction, room]
+  )
 
   const slashCommands = [
     {
@@ -1175,166 +1563,19 @@ export default function TextChatCard({
       .markdown-body hr { border-color: #374151; margin: 0.75rem 0; }
     `}</style>
       <div className="flex h-full flex-col overflow-hidden">
-        <div className="scrollbar-thin flex-1 overflow-y-auto p-4 text-sm">
-          {messages.length === 0 && attachments.length === 0 && (
-            <p className="mt-4 text-center text-xs text-gray-500">
-              No messages yet
-            </p>
-          )}
-          {buildRoomTimeline(messages, attachments).map((item, i) => {
-            if (item.type !== "message") {
-              const attachment = item.attachment!
-              return (
-                <div className="mb-4 flex w-full items-end" key={attachment.id}>
-                  <div className="mr-2 flex-shrink-0">
-                    <ParticipantAvatar
-                      name={attachment.senderName}
-                      size="compact"
-                      className="text-chat-avatar"
-                    />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="mb-1 ml-1 text-xs text-gray-400">
-                      {attachment.senderName}
-                      <span className="ml-1 text-[10px] text-blue-300">
-                        🤖 Agent
-                      </span>
-                    </p>
-                    <AgentAttachmentCard
-                      attachment={attachment}
-                      onPreview={(attachmentId) => setArtifactId(attachmentId)}
-                    />
-                  </div>
-                </div>
-              )
-            }
-            const p = item.message!
-            if (p.type === "action" && p.actionType === "reaction") return null
-            const isSelf = p.peerId === LOCAL_PEER_ID
-            const recipientCues = messageRecipientCues(p, participants)
-            return (
-              <div
-                className={`mb-4 flex w-full items-end ${
-                  isSelf ? "flex-row-reverse" : "flex-row"
-                }`}
-                key={i}
-              >
-                <div className={`flex-shrink-0 ${isSelf ? "ml-2" : "mr-2"}`}>
-                  <ParticipantAvatar
-                    name={p.name}
-                    size="compact"
-                    className="text-chat-avatar"
-                  />
-                </div>
-                <div className="min-w-0 flex-1">
-                  {!isSelf && (
-                    <p className="mb-1 ml-1 text-xs text-gray-400">
-                      {p.name}
-                      {p.kind === "agent" && (
-                        <span className="ml-1 text-[10px] text-blue-300">
-                          🤖 Agent
-                        </span>
-                      )}
-                    </p>
-                  )}
-                  {p.type === "text" ? (
-                    <div
-                      className={
-                        isSelf
-                          ? "ml-auto w-fit max-w-[88%] rounded-2xl rounded-br-md bg-blue-600 px-4 py-2.5 text-white"
-                          : "w-fit max-w-full rounded-2xl rounded-tl-md border border-white/10 bg-gray-800/80 px-4 py-2.5 text-gray-100"
-                      }
-                    >
-                      {recipientCues.length > 0 && (
-                        <p className="mb-1 flex flex-wrap items-center gap-x-1 text-[11px] font-medium text-white/75">
-                          <span>→</span>
-                          {recipientCues.map((cue, index) => (
-                            <span key={index}>
-                              {cue.isName ? `@${cue.label}` : cue.label}
-                            </span>
-                          ))}
-                        </p>
-                      )}
-                      <MessageMarkdown text={p.text ?? ""} />
-                    </div>
-                  ) : p.type === "action" ? (
-                    <ActionCard
-                      msg={p}
-                      isSelf={isSelf}
-                      allMessages={messages}
-                      myPeerId={LOCAL_PEER_ID}
-                      onVote={handleVote}
-                      localParticipantId={localParticipantId}
-                      onCollabRespond={onCollabRespond}
-                      onViewArtifact={(attachmentId) =>
-                        setArtifactId(attachmentId)
-                      }
-                      onCollabResult={onCollabResult}
-                      onOpenResultComposer={(target) => setResultTarget(target)}
-                    />
-                  ) : (
-                    <FileMessageBubble msg={p} isSelf={isSelf} />
-                  )}
-                </div>
-              </div>
-            )
-          })}
-          {pendingFiles.map((f) => (
-            <div
-              key={f.id}
-              className="mb-4 flex w-full flex-row-reverse items-end"
-            >
-              <div className="ml-2 flex-shrink-0">
-                <ParticipantAvatar
-                  name={nickName}
-                  size="compact"
-                  className="text-chat-avatar"
-                />
-              </div>
-              <div style={{ maxWidth: "72%" }}>
-                <div
-                  className={`flex items-center gap-2 rounded-bl-3xl rounded-tl-3xl rounded-tr-xl px-4 py-3 ${
-                    f.error ? "bg-red-700/60" : "bg-blue-600/60"
-                  }`}
-                >
-                  {f.error ? (
-                    <span className="text-xs text-white/80">
-                      {f.errorMessage ?? "Failed to send"}
-                    </span>
-                  ) : (
-                    <>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        className="h-4 w-4 animate-spin text-white/70"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                        />
-                      </svg>
-                      <span className="max-w-[140px] truncate text-xs text-white/70">
-                        {f.fileName}
-                      </span>
-                      <span className="text-xs text-white/40">Sending…</span>
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-          ))}
-          <div ref={messagesEndRef} />
-        </div>
+        <RoomTimeline
+          messages={messages}
+          attachments={attachments}
+          participants={participants}
+          pendingFiles={pendingFiles}
+          nickName={nickName}
+          localParticipantId={localParticipantId}
+          onVote={handleVote}
+          onCollabRespond={onCollabRespond}
+          onViewArtifact={handlePreviewArtifact}
+          onCollabResult={onCollabResult}
+          onOpenResultComposer={handleOpenResultComposer}
+        />
 
         {showPollCreator && (
           <PollCreator
@@ -1554,4 +1795,6 @@ export default function TextChatCard({
       )}
     </>
   )
-}
+})
+
+export default TextChatCard

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { memo, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
@@ -14,10 +14,10 @@ interface UserCardProps extends UserInfo {
   /** Room-wide publish authorization for this eligible Agent only. */
   voiceAvailable?: boolean
   voiceEnabled?: boolean
-  onToggleAgentVoice?: () => void
+  onToggleAgentVoice?: (peerId: string, enabled: boolean) => void
 }
 
-export default function UserCard(user: UserCardProps) {
+function UserCard(user: UserCardProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
   const [canScreenShare] = useState(() => {
@@ -99,7 +99,9 @@ export default function UserCard(user: UserCardProps) {
           {user.kind === "agent" && user.voiceAvailable && (
             <button
               type="button"
-              onClick={user.onToggleAgentVoice}
+              onClick={() =>
+                user.onToggleAgentVoice?.(user.peerId, !user.voiceEnabled)
+              }
               title={
                 user.voiceEnabled
                   ? `Mute ${user.name}`
@@ -263,7 +265,9 @@ export default function UserCard(user: UserCardProps) {
           {user.kind === "agent" && user.voiceAvailable && (
             <button
               type="button"
-              onClick={user.onToggleAgentVoice}
+              onClick={() =>
+                user.onToggleAgentVoice?.(user.peerId, !user.voiceEnabled)
+              }
               title={
                 user.voiceEnabled
                   ? `Mute ${user.name}`
@@ -286,3 +290,5 @@ export default function UserCard(user: UserCardProps) {
     </div>
   )
 }
+
+export default memo(UserCard)

--- a/app/src/components/collabUi.test.ts
+++ b/app/src/components/collabUi.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest"
 
 import type { Message } from "@common/types"
 
-import { hasCollabTerminalResult, isCollabRequestAnswered } from "./collabUi"
+import {
+  buildCollabLifecycleIndex,
+  hasCollabTerminalResult,
+  isCollabRequestAnswered,
+} from "./collabUi"
 function collab(
   requestId: string,
   kind: "request" | "accepted" | "declined" | "completed" | "failed"
@@ -75,5 +79,62 @@ describe("terminal-result lifecycle helpers (#121)", () => {
     expect(
       isCollabRequestAnswered(log, "r1") || hasCollabTerminalResult(log, "r1")
     ).toBe(false)
+  })
+})
+
+describe("collaboration lifecycle index (#280)", () => {
+  it("projects each requestId without leaking duplicate or unrelated envelopes", () => {
+    const index = buildCollabLifecycleIndex([
+      collab("request", "request"),
+      collab("accepted", "request"),
+      collab("accepted", "accepted"),
+      collab("declined", "request"),
+      collab("declined", "declined"),
+      collab("completed", "request"),
+      collab("completed", "completed"),
+      collab("failed", "request"),
+      collab("failed", "failed"),
+      // Duplicate outcomes and a second request must remain scoped.
+      collab("accepted", "accepted"),
+      collab("other", "accepted"),
+    ])
+
+    expect(index.get("request")).toEqual({
+      answered: false,
+      accepted: false,
+      declined: false,
+      terminal: false,
+    })
+    expect(index.get("accepted")).toEqual({
+      answered: true,
+      accepted: true,
+      declined: false,
+      terminal: false,
+    })
+    expect(index.get("declined")).toEqual({
+      answered: true,
+      accepted: false,
+      declined: true,
+      terminal: false,
+    })
+    expect(index.get("completed")).toEqual({
+      answered: false,
+      accepted: false,
+      declined: false,
+      terminal: true,
+    })
+    expect(index.get("failed")).toEqual({
+      answered: false,
+      accepted: false,
+      declined: false,
+      terminal: true,
+    })
+    expect(index.get("other")).toEqual({
+      answered: true,
+      accepted: true,
+      declined: false,
+      terminal: false,
+    })
+    expect(index.has("missing")).toBe(false)
   })
 })

--- a/app/src/components/collabUi.ts
+++ b/app/src/components/collabUi.ts
@@ -1,5 +1,49 @@
 import type { Message } from "../common/types"
 
+export interface CollabLifecycleProjection {
+  answered: boolean
+  accepted: boolean
+  declined: boolean
+  terminal: boolean
+}
+
+/**
+ * Build the presentation-only collaboration lifecycle view once per message
+ * set. The canonical Room message log remains the source of truth; this map
+ * just avoids making every action card rescan that log independently.
+ */
+export function buildCollabLifecycleIndex(
+  messages: Message[]
+): Map<string, CollabLifecycleProjection> {
+  const index = new Map<string, CollabLifecycleProjection>()
+  for (const message of messages) {
+    const collab = message.collab
+    if (!collab) continue
+
+    const current =
+      index.get(collab.requestId) ??
+      ({
+        answered: false,
+        accepted: false,
+        declined: false,
+        terminal: false,
+      } satisfies CollabLifecycleProjection)
+
+    if (collab.kind === "accepted") {
+      current.accepted = true
+      current.answered = true
+    } else if (collab.kind === "declined") {
+      current.declined = true
+      current.answered = true
+    } else if (collab.kind === "completed" || collab.kind === "failed") {
+      current.terminal = true
+    }
+
+    index.set(collab.requestId, current)
+  }
+  return index
+}
+
 /** #115: lifecycle-derived answered state for a collab request card. The
  * message log IS the record — a later accepted/declined envelope with the
  * same requestId means the decision is made, so response controls must

--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -404,6 +404,47 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     for (let index = 0; index < 20; index += 1) await Promise.resolve()
   }
 
+  it("reuses canonical message objects across a muted full Room state refresh", async () => {
+    const { result, socket, unmount } = await connect()
+    const initialState = roomState([participant("publisher-a", [])])
+    initialState.messages = Array.from({ length: 120 }, (_, index) => ({
+      id: `message-${index + 1}`,
+      peerId: "publisher-a",
+      name: "publisher-a",
+      kind: "human" as const,
+      type: "text" as const,
+      text: `message ${index + 1}`,
+      createdAt: index + 1,
+      sequence: index + 1,
+    }))
+    sendState(socket, initialState)
+    await waitFor(() => expect(result.current.messages).toHaveLength(120))
+    const initialMessages = result.current.messages
+
+    const refreshedParticipant = participant("publisher-a", [])
+    refreshedParticipant.media!.muted = true
+    const refreshedState = roomState([refreshedParticipant])
+    refreshedState.messages = initialState.messages.map((message) => ({
+      ...message,
+    }))
+    sendState(socket, refreshedState)
+    await waitFor(() =>
+      expect(
+        result.current.participants.find(
+          (entry) => entry.peerId === "publisher-a"
+        )?.muteState
+      ).toBe(true)
+    )
+
+    expect(result.current.messages).toHaveLength(initialMessages.length)
+    expect(
+      result.current.messages.every(
+        (message, index) => message === initialMessages[index]
+      )
+    ).toBe(true)
+    unmount()
+  })
+
   it("correlates two video publishers by MID even when ontrack order is reversed", async () => {
     const { result, socket, pc, unmount } = await connect()
     sendState(

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
-import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
+import {
+  mergeRoomAndEphemeralMessages,
+  reconcileCanonicalRoomMessages,
+} from "@common/messageReconciliation"
 import { validateRoomAttachmentRead } from "@common/roomAttachments"
 import {
   createRuntimeProviderClaim as createRuntimeProviderCredential,
@@ -1078,7 +1081,10 @@ export function useSfuChatRoom(
   )
 
   const replaceRoomMessages = useCallback((nextMessages: Message[]) => {
-    roomMessagesRef.current = nextMessages
+    roomMessagesRef.current = reconcileCanonicalRoomMessages(
+      roomMessagesRef.current,
+      nextMessages
+    )
     setMessages(
       mergeRoomAndEphemeralMessages(
         roomMessagesRef.current,


### PR DESCRIPTION
## Summary

- Isolate the Room timeline from composer state so typing does not rebuild historical rows.
- Memoize message and attachment rows, while keeping the canonical Room message log as the source of truth.
- Precompute collaboration lifecycle and poll-vote indexes once per message-set update instead of rescanning the full history from every action card.
- Stabilize RoomContent callbacks and participant voice handlers so unrelated parent updates do not invalidate the timeline or participant cards.
- Reconcile full Room-state message snapshots by stable canonical `messageId`/`sequence` so mute-driven refreshes retain historical row identity.

## Root cause

`TextChatCard` owned both the composer and the timeline. Every composer update reran the full timeline render, and every collaboration or poll action card independently scanned the complete message array. Inline callbacks from `RoomContent` also changed identity on unrelated renders, preventing child memoization from helping. A mute broadcast then exposed the remaining gap: `useSfuChatRoom.applyRoomState` rematerialized every canonical `Message`, so the row comparator could not reuse historical rows.

## What changed

- Moved timeline construction, scroll handling, indexes, and pending-file rendering into a memoized `RoomTimeline` subtree.
- Added row-level memoization with semantic comparisons for stable historical messages, poll votes, collaboration lifecycle state, recipients, and callbacks.
- Added narrow canonical message reconciliation at `replaceRoomMessages`; matching stable identities reuse existing objects, while ID/sequence conflicts stay fresh.
- Kept the existing sequence-based Room/attachment merge and ephemeral file ordering behavior.
- Kept the initial Room history at 100 messages; no pagination or protocol changes were added.
- Virtualization was intentionally avoided: the issue's few-hundred-entry target is handled by render isolation, memoized rows, and linear precomputation while preserving the existing simple timeline behavior.

## Synthetic render evidence

- 120 historical rows + three composer updates: historical `ParticipantAvatar` row-render count stayed at 120 (and Markdown stayed at 120).
- 120 historical rows + a fresh server snapshot paired with a participant mute projection: historical row-render count stayed at 120; the hook test also confirmed all 120 canonical message object references were reused.
- 120 historical rows + one genuinely new message: historical row-render count increased from 120 to 121, rendering only the new row.
- 260 synthetic text messages + 20 synthetic Agent attachments: all 260 Markdown rows rendered and the final message/artifact remained visible.

## Validation

- `cd app && yarn type-check` — passed.
- `cd app && yarn test` — passed: 69 test files, 640 tests.
- `cd app && yarn eslint src --no-fix` — passed.
- `cd app && yarn prettier --check .` — passed.
- `cd app && yarn cf-build` — passed; OpenNext saved `.open-next/worker.js`.
- `git diff --check` — passed.

Refs #280
