### PR TITLE
[codex] fix OpenCode ACP launcher recipe

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,8 +183,10 @@ historical reference: tag `node-agent-runtime-e2e-2026-08-27`, branch
 Resident launchers run with a restricted environment and a per-instance 0700
 workspace. Provider authentication variables may be retained, but unrelated
 AWS/GitHub/shell secrets and ambient Codex privilege configuration are removed;
-the built-in Codex launcher explicitly selects read-only mode. OpenCode is
-forced to a loopback ephemeral ACP server with mDNS disabled. A custom
+the built-in Codex launcher explicitly selects read-only mode. OpenCode uses
+its documented ACP stdio launcher in pure mode (external plugins disabled); its
+defaults keep the ACP server on loopback with an ephemeral port and mDNS
+disabled. A custom
 `--agent-command` is a trusted local ACP implementation, not a sandbox: ACP
 protocol compliance alone cannot contain a malicious process.
 

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -638,7 +638,7 @@ func TestGetLauncherRegistryContracts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opencode missing: %v", err)
 	}
-	want := []string{"acp", "--hostname", "127.0.0.1", "--port", "0", "--mdns=false", "--pure"}
+	want := []string{"acp", "--pure"}
 	if len(opencode.Args) != len(want) {
 		t.Fatalf("opencode args mismatch: %v", opencode.Args)
 	}
@@ -646,6 +646,10 @@ func TestGetLauncherRegistryContracts(t *testing.T) {
 		if opencode.Args[i] != want[i] {
 			t.Fatalf("opencode args[%d]: got %s want %s", i, opencode.Args[i], want[i])
 		}
+	}
+	if !strings.Contains(opencode.Notes, "defaults to loopback") ||
+		!strings.Contains(opencode.Notes, "external plugins disabled") {
+		t.Fatalf("opencode notes must document the retained pure-mode boundary: %s", opencode.Notes)
 	}
 
 	hermes, err := GetLauncher("hermes")

--- a/agent/internal/harness/launchers.go
+++ b/agent/internal/harness/launchers.go
@@ -29,10 +29,10 @@ var builtInLaunchers = []types.AgentLauncher{
 		ID:          "opencode",
 		DisplayName: "OpenCode",
 		Command:     "opencode",
-		Args:        []string{"acp", "--hostname", "127.0.0.1", "--port", "0", "--mdns=false", "--pure"},
+		Args:        []string{"acp", "--pure"},
 		Maturity:    types.MaturityNative,
 		Security:    types.SecurityTrustedRoom,
-		Notes:       "Local-only ACP server: loopback hostname, ephemeral port, mDNS disabled, and pure mode.",
+		Notes:       "Native ACP over stdio in pure mode (external plugins disabled); OpenCode defaults to loopback, an ephemeral port, and mDNS disabled.",
 	},
 	{
 		ID:          "codex",


### PR DESCRIPTION
## Summary

The built-in OpenCode launcher depended on explicit `--hostname`, `--port`, and `--mdns` transport flags even though the installed OpenCode ACP command documents those same values as defaults. This follow-up verifies the exact local OpenCode 1.18.18 wire contract and removes the redundant historical flags while retaining the independently verified `--pure` plugin boundary.

The change is limited to the OpenCode launcher registry, its deterministic argument/notes contract test, and the developer launch documentation. No generic ACP permission relay, Room permission UI, or other Harness launcher is changed.

## Reproduction matrix

The probe used the exact locally installed `opencode 1.18.18`, a disposable temporary working directory, the same ACP v1 nd-JSON `initialize` frame sent by Free4Chat (`protocolVersion: 1`, `free4chat-agent-runtime` `0.1.0`, empty `clientCapabilities`), then `session/new({cwd, mcpServers: []})` and one harmless retained-session prompt. The subprocess received the same strict Harness environment allow-list; no environment values or credentials were printed, and no global OpenCode configuration was modified.

| Case | Command | `initialize` | `session/new` | harmless prompt |
| --- | --- | --- | --- | --- |
| A | `opencode acp` | valid response | success | success |
| B | `opencode acp --pure` | valid response | success | success |
| C | `opencode acp --hostname 127.0.0.1 --port 0 --mdns=false --pure` | valid response | success | success |

The installed binary's own `opencode acp --help` reports loopback hostname, port `0`, and mDNS disabled as defaults. The current full recipe therefore did not fail in this exact local rerun; the evidence supports removing the redundant transport flags as compatibility hardening rather than claiming a reproduced C-only failure. `--pure` is retained because it is compatible and explicitly disables external plugins; it is not treated as a permission mode.

## Fix

The built-in recipe is now:

```text
opencode acp --pure
```

This keeps the local-only defaults supplied by OpenCode itself and avoids coupling Free4Chat to historical flag spelling or transport plumbing. OpenCode 1.18.18 completed the generic ACP initialize/session/prompt wire test, so no minimum-version boundary or doctor special case was needed. Existing doctor executable checks remain actionable for an unavailable `opencode` binary.

## Validation

- `go test ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `go build ./cmd/free4chat-agent`
- `git diff --check`
- exact OpenCode 1.18.18 A/B/C ACP wire matrix above

No permission policy was broadened, no global OpenCode configuration was changed, and Hermes/Codex/Claude/Pi/DeepSeek/custom ACP launchers are unchanged.

Refs #287
Refs #246
Related #286 (transport evidence only; permission-policy work remains out of scope)
