### PR TITLE
fix: dispatch Room permission requests

### DIFF
--- a/app/src/room/server.test.ts
+++ b/app/src/room/server.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { handleRoomRequest, type RoomProtocolEnv } from "./server"
+import {
+  handleRoomRequest,
+  isRoomRequestPath,
+  type RoomProtocolEnv,
+} from "./server"
 
 /**
  * Attachment upload gate for agent read_attachment (#82/#90): images were
@@ -9,6 +13,13 @@ import { handleRoomRequest, type RoomProtocolEnv } from "./server"
  */
 
 const ORIGIN = "http://localhost:3000"
+
+describe("Worker Room route dispatch", () => {
+  it("dispatches the Runtime permission request path to the Room handler", () => {
+    expect(isRoomRequestPath("/api/room/permissions/request")).toBe(true)
+    expect(isRoomRequestPath("/api/room/not-a-protocol-route")).toBe(false)
+  })
+})
 
 type CapturedUpload = { contentType: string | null }
 type CapturedControl = {

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -7,6 +7,15 @@ const MAX_ROOM_LENGTH = 64
 const MAX_AGENT_ATTACHMENT_BYTES = 768 * 1024
 const MAX_PERMISSION_REQUEST_BODY_BYTES = 64 * 1024
 const AGENT_EVENT_PATH = "/api/room/agent-events"
+const ROOM_REQUEST_PATHS = new Set([
+  "/api/room/attachments",
+  "/api/room/live-transcript/append",
+  AGENT_EVENT_PATH,
+  "/api/room/permissions/request",
+  "/api/room/runtime-provider/connect",
+  "/api/room/surfaces/read",
+  "/api/room/attachments/read",
+])
 const SUPPORTED_IMAGE_TYPES = new Set([
   "image/jpeg",
   "image/png",
@@ -22,6 +31,13 @@ const SUPPORTED_IMAGE_TYPES = new Set([
 
 export interface RoomProtocolEnv {
   SFU_ROOM: DurableObjectNamespace<RoomSession>
+}
+
+// Keep the Worker entrypoint and the protocol handler on the same allowlist.
+// A path that is implemented below but omitted here falls through to the
+// Next.js app and becomes an opaque HTML 404 to native Runtime clients.
+export function isRoomRequestPath(pathname: string): boolean {
+  return ROOM_REQUEST_PATHS.has(pathname)
 }
 
 function json(data: unknown, status = 200): Response {

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -3,7 +3,7 @@ import { default as handler } from "./.open-next/worker.js"
 
 import { handleSfuRequest } from "./src/sfu/server"
 import { handleMcpRequest } from "./src/mcp/server"
-import { handleRoomRequest } from "./src/room/server"
+import { handleRoomRequest, isRoomRequestPath } from "./src/room/server"
 
 export { RoomSession } from "./src/do/RoomSession"
 
@@ -16,14 +16,7 @@ export default {
     if (pathname.startsWith("/api/sfu/")) {
       return handleSfuRequest(request, env)
     }
-    if (
-      pathname === "/api/room/attachments" ||
-      pathname === "/api/room/live-transcript/append" ||
-      pathname === "/api/room/agent-events" ||
-      pathname === "/api/room/runtime-provider/connect" ||
-      pathname === "/api/room/surfaces/read" ||
-      pathname === "/api/room/attachments/read"
-    ) {
+    if (isRoomRequestPath(pathname)) {
       return handleRoomRequest(request, env)
     }
     return handler.fetch(request, env, ctx)


### PR DESCRIPTION
## Problem

The Runtime permission flow is implemented by `app/src/room/server.ts`, but the Worker entrypoint did not dispatch `/api/room/permissions/request` to that handler. Production requests therefore fell through to the generated Next.js handler and returned an HTML 404.

The resident Runtime treats that non-2xx response as `Room permission request rejected` / `Room permission request failed`, so a Harness reports an immediate denial and no Human approval card is created. Cloudflare Observability confirmed `response.status=404` for this exact production path.

## Fix

- Share one Room protocol route allowlist between the Worker entrypoint and the Room handler.
- Include `/api/room/permissions/request` in that allowlist.
- Keep unknown paths on the existing Next.js fallback path.
- Add a focused dispatch regression test so a newly implemented Room route cannot silently become an opaque Runtime 404.

This is a routing fix only. It does not change the permission model, ACP correlation, approval semantics, or Runtime transport.

## Validation

- `vitest run src/room/server.test.ts` — 13 tests passed
- `yarn test` — 71 files / 656 tests passed
- `yarn type-check` — passed
- `eslint src` — passed
- Prettier check — passed
- `yarn build` — passed
- `yarn docs:check` — passed
- `go test ./...` — passed
- `go vet ./...` — passed

`yarn cf-build` reached the OpenNext build but is currently blocked by an existing strict-mode type error in `app/src/common/utils.tsx:34` (`any` not assignable to `never`) after Next auto-enables `strictNullChecks`; this is unrelated to the three-file diff.
