### PR TITLE
chore(agent): bump runtime version to 0.5.23

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.22"
+var Version = "0.5.23"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Release preparation

- Bump `agent/internal/doctor/doctor.go` `Version` from 0.5.22 to 0.5.23.
- Keep `app/public/agent.md`, `app/public/llms-full.txt`, and `app/src/common/agentInvite.ts` unchanged; live bootstrap activation remains a separate post-release step.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test ./...`
- `go build ./cmd/free4chat-agent`
- `bash scripts/test-install-agent.sh` (19/19)
- `bash scripts/test-bootstrap-contract.sh`
- `git diff --check`

After merge, push tag `agent-v0.5.23` to trigger the existing four-platform release workflow.
