### PR TITLE
[codex] document Harness permission behavior

### DIFF
--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -597,14 +597,55 @@ the Harness's local credentials or raw request payload in the Room. It
 publishes only a bounded Human-facing description of the requested action and
 the exact native permission options.
 
+## Built-in Harness behavior
+
+Room approval cards are conditional on the Harness's native policy. A Harness
+may execute an action under its native/default policy, or it may emit an ACP
+`session/request_permission` request for an explicit Human decision. The
+absence of a Room approval card is not by itself evidence that Free4Chat's
+approval transport failed.
+
+### Claude
+
+Claude is production-verified with Free4Chat Room approval. A real resident
+Claude Harness can request tool permission, show a Room approval card, receive
+an `Allow` or `Deny` choice, and continue or stop the same ACP turn. This does
+not mean that every Claude tool action always prompts; the Harness and its
+native policy decide whether an ACP permission request is emitted.
+
+### Codex
+
+Current Codex ACP behavior has an upstream bridge/policy limitation. Native
+Codex can prompt under stricter policies such as `untrusted`, but the tested
+`codex-acp` modes do not currently expose that path cleanly to Free4Chat. This
+is a compatibility limitation in the upstream bridge/policy path, not a
+Free4Chat Room approval failure. No vendor-specific workaround is required by
+the Room permission model.
+
+### OpenCode, Hermes, and Pi
+
+OpenCode and Hermes behavior depends on their native ACP and permission-policy
+configuration; Room approval is compatibility-specific and is not claimed as
+production-verified for either Harness here.
+
+Pi may execute tools directly under its native/default local policy without
+emitting an ACP permission request. That is valid Harness behavior, not a
+failure or unsupported state merely because no Room approval card appears.
+
+Some Harnesses may offer durable choices such as `Always Allow`. Their
+lifetime, storage location, and exact effect are defined by the Harness.
+Free4Chat does not infer or broaden those semantics from a button label or
+option kind. It returns the exact native option id unchanged and does not
+invent a Free4Chat scope such as session, project, user, or global.
+
 ## Human-present and headless Rooms
 
-| Scenario | Permission behavior |
-| --- | --- |
-| Web Room + Human | The Human receives a structured approval card. |
-| CLI-only / Agent-only | The Harness runs under its current native/default policy. |
-| Headless Harness asks for approval | The request expires or is cancelled and fails closed. |
-| Unattended automation | The operator should choose a Harness-native unattended policy, if that Harness supports one. |
+| Scenario                           | Permission behavior                                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| Web Room + Human                   | The Human receives a structured approval card.                                               |
+| CLI-only / Agent-only              | The Harness runs under its current native/default policy.                                    |
+| Headless Harness asks for approval | The request expires or is cancelled and fails closed.                                        |
+| Unattended automation              | The operator should choose a Harness-native unattended policy, if that Harness supports one. |
 
 CLI-only collaboration remains supported and does not require `setup`. For
 headless operation, configure an appropriate native Harness policy separately.

--- a/docs/en/concepts/agent-permissions.md
+++ b/docs/en/concepts/agent-permissions.md
@@ -26,14 +26,55 @@ the Harness's local credentials or raw request payload in the Room. It
 publishes only a bounded Human-facing description of the requested action and
 the exact native permission options.
 
+## Built-in Harness behavior
+
+Room approval cards are conditional on the Harness's native policy. A Harness
+may execute an action under its native/default policy, or it may emit an ACP
+`session/request_permission` request for an explicit Human decision. The
+absence of a Room approval card is not by itself evidence that Free4Chat's
+approval transport failed.
+
+### Claude
+
+Claude is production-verified with Free4Chat Room approval. A real resident
+Claude Harness can request tool permission, show a Room approval card, receive
+an `Allow` or `Deny` choice, and continue or stop the same ACP turn. This does
+not mean that every Claude tool action always prompts; the Harness and its
+native policy decide whether an ACP permission request is emitted.
+
+### Codex
+
+Current Codex ACP behavior has an upstream bridge/policy limitation. Native
+Codex can prompt under stricter policies such as `untrusted`, but the tested
+`codex-acp` modes do not currently expose that path cleanly to Free4Chat. This
+is a compatibility limitation in the upstream bridge/policy path, not a
+Free4Chat Room approval failure. No vendor-specific workaround is required by
+the Room permission model.
+
+### OpenCode, Hermes, and Pi
+
+OpenCode and Hermes behavior depends on their native ACP and permission-policy
+configuration; Room approval is compatibility-specific and is not claimed as
+production-verified for either Harness here.
+
+Pi may execute tools directly under its native/default local policy without
+emitting an ACP permission request. That is valid Harness behavior, not a
+failure or unsupported state merely because no Room approval card appears.
+
+Some Harnesses may offer durable choices such as `Always Allow`. Their
+lifetime, storage location, and exact effect are defined by the Harness.
+Free4Chat does not infer or broaden those semantics from a button label or
+option kind. It returns the exact native option id unchanged and does not
+invent a Free4Chat scope such as session, project, user, or global.
+
 ## Human-present and headless Rooms
 
-| Scenario | Permission behavior |
-| --- | --- |
-| Web Room + Human | The Human receives a structured approval card. |
-| CLI-only / Agent-only | The Harness runs under its current native/default policy. |
-| Headless Harness asks for approval | The request expires or is cancelled and fails closed. |
-| Unattended automation | The operator should choose a Harness-native unattended policy, if that Harness supports one. |
+| Scenario                           | Permission behavior                                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| Web Room + Human                   | The Human receives a structured approval card.                                               |
+| CLI-only / Agent-only              | The Harness runs under its current native/default policy.                                    |
+| Headless Harness asks for approval | The request expires or is cancelled and fails closed.                                        |
+| Unattended automation              | The operator should choose a Harness-native unattended policy, if that Harness supports one. |
 
 CLI-only collaboration remains supported and does not require `setup`. For
 headless operation, configure an appropriate native Harness policy separately.


### PR DESCRIPTION
## Summary

Refs #297.

The public Agent permission page described the stable Room/Harness permission boundary, but it did not yet reflect the production-verified Claude flow or explain why other built-in Harnesses may legitimately produce no Room approval card. That gap could make native-policy execution look like a Free4Chat transport failure and could imply that durable option labels have Free4Chat-defined scope.

## Changes

- Document Claude Room approval as production-verified, including explicit Allow/Deny and continuation or termination of the same ACP turn.
- Explain that approval cards are conditional on Harness-native policy and that Pi may execute directly without emitting ACP permission requests.
- Describe current Codex behavior as an upstream `codex-acp` bridge/policy compatibility limitation, not a Free4Chat approval failure.
- Keep OpenCode/Hermes behavior compatibility-specific without claiming production verification.
- Clarify that durable choices such as `Always Allow` remain Harness-owned and that Free4Chat returns the exact native option id without inventing scope semantics.
- Regenerate `app/public/llms-full.txt` from the canonical Markdown source.

No Runtime, Room protocol, Worker, launcher, Harness policy, or ACP parsing code changed.

## Validation

- `yarn docs:generate`
- `yarn docs:check`
- `yarn type-check`
- `yarn lint`
- `yarn test src/__tests__/docs/docs.test.ts` — 19/19 passed
- `yarn test` — all 71 files and 656 tests passed; the command still exits non-zero because Vitest reports one existing post-teardown `window is not defined` analytics-timer error from `src/common/utils.tsx:100`
- Prettier check for the changed Markdown and generated corpus
- `git diff --check`
