### PR TITLE
ui(room): remove participant reaction shortcuts

### DIFF
--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -416,6 +416,36 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     ).toBeTruthy()
   })
 
+  it("keeps participant cards free of personal reaction quick controls", () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+        {
+          peerId: "agent-codex",
+          name: "Codex",
+          kind: "agent",
+          room: "test-room",
+        },
+      ],
+    })
+
+    const { container } = render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    expect(container.querySelector(".room-reactions")).toBeNull()
+    for (const emoji of ["👍", "😂", "🔥", "❓"])
+      expect(screen.queryByRole("button", { name: emoji })).toBeNull()
+  })
+
   it("emits LiveTranscriptStarted only on actual Start, never on popover open", () => {
     vi.mocked(trackAnalyticsEvent).mockClear()
     mockUseSfuChatRoom.mockReturnValue({

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -19,7 +19,6 @@ import {
 import { useSfuChatRoom } from "../hooks/useSfuChatRoom"
 import { useTurnstile } from "../hooks/useTurnstile"
 
-const REACTION_EMOJIS = ["👍", "😂", "🔥", "❓"]
 const MAX_FILE_SIZE = 20 * 1024 * 1024
 
 function ScreenShareViewer({
@@ -316,13 +315,6 @@ export default function RoomContent({
       sendTextMessage(text, targets)
     },
     [roomName, sendTextMessage]
-  )
-
-  const sendReaction = useCallback(
-    (emoji: string) => {
-      sendActionMessage("reaction", { emoji, ts: Date.now().toString() })
-    },
-    [sendActionMessage]
   )
 
   const wrappedSendFile = useCallback(
@@ -738,20 +730,6 @@ export default function RoomContent({
                       screenshareAllowed={screenshareAllowed}
                       className="w-40 flex-none"
                     />
-                    {p.peerId === LOCAL_PEER_ID && (
-                      <div className="room-reactions hidden items-center gap-1 md:flex">
-                        {REACTION_EMOJIS.map((emoji) => (
-                          <button
-                            key={emoji}
-                            type="button"
-                            onClick={() => sendReaction(emoji)}
-                            className="rounded-full px-1.5 py-0.5 text-base transition-transform hover:scale-125 active:scale-95"
-                          >
-                            {emoji}
-                          </button>
-                        ))}
-                      </div>
-                    )}
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- Remove the self-only emoji quick controls from the participant grid so every participant card follows the same vertical rhythm.
- Keep the underlying `actionType="reaction"` compatibility path, Room reaction observer, floating reaction rendering, and timeline suppression unchanged.

## Scope

- Removed the `REACTION_EMOJIS` UI constant, `sendReaction` UI handler, and `.room-reactions` participant-card block.
- Added a regression test that verifies the participant grid exposes no personal reaction shortcut buttons.
- No Room, SFU, protocol, or reaction parsing changes.

## Validation

- `cd app && yarn type-check` — passed.
- `cd app && yarn test` — passed: 69 test files, 641 tests.
- `cd app && yarn eslint src --no-fix` — passed.
- `cd app && yarn prettier --check .` — passed.
- `cd app && yarn cf-build` — passed; OpenNext saved `.open-next/worker.js`.
- `git diff --check` — passed.

Follow-up to #282.
