### PR TITLE
docs(agent): activate Runtime 0.5.24 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -371,7 +371,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.22"
+expected_version="0.5.24"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1839,7 +1839,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.22"
+expected_version="0.5.24"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary
- activate the published `agent-v0.5.24` Runtime in the live bootstrap contract
- update both the human-readable version and pinned installer expected_version in `app/public/agent.md`
- regenerate `app/public/llms-full.txt`

## Release evidence
- native GitHub Release: https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.24
- four platform assets and `SHA256SUMS` verified
- downloaded darwin-arm64 asset checksum and `doctor --json` verified

## Validation
- `bash agent/scripts/test-bootstrap-contract.sh`
- `yarn docs:check`

This activation PR is intentionally separate from the already published native Release.