### PR TITLE
feat(agent): add ACP permission responder foundation

### DIFF
--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,7 +49,95 @@ type AdapterOptions struct {
 	// that owns the resident daemon. It is passed to the Harness as
 	// launcher-owned FREE4CHAT_AGENT_BIN policy, never through Room state.
 	RuntimeExecutable string
+	// PermissionResponder is an optional, resident-local decision seam for
+	// ACP session/request_permission calls. A nil responder preserves the
+	// production fail-closed behavior and cancels the request immediately.
+	PermissionResponder ACPPermissionResponder
 }
+
+// ACPMode is the Harness-native session mode advertised by session/new.
+// Free4Chat preserves these fields without assigning them universal policy
+// semantics.
+type ACPMode struct {
+	ID          string `json:"id"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ACPModeState is the resident-local projection of the Harness-native mode
+// control advertised by an ACP session.
+type ACPModeState struct {
+	CurrentModeID  string    `json:"currentModeId"`
+	AvailableModes []ACPMode `json:"availableModes"`
+}
+
+// ACPConfigOptionValue is one Harness-native value offered by a session
+// config option.
+type ACPConfigOptionValue struct {
+	Value       string `json:"value"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ACPConfigOption is a sanitized native ACP session config option. Only
+// options that are mode/policy-shaped are retained by parseSessionControls.
+type ACPConfigOption struct {
+	ID           string                 `json:"id"`
+	Name         string                 `json:"name,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Category     string                 `json:"category,omitempty"`
+	Type         string                 `json:"type,omitempty"`
+	CurrentValue string                 `json:"currentValue,omitempty"`
+	Options      []ACPConfigOptionValue `json:"options,omitempty"`
+}
+
+// ACPSessionControls contains only native ACP controls retained for a
+// resident. It is not a Free4Chat permission policy or security guarantee.
+type ACPSessionControls struct {
+	Modes         *ACPModeState     `json:"modes,omitempty"`
+	ConfigOptions []ACPConfigOption `json:"configOptions,omitempty"`
+}
+
+// ACPToolCall is the useful, local-only tool context attached to one native
+// permission request. RawInput and Content remain opaque to Free4Chat.
+type ACPToolCall struct {
+	ToolCallID string
+	Title      string
+	Kind       string
+	Status     string
+	RawInput   json.RawMessage
+	Content    json.RawMessage
+}
+
+// ACPPermissionOption preserves the exact native option offered by the
+// Harness. In particular, Free4Chat never interprets Kind or Meta.
+type ACPPermissionOption struct {
+	OptionID string
+	Name     string
+	Kind     string
+	Meta     json.RawMessage
+}
+
+// ACPPermissionRequest is the sanitized local callback payload for one
+// session/request_permission call. RequestID is retained as compact JSON so
+// numeric and string JSON-RPC ids remain distinguishable.
+type ACPPermissionRequest struct {
+	RequestID string
+	SessionID string
+	ToolCall  ACPToolCall
+	Options   []ACPPermissionOption
+}
+
+// ACPPermissionResponse selects one exact option previously offered in the
+// corresponding ACPPermissionRequest. An empty OptionID means cancellation.
+type ACPPermissionResponse struct {
+	OptionID string
+}
+
+// ACPPermissionResponder is deliberately a transport seam, not a policy
+// engine. The responder owns whether/when an authorized external actor
+// chooses one of the Harness-provided options.
+type ACPPermissionResponder func(context.Context, ACPPermissionRequest) (ACPPermissionResponse, error)
 
 // ACPCapabilities is the parsed initialize response projection.
 type ACPCapabilities struct {
@@ -58,6 +147,9 @@ type ACPCapabilities struct {
 	ResumePresent bool
 	// ClosePresent gates the graceful session/close attempt on shutdown.
 	ClosePresent bool
+	// SessionControls is the native control metadata returned by session/new.
+	// It remains resident-local and is cleared on session replacement/death.
+	SessionControls *ACPSessionControls
 }
 
 // acpMessage is one JSON-RPC 2.0 envelope over nd-json stdio.
@@ -92,6 +184,11 @@ type pendingCall struct {
 	result chan *acpMessage
 }
 
+type pendingPermission struct {
+	id      json.RawMessage
+	request ACPPermissionRequest
+}
+
 // harnessProcess owns the ONE cmd.Wait() call for a child lifecycle. Both
 // the death watcher and closeInternal observe the same exit signal, so the
 // shutdown path can reliably distinguish "terminated" from "ignored TERM"
@@ -119,21 +216,22 @@ func (p *harnessProcess) reap() {
 
 // ACPAdapter drives one local Harness process over ACP v1 (nd-json JSON-RPC
 // on stdio). It implements types.HarnessAdapter. Permission requests are
-// fail-closed (always cancelled); custom commands remain trusted-local code,
-// not a sandbox.
+// fail-closed when no responder is configured; custom commands remain
+// trusted-local code, not a sandbox.
 type ACPAdapter struct {
 	launcher   types.AgentLauncher
 	workingDir string
 	options    AdapterOptions
 	name       string
 
-	mu      sync.Mutex
-	writeMu sync.Mutex // serializes every stdin frame
-	proc    *harnessProcess
-	stdin   io.WriteCloser
-	pending map[string]*pendingCall
-	nextID  int64
-	gen     int64 // lifecycle generation of the current child
+	mu                 sync.Mutex
+	writeMu            sync.Mutex // serializes every stdin frame
+	proc               *harnessProcess
+	stdin              io.WriteCloser
+	pending            map[string]*pendingCall
+	pendingPermissions map[string]*pendingPermission
+	nextID             int64
+	gen                int64 // lifecycle generation of the current child
 	// sessionGeneration advances only after a session/new response succeeds.
 	// Unlike gen it is meaningful to the Runtime: a replacement session has
 	// no retained conversation memory, while a transport reconnect alone does
@@ -145,6 +243,8 @@ type ACPAdapter struct {
 	closing           bool
 	promptActive      bool
 	turnChunks        []string
+	turnContext       context.Context
+	turnCancel        context.CancelFunc
 }
 
 // NewACPAdapter creates an adapter bound to one workspace directory. It does
@@ -157,11 +257,12 @@ func NewACPAdapter(launcher types.AgentLauncher, workingDir string, options Adap
 		options.CancelGraceMs = defaultCancelGraceMs
 	}
 	return &ACPAdapter{
-		launcher:   launcher,
-		workingDir: workingDir,
-		options:    options,
-		name:       launcher.ID,
-		pending:    make(map[string]*pendingCall),
+		launcher:           launcher,
+		workingDir:         workingDir,
+		options:            options,
+		name:               launcher.ID,
+		pending:            make(map[string]*pendingCall),
+		pendingPermissions: make(map[string]*pendingPermission),
 	}
 }
 
@@ -180,6 +281,102 @@ func (a *ACPAdapter) Capabilities() *types.HarnessCapabilities {
 		Images: a.caps.Images,
 		Resume: a.caps.ResumePresent,
 	}
+}
+
+// SessionControls returns a copy of the native mode/config metadata last
+// advertised by session/new or session/update. It is resident-local and is
+// cleared when the ACP session is replaced or the Harness exits.
+func (a *ACPAdapter) SessionControls() *ACPSessionControls {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.caps == nil {
+		return nil
+	}
+	return cloneSessionControls(a.caps.SessionControls)
+}
+
+// PendingPermissionCount reports the number of permission requests currently
+// parked for the active turn. It is intentionally local diagnostic state and
+// never enters Room/status output.
+func (a *ACPAdapter) PendingPermissionCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pendingPermissions)
+}
+
+// SetMode applies one Harness-native session mode that was advertised by the
+// current session. The adapter does not infer or translate policy semantics.
+func (a *ACPAdapter) SetMode(modeID string) error {
+	a.mu.Lock()
+	if a.sessionID == "" || a.stdin == nil || a.caps == nil || a.caps.SessionControls == nil || a.caps.SessionControls.Modes == nil {
+		a.mu.Unlock()
+		return errors.New("ACP session mode control is unavailable")
+	}
+	if !hasMode(a.caps.SessionControls.Modes, modeID) {
+		a.mu.Unlock()
+		return fmt.Errorf("ACP session mode %q was not advertised", modeID)
+	}
+	sessionID := a.sessionID
+	generation := a.sessionGeneration
+	a.mu.Unlock()
+
+	params, _ := json.Marshal(map[string]any{"sessionId": sessionID, "modeId": modeID})
+	if _, err := a.request("session/set_mode", params); err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sessionID == sessionID && a.sessionGeneration == generation && a.caps != nil && a.caps.SessionControls != nil && a.caps.SessionControls.Modes != nil {
+		a.caps.SessionControls.Modes.CurrentModeID = modeID
+	}
+	return nil
+}
+
+// SetConfigOption applies one advertised native session config option. A
+// value must be present in the option's advertised values; this prevents the
+// generic adapter from inventing or silently broadening Harness policy.
+func (a *ACPAdapter) SetConfigOption(configID, value string) error {
+	a.mu.Lock()
+	if a.sessionID == "" || a.stdin == nil || a.caps == nil || a.caps.SessionControls == nil {
+		a.mu.Unlock()
+		return errors.New("ACP session config control is unavailable")
+	}
+	option, ok := findConfigOption(a.caps.SessionControls.ConfigOptions, configID)
+	if !ok {
+		a.mu.Unlock()
+		return fmt.Errorf("ACP session config option %q was not advertised", configID)
+	}
+	if !hasConfigValue(option, value) {
+		a.mu.Unlock()
+		return fmt.Errorf("ACP config value %q was not advertised for %q", value, configID)
+	}
+	sessionID := a.sessionID
+	generation := a.sessionGeneration
+	a.mu.Unlock()
+
+	params, _ := json.Marshal(map[string]any{
+		"sessionId": sessionID,
+		"configId":  configID,
+		"value":     value,
+	})
+	response, err := a.request("session/set_config_option", params)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sessionID != sessionID || a.sessionGeneration != generation || a.caps == nil || a.caps.SessionControls == nil {
+		return nil
+	}
+	if controls := parseSessionControls(response.Result); controls != nil && len(controls.ConfigOptions) > 0 {
+		a.caps.SessionControls.ConfigOptions = controls.ConfigOptions
+	} else if current, ok := findConfigOption(a.caps.SessionControls.ConfigOptions, configID); ok {
+		current.CurrentValue = value
+		replaceConfigOption(a.caps.SessionControls.ConfigOptions, current)
+	}
+	return nil
 }
 
 // SessionGeneration identifies the current successfully-created ACP
@@ -212,6 +409,7 @@ func (a *ACPAdapter) fail(err error) {
 // ONLY for notifications belonging to the CURRENT process generation: delayed
 // EOF from an earlier dead child must never wipe a fresh respawn.
 func (a *ACPAdapter) markProcessDead(gen int64, err error) {
+	var turnCancel context.CancelFunc
 	a.mu.Lock()
 	if a.closing {
 		a.mu.Unlock()
@@ -221,7 +419,7 @@ func (a *ACPAdapter) markProcessDead(gen int64, err error) {
 		a.mu.Unlock()
 		return
 	}
-	live := a.proc != nil || a.stdin != nil || a.sessionID != "" || a.caps != nil || len(a.pending) > 0
+	live := a.proc != nil || a.stdin != nil || a.sessionID != "" || a.caps != nil || len(a.pending) > 0 || len(a.pendingPermissions) > 0
 	if !live {
 		a.mu.Unlock()
 		return
@@ -234,9 +432,16 @@ func (a *ACPAdapter) markProcessDead(gen int64, err error) {
 		close(call.result)
 	}
 	a.pending = make(map[string]*pendingCall)
+	a.pendingPermissions = make(map[string]*pendingPermission)
+	turnCancel = a.turnCancel
+	a.turnContext = nil
+	a.turnCancel = nil
 	a.promptActive = false
 	a.turnChunks = nil
 	a.mu.Unlock()
+	if turnCancel != nil {
+		turnCancel()
+	}
 	a.fail(fmt.Errorf("ACP process exited (%v)", err))
 }
 
@@ -326,7 +531,8 @@ func (a *ACPAdapter) handshake() (*ACPCapabilities, string, error) {
 			"version": clientVersion,
 		},
 		// Deliberately advertise no filesystem, terminal, MCP, or other host
-		// capabilities. Permission requests are cancelled as well.
+		// capabilities. Without an explicitly installed local responder,
+		// permission requests remain fail-closed and are cancelled.
 		"clientCapabilities": map[string]any{},
 	})
 	raw, err := a.request("initialize", initializeParams)
@@ -359,6 +565,7 @@ func (a *ACPAdapter) handshake() (*ACPCapabilities, string, error) {
 	if err := json.Unmarshal(raw.Result, &sessionResponse); err != nil || sessionResponse.SessionID == "" {
 		return nil, "", errors.New("ACP agent did not return a sessionId")
 	}
+	caps.SessionControls = parseSessionControls(raw.Result)
 	return caps, sessionResponse.SessionID, nil
 }
 
@@ -384,6 +591,149 @@ func parseAgentCapabilities(raw []byte) (*ACPCapabilities, error) {
 		caps.ClosePresent = true
 	}
 	return caps, nil
+}
+
+func parseSessionControls(raw []byte) *ACPSessionControls {
+	var wire struct {
+		Modes *struct {
+			CurrentModeID string `json:"currentModeId"`
+			Available     []struct {
+				ID          string `json:"id"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+			} `json:"availableModes"`
+		} `json:"modes"`
+		ConfigOptions []struct {
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			Description  string `json:"description"`
+			Category     string `json:"category"`
+			Type         string `json:"type"`
+			CurrentValue string `json:"currentValue"`
+			Options      []struct {
+				Value       string `json:"value"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+			} `json:"options"`
+		} `json:"configOptions"`
+	}
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return nil
+	}
+
+	controls := &ACPSessionControls{}
+	if wire.Modes != nil {
+		modes := &ACPModeState{CurrentModeID: wire.Modes.CurrentModeID}
+		for _, mode := range wire.Modes.Available {
+			if mode.ID == "" {
+				continue
+			}
+			modes.AvailableModes = append(modes.AvailableModes, ACPMode{
+				ID:          mode.ID,
+				Name:        boundedACPText(mode.Name),
+				Description: boundedACPText(mode.Description),
+			})
+		}
+		if len(modes.AvailableModes) > 0 || modes.CurrentModeID != "" {
+			controls.Modes = modes
+		}
+	}
+	for _, option := range wire.ConfigOptions {
+		if !isPolicyConfigOption(option.ID, option.Category) || option.ID == "" {
+			continue
+		}
+		projected := ACPConfigOption{
+			ID:           option.ID,
+			Name:         boundedACPText(option.Name),
+			Description:  boundedACPText(option.Description),
+			Category:     option.Category,
+			Type:         option.Type,
+			CurrentValue: option.CurrentValue,
+		}
+		for _, value := range option.Options {
+			if value.Value == "" {
+				continue
+			}
+			projected.Options = append(projected.Options, ACPConfigOptionValue{
+				Value:       value.Value,
+				Name:        boundedACPText(value.Name),
+				Description: boundedACPText(value.Description),
+			})
+		}
+		controls.ConfigOptions = append(controls.ConfigOptions, projected)
+	}
+	if controls.Modes == nil && len(controls.ConfigOptions) == 0 {
+		return nil
+	}
+	return controls
+}
+
+func isPolicyConfigOption(id, category string) bool {
+	id = strings.ToLower(strings.TrimSpace(id))
+	category = strings.ToLower(strings.TrimSpace(category))
+	return id == "mode" || id == "permission" || id == "policy" ||
+		strings.Contains(category, "mode") || strings.Contains(category, "permission") || strings.Contains(category, "policy")
+}
+
+func boundedACPText(value string) string {
+	const maxACPText = 16 * 1024
+	runes := []rune(value)
+	if len(runes) <= maxACPText {
+		return value
+	}
+	return string(runes[:maxACPText])
+}
+
+func cloneSessionControls(controls *ACPSessionControls) *ACPSessionControls {
+	if controls == nil {
+		return nil
+	}
+	clone := &ACPSessionControls{}
+	if controls.Modes != nil {
+		clone.Modes = &ACPModeState{CurrentModeID: controls.Modes.CurrentModeID}
+		clone.Modes.AvailableModes = append([]ACPMode(nil), controls.Modes.AvailableModes...)
+	}
+	for _, option := range controls.ConfigOptions {
+		option.Options = append([]ACPConfigOptionValue(nil), option.Options...)
+		clone.ConfigOptions = append(clone.ConfigOptions, option)
+	}
+	return clone
+}
+
+func hasMode(modes *ACPModeState, modeID string) bool {
+	for _, mode := range modes.AvailableModes {
+		if mode.ID == modeID {
+			return true
+		}
+	}
+	return false
+}
+
+func findConfigOption(options []ACPConfigOption, configID string) (ACPConfigOption, bool) {
+	for _, option := range options {
+		if option.ID == configID {
+			return option, true
+		}
+	}
+	return ACPConfigOption{}, false
+}
+
+func hasConfigValue(option ACPConfigOption, value string) bool {
+	for _, candidate := range option.Options {
+		if candidate.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceConfigOption(options []ACPConfigOption, replacement ACPConfigOption) {
+	for index := range options {
+		if options[index].ID == replacement.ID {
+			options[index] = replacement
+			return
+		}
+	}
 }
 
 // readLoop pumps stdout frames into the dispatcher until the pipe dies.
@@ -420,15 +770,12 @@ func (a *ACPAdapter) dispatch(message *acpMessage) {
 		}
 		return
 	}
-	// Agent -> client request. Permission requests are fail-closed:
-	// always answered cancelled; everything else is method-not-found.
+	// Agent -> client request. Permission requests are handed off in a
+	// goroutine so a delayed responder never blocks the ACP read loop.
 	if len(message.ID) > 0 && message.Method != "" {
 		switch message.Method {
 		case "session/request_permission":
-			result, _ := json.Marshal(map[string]any{
-				"outcome": map[string]any{"outcome": "cancelled"},
-			})
-			_ = a.writeFrame(responseFrame(message.ID, result))
+			a.dispatchPermission(message)
 		default:
 			rpcErr := acpRPCError{Code: -32601, Message: "method not found"}
 			_ = a.writeFrame(errorFrame(message.ID, rpcErr))
@@ -437,12 +784,180 @@ func (a *ACPAdapter) dispatch(message *acpMessage) {
 	}
 	// Notification.
 	if message.Method == "session/update" {
+		a.applySessionUpdate(message.Params)
 		if chunk, ok := extractTextChunk(message.Params); ok && chunk != "" {
 			a.mu.Lock()
 			if a.promptActive {
 				a.turnChunks = append(a.turnChunks, chunk)
 			}
 			a.mu.Unlock()
+		}
+	}
+}
+
+func (a *ACPAdapter) dispatchPermission(message *acpMessage) {
+	request, err := parsePermissionRequest(message)
+	if err != nil {
+		_ = a.writeFrame(cancelPermissionFrame(message.ID))
+		return
+	}
+
+	key := message.idKey()
+	a.mu.Lock()
+	if a.closing || !a.promptActive || a.turnContext == nil || a.sessionID == "" || request.SessionID != a.sessionID {
+		a.mu.Unlock()
+		_ = a.writeFrame(cancelPermissionFrame(message.ID))
+		return
+	}
+	if _, exists := a.pendingPermissions[key]; exists {
+		a.mu.Unlock()
+		_ = a.writeFrame(cancelPermissionFrame(message.ID))
+		return
+	}
+	pending := &pendingPermission{
+		id:      append(json.RawMessage(nil), message.ID...),
+		request: request,
+	}
+	a.pendingPermissions[key] = pending
+	responder := a.options.PermissionResponder
+	turnContext := a.turnContext
+	a.mu.Unlock()
+
+	if responder == nil {
+		a.finishPermission(key, "")
+		return
+	}
+	go func() {
+		response, responseErr := responder(turnContext, request)
+		if responseErr != nil || response.OptionID == "" || !permissionOptionOffered(request.Options, response.OptionID) {
+			a.finishPermission(key, "")
+			return
+		}
+		a.finishPermission(key, response.OptionID)
+	}()
+}
+
+func parsePermissionRequest(message *acpMessage) (ACPPermissionRequest, error) {
+	var wire struct {
+		SessionID string `json:"sessionId"`
+		ToolCall  struct {
+			ToolCallID string          `json:"toolCallId"`
+			Title      string          `json:"title"`
+			Kind       string          `json:"kind"`
+			Status     string          `json:"status"`
+			RawInput   json.RawMessage `json:"rawInput"`
+			Content    json.RawMessage `json:"content"`
+		} `json:"toolCall"`
+		Options []struct {
+			OptionID string          `json:"optionId"`
+			Name     string          `json:"name"`
+			Kind     string          `json:"kind"`
+			Meta     json.RawMessage `json:"_meta"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(message.Params, &wire); err != nil || wire.SessionID == "" {
+		return ACPPermissionRequest{}, errors.New("invalid ACP permission request")
+	}
+	request := ACPPermissionRequest{
+		RequestID: message.idKey(),
+		SessionID: wire.SessionID,
+		ToolCall: ACPToolCall{
+			ToolCallID: wire.ToolCall.ToolCallID,
+			Title:      boundedACPText(wire.ToolCall.Title),
+			Kind:       wire.ToolCall.Kind,
+			Status:     wire.ToolCall.Status,
+			RawInput:   cloneRawJSON(wire.ToolCall.RawInput),
+			Content:    cloneRawJSON(wire.ToolCall.Content),
+		},
+	}
+	for _, option := range wire.Options {
+		if option.OptionID == "" {
+			continue
+		}
+		request.Options = append(request.Options, ACPPermissionOption{
+			OptionID: option.OptionID,
+			Name:     boundedACPText(option.Name),
+			Kind:     option.Kind,
+			Meta:     cloneRawJSON(option.Meta),
+		})
+	}
+	return request, nil
+}
+
+func cloneRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}
+
+func permissionOptionOffered(options []ACPPermissionOption, optionID string) bool {
+	for _, option := range options {
+		if option.OptionID == optionID {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *ACPAdapter) finishPermission(key, optionID string) {
+	a.mu.Lock()
+	pending, ok := a.pendingPermissions[key]
+	if ok {
+		delete(a.pendingPermissions, key)
+	}
+	a.mu.Unlock()
+	if !ok {
+		return
+	}
+	if optionID == "" {
+		_ = a.writeFrame(cancelPermissionFrame(pending.id))
+		return
+	}
+	_ = a.writeFrame(selectedPermissionFrame(pending.id, optionID))
+}
+
+func cancelPermissionFrame(id json.RawMessage) []byte {
+	return responseFrame(id, map[string]any{
+		"outcome": map[string]any{"outcome": "cancelled"},
+	})
+}
+
+func selectedPermissionFrame(id json.RawMessage, optionID string) []byte {
+	return responseFrame(id, map[string]any{
+		"outcome": map[string]any{"outcome": "selected", "optionId": optionID},
+	})
+}
+
+func (a *ACPAdapter) applySessionUpdate(params json.RawMessage) {
+	var update struct {
+		SessionID string `json:"sessionId"`
+		Update    struct {
+			SessionUpdate string            `json:"sessionUpdate"`
+			CurrentModeID string            `json:"currentModeId"`
+			ConfigOptions []json.RawMessage `json:"configOptions"`
+		} `json:"update"`
+	}
+	if json.Unmarshal(params, &update) != nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.caps == nil || a.caps.SessionControls == nil || (a.sessionID != "" && update.SessionID != "" && update.SessionID != a.sessionID) {
+		return
+	}
+	switch update.Update.SessionUpdate {
+	case "current_mode_update":
+		if a.caps.SessionControls.Modes != nil && update.Update.CurrentModeID != "" {
+			a.caps.SessionControls.Modes.CurrentModeID = update.Update.CurrentModeID
+		}
+	case "config_option_update":
+		if len(update.Update.ConfigOptions) == 0 {
+			return
+		}
+		controls := parseSessionControls(mustJSON(map[string]any{"configOptions": update.Update.ConfigOptions}))
+		if controls != nil && len(controls.ConfigOptions) > 0 {
+			a.caps.SessionControls.ConfigOptions = controls.ConfigOptions
 		}
 	}
 }
@@ -627,6 +1142,7 @@ func (a *ACPAdapter) RunTurn(input types.HarnessTurnInput, expectedSessionGenera
 	}
 	a.promptActive = true
 	a.turnChunks = nil
+	a.turnContext, a.turnCancel = context.WithCancel(context.Background())
 	blocks := promptBlocks(input, a.caps != nil && a.caps.Images)
 	params, _ := json.Marshal(map[string]any{
 		"sessionId": a.sessionID,
@@ -709,9 +1225,41 @@ func (a *ACPAdapter) drainChunks() string {
 func (a *ACPAdapter) resetPrompt(key string) {
 	a.mu.Lock()
 	delete(a.pending, key)
+	turnCancel := a.turnCancel
+	a.turnContext = nil
+	a.turnCancel = nil
+	permissions := a.takePendingPermissionsLocked()
 	a.promptActive = false
 	a.turnChunks = nil
 	a.mu.Unlock()
+	if turnCancel != nil {
+		turnCancel()
+	}
+	for _, permission := range permissions {
+		_ = a.writeFrame(cancelPermissionFrame(permission.id))
+	}
+}
+
+func (a *ACPAdapter) takePendingPermissionsLocked() []*pendingPermission {
+	permissions := make([]*pendingPermission, 0, len(a.pendingPermissions))
+	for _, permission := range a.pendingPermissions {
+		permissions = append(permissions, permission)
+	}
+	a.pendingPermissions = make(map[string]*pendingPermission)
+	return permissions
+}
+
+func (a *ACPAdapter) cancelPendingPermissions() {
+	a.mu.Lock()
+	turnCancel := a.turnCancel
+	permissions := a.takePendingPermissionsLocked()
+	a.mu.Unlock()
+	if turnCancel != nil {
+		turnCancel()
+	}
+	for _, permission := range permissions {
+		_ = a.writeFrame(cancelPermissionFrame(permission.id))
+	}
 }
 
 // recoverTimedOutTurn cancels the prompt and, if it does not settle within
@@ -753,6 +1301,7 @@ func (a *ACPAdapter) CancelTurn() error {
 	})
 	a.mu.Unlock()
 
+	a.cancelPendingPermissions()
 	return a.writeFrame(envelope)
 }
 
@@ -773,6 +1322,7 @@ func (a *ACPAdapter) forceClose() {
 }
 
 func (a *ACPAdapter) closeInternal(force bool) error {
+	var turnCancel context.CancelFunc
 	a.mu.Lock()
 	if a.closing {
 		a.mu.Unlock()
@@ -791,11 +1341,18 @@ func (a *ACPAdapter) closeInternal(force bool) error {
 	a.proc = nil
 	a.promptActive = false
 	a.turnChunks = nil
+	turnCancel = a.turnCancel
+	a.turnContext = nil
+	a.turnCancel = nil
 	for _, call := range a.pending {
 		close(call.result)
 	}
 	a.pending = make(map[string]*pendingCall)
+	a.pendingPermissions = make(map[string]*pendingPermission)
 	a.mu.Unlock()
+	if turnCancel != nil {
+		turnCancel()
+	}
 
 	// Teardown state is cleared; allow a later EnsureSession to spawn a
 	// fresh process (timed-out turns rely on this recovery path). Late death

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -824,16 +824,16 @@ func (a *ACPAdapter) dispatchPermission(message *acpMessage) {
 	a.mu.Unlock()
 
 	if responder == nil {
-		a.finishPermission(key, "")
+		a.finishPermission(key, pending, "")
 		return
 	}
 	go func() {
 		response, responseErr := responder(turnContext, request)
 		if responseErr != nil || response.OptionID == "" || !permissionOptionOffered(request.Options, response.OptionID) {
-			a.finishPermission(key, "")
+			a.finishPermission(key, pending, "")
 			return
 		}
-		a.finishPermission(key, response.OptionID)
+		a.finishPermission(key, pending, response.OptionID)
 	}()
 }
 
@@ -900,16 +900,15 @@ func permissionOptionOffered(options []ACPPermissionOption, optionID string) boo
 	return false
 }
 
-func (a *ACPAdapter) finishPermission(key, optionID string) {
+func (a *ACPAdapter) finishPermission(key string, pending *pendingPermission, optionID string) {
 	a.mu.Lock()
-	pending, ok := a.pendingPermissions[key]
-	if ok {
-		delete(a.pendingPermissions, key)
-	}
-	a.mu.Unlock()
-	if !ok {
+	current, ok := a.pendingPermissions[key]
+	if !ok || current != pending {
+		a.mu.Unlock()
 		return
 	}
+	delete(a.pendingPermissions, key)
+	a.mu.Unlock()
 	if optionID == "" {
 		_ = a.writeFrame(cancelPermissionFrame(pending.id))
 		return

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -186,6 +187,53 @@ func TestACPNegotiatesOnceAndReusesOneSession(t *testing.T) {
 	}
 }
 
+func TestACPRetainsAndAppliesAdvertisedSessionControls(t *testing.T) {
+	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{
+		"FAKE_POLICY_CAP": "1",
+	}), AdapterOptions{})
+	defer adapter.Close()
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	controls := adapter.SessionControls()
+	if controls == nil || controls.Modes == nil || controls.Modes.CurrentModeID != "observe" || !hasMode(controls.Modes, "workspace") {
+		t.Fatalf("native session modes were not retained: %+v", controls)
+	}
+	option, ok := findConfigOption(controls.ConfigOptions, "mode")
+	if !ok || !hasConfigValue(option, "workspace") {
+		t.Fatalf("native mode config option was not retained: %+v", controls)
+	}
+
+	if err := adapter.SetMode("workspace"); err != nil {
+		t.Fatalf("advertised session/set_mode failed: %v", err)
+	}
+	if current := adapter.SessionControls().Modes.CurrentModeID; current != "workspace" {
+		t.Fatalf("session mode was not updated: %q", current)
+	}
+	if err := adapter.SetConfigOption("mode", "observe"); err != nil {
+		t.Fatalf("advertised session/set_config_option failed: %v", err)
+	}
+	if current := findCurrentConfigValue(t, adapter.SessionControls(), "mode"); current != "observe" {
+		t.Fatalf("config option was not updated: %q", current)
+	}
+	if err := adapter.SetMode("unadvertised"); err == nil {
+		t.Fatal("unadvertised mode was accepted")
+	}
+	if err := adapter.SetConfigOption("mode", "unadvertised"); err == nil {
+		t.Fatal("unadvertised config value was accepted")
+	}
+}
+
+func findCurrentConfigValue(t *testing.T, controls *ACPSessionControls, configID string) string {
+	t.Helper()
+	option, ok := findConfigOption(controls.ConfigOptions, configID)
+	if !ok {
+		t.Fatalf("config option %q missing from %+v", configID, controls)
+	}
+	return option.CurrentValue
+}
+
 func TestACPRejectsTurnForUnexpectedSessionGeneration(t *testing.T) {
 	adapter, _ := newTestAdapter(t, scriptLauncher("normal", nil), AdapterOptions{})
 	defer adapter.Close()
@@ -257,6 +305,258 @@ func TestACPAutoCancelsPermissionAndNegotiatesImages(t *testing.T) {
 	// and the Harness reported the cancelled continuation.
 	if result.Text != "permission-cancelled" {
 		t.Fatalf("expected cancelled continuation, got %q", result.Text)
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("no-responder permission leaked: %d", count)
+	}
+}
+
+func TestACPDelayedPermissionSelectionContinuesSameTurn(t *testing.T) {
+	started := make(chan ACPPermissionRequest, 1)
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: func(ctx context.Context, request ACPPermissionRequest) (ACPPermissionResponse, error) {
+			started <- request
+			select {
+			case <-time.After(80 * time.Millisecond):
+				return ACPPermissionResponse{OptionID: "allow-once"}, nil
+			case <-ctx.Done():
+				return ACPPermissionResponse{}, ctx.Err()
+			}
+		},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+
+	done := make(chan struct {
+		result types.HarnessTurnResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		done <- struct {
+			result types.HarnessTurnResult
+			err    error
+		}{result, err}
+	}()
+
+	select {
+	case request := <-started:
+		if request.RequestID != "78" || request.SessionID == "" || request.ToolCall.ToolCallID != "tool-delayed" || request.ToolCall.Title != "delayed harmless operation" {
+			t.Fatalf("permission request context was not preserved: %+v", request)
+		}
+		if string(request.ToolCall.RawInput) != `{"command":"touch temporary-marker"}` {
+			t.Fatalf("tool call input was not preserved: %s", request.ToolCall.RawInput)
+		}
+		if len(request.Options) != 2 || request.Options[0].OptionID != "allow-once" || request.Options[0].Name != "Allow Once" || request.Options[0].Kind != "allow_once" || request.Options[1].OptionID != "reject-once" || request.Options[1].Name != "Reject" || request.Options[1].Kind != "reject_once" {
+			t.Fatalf("permission options were not preserved: %+v", request.Options)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission responder was not called")
+	}
+	if adapter.PendingPermissionCount() != 1 {
+		t.Fatalf("permission did not remain pending: %d", adapter.PendingPermissionCount())
+	}
+	select {
+	case got := <-done:
+		if got.err != nil || got.result.Text != "permission-approved" {
+			t.Fatalf("delayed approval did not continue same turn: %+v %v", got.result, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("delayed permission turn did not settle")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission leaked after turn settlement: %d", count)
+	}
+}
+
+func TestACPRejectsInvalidPermissionOptionAndKeepsFailClosed(t *testing.T) {
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: func(context.Context, ACPPermissionRequest) (ACPPermissionResponse, error) {
+			return ACPPermissionResponse{OptionID: "not-offered"}, nil
+		},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+	if err != nil || result.Text != "permission-cancelled" {
+		t.Fatalf("invalid option was not cancelled: %+v %v", result, err)
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("invalid option leaked permission state: %d", count)
+	}
+}
+
+func TestACPExplicitPermissionRejectionContinuesCancelledTurn(t *testing.T) {
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: func(context.Context, ACPPermissionRequest) (ACPPermissionResponse, error) {
+			return ACPPermissionResponse{OptionID: "reject-once"}, nil
+		},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+	if err != nil || result.Text != "permission-cancelled" {
+		t.Fatalf("explicit rejection did not continue cancelled turn: %+v %v", result, err)
+	}
+}
+
+func TestACPPermissionCancelClearsPendingRequest(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{})
+	adapter.options.PermissionResponder = func(ctx context.Context, _ ACPPermissionRequest) (ACPPermissionResponse, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		return ACPPermissionResponse{}, ctx.Err()
+	}
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission responder did not start")
+	}
+	if err := adapter.CancelTurn(); err != nil {
+		t.Fatalf("cancel turn failed: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("cancelled permission turn failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled permission turn did not settle")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission remained after CancelTurn: %d", count)
+	}
+}
+
+func TestACPTurnTimeoutClearsPendingPermission(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		TurnTimeoutMs: 40,
+		CancelGraceMs: 500,
+		PermissionResponder: func(ctx context.Context, _ ACPPermissionRequest) (ACPPermissionResponse, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return ACPPermissionResponse{}, ctx.Err()
+		},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission responder did not start")
+	}
+	select {
+	case err := <-done:
+		var timeoutErr *TurnTimeoutError
+		if !errors.As(err, &timeoutErr) {
+			t.Fatalf("expected turn timeout, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed-out permission turn did not settle")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission remained after timeout: %d", count)
+	}
+}
+
+func TestACPProcessExitClearsPendingPermission(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: func(ctx context.Context, _ ACPPermissionRequest) (ACPPermissionResponse, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return ACPPermissionResponse{}, ctx.Err()
+		},
+	})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission responder did not start")
+	}
+	adapter.mu.Lock()
+	process := adapter.proc
+	adapter.mu.Unlock()
+	if process == nil || process.cmd.Process == nil {
+		t.Fatal("permission test process disappeared before exit test")
+	}
+	if err := process.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill fake permission Harness: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("process exit left permission turn blocked")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission remained after process exit: %d", count)
+	}
+}
+
+func TestACPAdapterCloseClearsPendingPermission(t *testing.T) {
+	started := make(chan struct{}, 1)
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: func(ctx context.Context, _ ACPPermissionRequest) (ACPPermissionResponse, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return ACPPermissionResponse{}, ctx.Err()
+		},
+	})
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		done <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission responder did not start")
+	}
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("adapter close failed: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter close left permission turn blocked")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission remained after adapter close: %d", count)
 	}
 }
 

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -557,6 +558,133 @@ func TestACPAdapterCloseClearsPendingPermission(t *testing.T) {
 	}
 	if count := adapter.PendingPermissionCount(); count != 0 {
 		t.Fatalf("permission remained after adapter close: %d", count)
+	}
+}
+
+func TestACPStalePermissionResponderCannotResolveReusedRequest(t *testing.T) {
+	type permissionDecision struct {
+		request ACPPermissionRequest
+		result  chan ACPPermissionResponse
+	}
+	decisions := make(chan permissionDecision, 2)
+	firstResult := make(chan ACPPermissionResponse, 1)
+	secondResult := make(chan ACPPermissionResponse, 1)
+	var responderCalls atomic.Int32
+	responder := func(ctx context.Context, request ACPPermissionRequest) (ACPPermissionResponse, error) {
+		call := permissionDecision{request: request, result: firstResult}
+		if responderCalls.Add(1) == 2 {
+			call.result = secondResult
+		}
+		decisions <- call
+		if call.result == firstResult {
+			// Deliberately ignore cancellation for A: the adapter must still
+			// reject its late completion after the process/session is gone.
+			return <-call.result, nil
+		}
+		select {
+		case result := <-call.result:
+			return result, nil
+		case <-ctx.Done():
+			return ACPPermissionResponse{}, ctx.Err()
+		}
+	}
+	adapter, _ := newTestAdapter(t, scriptLauncher("permission_wait", nil), AdapterOptions{
+		PermissionResponder: responder,
+	})
+	defer func() {
+		// Keep cleanup non-blocking even if an assertion fails before either
+		// responder has returned.
+		select {
+		case firstResult <- ACPPermissionResponse{}:
+		default:
+		}
+		select {
+		case secondResult <- ACPPermissionResponse{}:
+		default:
+		}
+		_ = adapter.Close()
+	}()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+
+	doneA := make(chan error, 1)
+	go func() {
+		_, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		doneA <- err
+	}()
+	var callA permissionDecision
+	select {
+	case callA = <-decisions:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission A did not start")
+	}
+
+	adapter.mu.Lock()
+	processA := adapter.proc
+	adapter.mu.Unlock()
+	if processA == nil || processA.cmd.Process == nil {
+		t.Fatal("permission A process disappeared before replacement")
+	}
+	if err := processA.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill permission A Harness: %v", err)
+	}
+	select {
+	case <-doneA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission A did not clear after process death")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission A remained after process death: %d", count)
+	}
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("replacement ensure failed: %v", err)
+	}
+	doneB := make(chan struct {
+		result types.HarnessTurnResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := adapter.RunTurn(turnInput("permission-test"), adapter.SessionGeneration())
+		doneB <- struct {
+			result types.HarnessTurnResult
+			err    error
+		}{result, err}
+	}()
+	var callB permissionDecision
+	select {
+	case callB = <-decisions:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission B did not start")
+	}
+	if callA.request.RequestID != callB.request.RequestID || callB.request.RequestID != "78" {
+		t.Fatalf("fake Harness did not reuse the request id: A=%q B=%q", callA.request.RequestID, callB.request.RequestID)
+	}
+
+	// A offers the same allow-once option as B. Its late completion must be
+	// ignored rather than resolving B's newly-created map entry.
+	callA.result <- ACPPermissionResponse{OptionID: "allow-once"}
+	select {
+	case got := <-doneB:
+		t.Fatalf("stale permission A resolved permission B: %+v", got)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if count := adapter.PendingPermissionCount(); count != 1 {
+		t.Fatalf("permission B was not still pending after stale A: %d", count)
+	}
+
+	callB.result <- ACPPermissionResponse{OptionID: "allow-once"}
+	select {
+	case got := <-doneB:
+		if got.err != nil || got.result.Text != "permission-approved" {
+			t.Fatalf("permission B did not resolve normally: %+v %v", got.result, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission B did not settle")
+	}
+	if count := adapter.PendingPermissionCount(); count != 0 {
+		t.Fatalf("permission B leaked after settlement: %d", count)
 	}
 }
 

--- a/agent/internal/harness/testdata/fakeagent/main.go
+++ b/agent/internal/harness/testdata/fakeagent/main.go
@@ -7,6 +7,7 @@
 //	env            reply with the Harness-visible FREE4CHAT_AGENT_DIR
 //	context_read   invoke the local CLI's bounded Room context read
 //	permission     answer a targeted turn after an auto-cancelled permission ask
+//	permission_wait  park a permission ask until the client chooses an offered option
 //	cancel         hold the requested turn until session/cancel arrives
 //	exit           die shortly after the first prompt completes
 //	restart        die after the first prompt; fresh process answers differently
@@ -14,7 +15,8 @@
 //	envelope       reply with the exact FAKE_REPLY_TEXT payload (#165 addressing tests)
 //
 // Markers/env: FAKE_EXIT_MARKER, FAKE_STATE_MARKER, FAKE_CANCEL_MARKER,
-// FAKE_IMAGE_CAP ("1" advertises image support), FAKE_REPLY_TEXT.
+// FAKE_IMAGE_CAP ("1" advertises image support), FAKE_REPLY_TEXT,
+// FAKE_POLICY_CAP ("1" advertises native modes/config options).
 package main
 
 import (
@@ -188,7 +190,64 @@ func main() {
 
 		case message.Method == "session/new":
 			sessionID = "session-" + strconv.Itoa(1)
-			reply(message.ID, map[string]any{"sessionId": sessionID})
+			response := map[string]any{"sessionId": sessionID}
+			if os.Getenv("FAKE_POLICY_CAP") == "1" {
+				response["modes"] = map[string]any{
+					"currentModeId": "observe",
+					"availableModes": []any{
+						map[string]any{"id": "observe", "name": "Observe", "description": "read-only"},
+						map[string]any{"id": "workspace", "name": "Workspace", "description": "workspace writes"},
+					},
+				}
+				response["configOptions"] = []any{map[string]any{
+					"id": "mode", "name": "Mode", "category": "mode", "type": "select",
+					"currentValue": "observe",
+					"options": []any{
+						map[string]any{"value": "observe", "name": "Observe"},
+						map[string]any{"value": "workspace", "name": "Workspace"},
+					},
+				}}
+			}
+			reply(message.ID, response)
+
+		case message.Method == "session/set_mode":
+			if os.Getenv("FAKE_POLICY_CAP") != "1" {
+				reply(message.ID, map[string]any{"error": "policy controls were not advertised"})
+				continue
+			}
+			var params struct {
+				ModeID string `json:"modeId"`
+			}
+			_ = json.Unmarshal(message.Params, &params)
+			notify("session/update", map[string]any{
+				"sessionId": sessionID,
+				"update":    map[string]any{"sessionUpdate": "current_mode_update", "currentModeId": params.ModeID},
+			})
+			reply(message.ID, map[string]any{})
+
+		case message.Method == "session/set_config_option":
+			if os.Getenv("FAKE_POLICY_CAP") != "1" {
+				reply(message.ID, map[string]any{"error": "policy controls were not advertised"})
+				continue
+			}
+			var params struct {
+				ConfigID string `json:"configId"`
+				Value    string `json:"value"`
+			}
+			_ = json.Unmarshal(message.Params, &params)
+			configOptions := []any{map[string]any{
+				"id": params.ConfigID, "name": "Mode", "category": "mode", "type": "select",
+				"currentValue": params.Value,
+				"options": []any{
+					map[string]any{"value": "observe", "name": "Observe"},
+					map[string]any{"value": "workspace", "name": "Workspace"},
+				},
+			}}
+			notify("session/update", map[string]any{
+				"sessionId": sessionID,
+				"update":    map[string]any{"sessionUpdate": "config_option_update", "configOptions": configOptions},
+			})
+			reply(message.ID, map[string]any{"configOptions": configOptions})
 
 		case message.Method == "session/close":
 			reply(message.ID, map[string]any{})
@@ -271,6 +330,31 @@ func main() {
 					continue
 				}
 				a.finishNormal(&message, sessionID)
+			case "permission_wait":
+				if len(prompt) > 0 && contains(prompt, "permission-test") {
+					send(&frame{
+						JSONRPC: "2.0",
+						ID:      json.RawMessage("78"),
+						Method:  "session/request_permission",
+						Params: mustJSON(map[string]any{
+							"sessionId": sessionID,
+							"toolCall": map[string]any{
+								"toolCallId": "tool-delayed",
+								"title":      "delayed harmless operation",
+								"kind":       "execute",
+								"status":     "pending",
+								"rawInput":   map[string]any{"command": "touch temporary-marker"},
+							},
+							"options": []any{
+								map[string]any{"optionId": "allow-once", "name": "Allow Once", "kind": "allow_once"},
+								map[string]any{"optionId": "reject-once", "name": "Reject", "kind": "reject_once"},
+							},
+						}),
+					})
+					a.pending = append([]byte(nil), message.ID...)
+					continue
+				}
+				a.finishNormal(&message, sessionID)
 			case "cancel":
 				if len(prompt) > 0 && contains(prompt, "cancel-test") {
 					a.pending = append([]byte(nil), message.ID...)
@@ -340,9 +424,21 @@ func main() {
 		case len(message.ID) > 0 && message.Result != nil:
 			// Runtime answered our outbound request (e.g. the auto-cancelled
 			// permission call). Continue the parked turn accordingly.
-			if a.mode == "permission" && a.pending != nil {
-				updateChunk(sessionID, "permission-cancelled")
-				reply(a.pending, map[string]any{"stopReason": "cancelled"})
+			if (a.mode == "permission" || a.mode == "permission_wait") && a.pending != nil {
+				var permissionResult struct {
+					Outcome struct {
+						Outcome  string `json:"outcome"`
+						OptionID string `json:"optionId"`
+					} `json:"outcome"`
+				}
+				_ = json.Unmarshal(message.Result, &permissionResult)
+				if a.mode == "permission_wait" && permissionResult.Outcome.Outcome == "selected" && permissionResult.Outcome.OptionID == "allow-once" {
+					updateChunk(sessionID, "permission-approved")
+					reply(a.pending, map[string]any{"stopReason": "end_turn"})
+				} else {
+					updateChunk(sessionID, "permission-cancelled")
+					reply(a.pending, map[string]any{"stopReason": "cancelled"})
+				}
 				a.pending = nil
 			}
 


### PR DESCRIPTION
## Summary

Implements the Runtime/ACP foundation for #286 without adding Room/UI integration.

### ACP responder seam

- `AdapterOptions.PermissionResponder` is a resident-local callback receiving `context.Context` and a sanitized `ACPPermissionRequest`.
- The request preserves the compact JSON-RPC request id, session id, useful tool-call context, and the exact offered option id/name/kind plus opaque metadata.
- A responder may return one exact offered `optionId`; unoffered, empty, or errored responses fail closed with ACP cancellation.
- The adapter never interprets native option kinds such as allow/reject or invents a universal policy DSL.
- With no responder configured, the existing immediate cancellation behavior remains unchanged.

### Lifecycle bounds

Pending requests are keyed to the active ACP turn/session and are removed on normal turn settlement, explicit turn cancellation, timeout recovery, Harness process death, and adapter shutdown. Responder callbacks receive a turn context that is cancelled on each of those boundaries. The ACP stdout read loop is never blocked while a responder waits.

### Native session controls

The adapter retains bounded, resident-local session mode and mode/policy-shaped config metadata from `session/new` and `session/update`. `session/set_mode` and `session/set_config_option` are available only for values advertised by the current ACP session; no Harness mode is changed automatically.

### Tests

The deterministic fake ACP Harness covers:

- delayed selection continuing the same `session/prompt`;
- explicit rejection;
- invalid/unoffered option fail-closed behavior;
- no responder cancellation;
- pending permission timeout, `session/cancel`, process exit, and adapter close;
- pending-state cleanup and retained-session generation behavior;
- native mode/config retention and advertised-value-only setters.

Validation passed:

```text
go test ./... -count=1
go vet ./...
go test -race ./internal/harness -count=1
go build -o /private/tmp/free4chat-agent-286 ./cmd/free4chat-agent
git diff --check
```

Production remains fail-closed until the future #286 integration PR wires an authorized Room/Human responder into `PermissionResponder`. That future PR must keep the responder resident-local, select only the exact options supplied by ACP, and avoid exposing ACP/session credentials or policy state through Room/MCP/status surfaces.
