### PR TITLE
feat: experiment with Room-backed external Counter

### DIFF
--- a/app/e2e/room/counter-bridge.spec.ts
+++ b/app/e2e/room/counter-bridge.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const ROOM_SLUG = `counter-e2e-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+
+type RoomSession = {
+  participantId: string
+  participantToken: string
+}
+
+async function installMediaShim(page: Page) {
+  await page.addInitScript(() => {
+    class FakeRTCPeerConnection {
+      onicecandidate = null
+      ontrack = null
+      ondatachannel = null
+      __transceivers: Array<{
+        sender: { track: unknown }
+        receiver: { track: null }
+        mid: string
+        direction: string
+      }> = []
+      addTrack() {
+        return { mid: "0", direction: "sendonly" }
+      }
+      addTransceiver(track: unknown, init: { direction?: string } = {}) {
+        const transceiver = {
+          sender: { track },
+          receiver: { track: null },
+          mid: "0",
+          direction: init?.direction ?? "sendrecv",
+        }
+        this.__transceivers.push(transceiver)
+        return transceiver
+      }
+      createDataChannel(label: string) {
+        return {
+          label,
+          readyState: "open",
+          bufferedAmount: 0,
+          bufferedAmountLowThreshold: 0,
+          send() {},
+          close() {},
+          addEventListener() {},
+          removeEventListener() {},
+        }
+      }
+      createOffer() {
+        return Promise.resolve({ type: "offer", sdp: "v=0\r\n" })
+      }
+      createAnswer() {
+        return Promise.resolve({ type: "answer", sdp: "v=0\r\n" })
+      }
+      setLocalDescription() {
+        return Promise.resolve()
+      }
+      setRemoteDescription() {
+        return Promise.resolve()
+      }
+      getTransceivers() {
+        return this.__transceivers
+      }
+      getConfiguration() {
+        return { iceServers: [] }
+      }
+      getStats() {
+        return Promise.resolve(new Map())
+      }
+      getSenders() {
+        return []
+      }
+      getReceivers() {
+        return []
+      }
+      addEventListener() {}
+      removeEventListener() {}
+      close() {}
+    }
+    ;(window as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakeRTCPeerConnection
+  })
+}
+
+async function joinRoom(page: Page, nickname: string): Promise<RoomSession> {
+  await installMediaShim(page)
+  let session: RoomSession | undefined
+  page.on("response", async (response) => {
+    if (
+      !response.url().includes("/api/sfu/session") ||
+      response.status() !== 200
+    )
+      return
+    try {
+      const payload = (await response.json()) as Partial<RoomSession>
+      if (payload.participantId && payload.participantToken)
+        session = payload as RoomSession
+    } catch {
+      // The page's own error state is the assertion for a malformed session.
+    }
+  })
+  await page.goto(`/room?id=${ROOM_SLUG}`)
+  await page.getByLabel("Nickname").fill(nickname)
+  await page.getByRole("button", { name: /Go/i }).click()
+  await expect(page.getByText(new RegExp(nickname)).first()).toBeVisible({
+    timeout: 15_000,
+  })
+  await expect.poll(() => session?.participantId).toBeTruthy()
+  return session!
+}
+
+test("two Room browsers share one external Counter task with scoped authority", async ({
+  browser,
+}) => {
+  const contextA = await browser.newContext()
+  const contextB = await browser.newContext()
+  const pageA = await contextA.newPage()
+  const pageB = await contextB.newPage()
+
+  const sessionA = await joinRoom(pageA, "Alice")
+  await pageA.getByRole("button", { name: "Start Counter" }).click()
+  await expect(pageA.getByTestId("counter-status")).toContainText("Count: 0")
+  await expect(pageA.getByTestId("counter-status")).toContainText("your turn")
+
+  const sessionB = await joinRoom(pageB, "Bob")
+  await expect(pageB.getByRole("button", { name: "Join Counter" })).toBeVisible(
+    {
+      timeout: 15_000,
+    }
+  )
+  await pageB.getByRole("button", { name: "Join Counter" }).click()
+  await expect(pageB.getByTestId("counter-status")).toContainText("waiting")
+  await expect(pageB.getByTestId("counter-increment")).toBeDisabled()
+
+  // The UI correctly disables a non-owner, but the authoritative action path
+  // is also exercised directly with B's real Room credential. Counter must
+  // reject it before any Room message or Agent wakeup can occur.
+  const authorizedUnauthorized = await pageB.evaluate(
+    async (session) => {
+      const response = await fetch("/api/room/experiments/counter", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Room-Id": session.room,
+          "X-Room-Participant-Id": session.participantId,
+          "X-Room-Participant-Token": session.participantToken,
+        },
+        body: JSON.stringify({ operation: "increment" }),
+      })
+      return response.status
+    },
+    { ...sessionB, room: ROOM_SLUG }
+  )
+  expect(authorizedUnauthorized).toBe(403)
+
+  await pageA.getByTestId("counter-increment").click()
+  await expect(pageA.getByTestId("counter-status")).toContainText("Count: 1")
+  await expect(pageB.getByTestId("counter-status")).toContainText("Count: 1")
+  await expect(pageB.getByTestId("counter-status")).toContainText("your turn")
+
+  await pageB.getByTestId("counter-increment").click()
+  await expect(pageB.getByTestId("counter-status")).toContainText("Count: 2")
+  await expect(pageA.getByTestId("counter-status")).toContainText("Count: 2")
+
+  const message = "ordinary Room chat still works"
+  await pageA.getByPlaceholder("Message the room or @ an Agent…").fill(message)
+  await pageA.keyboard.press("Enter")
+  await expect(pageB.getByText(message).first()).toBeVisible({
+    timeout: 15_000,
+  })
+
+  console.log(
+    JSON.stringify({
+      roomId: ROOM_SLUG,
+      participantA: sessionA.participantId,
+      participantB: sessionB.participantId,
+      task: "same Room-scoped Counter task",
+      count: 2,
+      ordinaryChat: "PASS",
+      agentWakeups: "none observed; unit path asserts 0 waiters",
+    })
+  )
+
+  await contextB.close()
+  await contextA.close()
+})

--- a/app/e2e/room/playwright.config.ts
+++ b/app/e2e/room/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   // same way they do for the homepage suite; the testMatch keeps this config
   // scoped to the Room spec only.
   testDir: "../..",
-  testMatch: "**/room.spec.ts",
+  testMatch: "**/room/*.spec.ts",
   timeout: 60_000,
   workers: 1,
   fullyParallel: false,

--- a/app/e2e/room/run-local-worker.mjs
+++ b/app/e2e/room/run-local-worker.mjs
@@ -192,6 +192,10 @@ async function main() {
           TURNSTILE_SECRET_KEY: "",
           TURNSTILE_DISABLED: "true",
           AGENT_MEDIA_ENABLED: "false",
+          ROOM_COUNTER_EXPERIMENT:
+            process.env.ROOM_COUNTER_EXPERIMENT ?? "false",
+          COUNTER_BASE_URL:
+            process.env.COUNTER_BASE_URL ?? "http://127.0.0.1:8787",
         },
         secrets: {
           SFU_APP_SECRET: DUMMY_APP_SECRET,

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,8 @@
     "docs:check": "node scripts/generate-docs-assets.mjs --check",
     "prepare": "husky",
     "e2e:homepage": "playwright test e2e/signal-collapse.spec.ts --config=e2e/playwright.config.ts",
-    "e2e:room": "playwright test e2e/room/room.spec.ts --config=e2e/room/playwright.config.ts"
+    "e2e:room": "playwright test e2e/room/room.spec.ts --config=e2e/room/playwright.config.ts",
+    "e2e:room-counter": "ROOM_COUNTER_EXPERIMENT=true NEXT_PUBLIC_ROOM_COUNTER_EXPERIMENT=true COUNTER_BASE_URL=http://127.0.0.1:8787 playwright test e2e/room/counter-bridge.spec.ts --config=e2e/room/playwright.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "2.0.0",

--- a/app/src/components/CounterExperiment.tsx
+++ b/app/src/components/CounterExperiment.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useState } from "react"
+
+import type { CounterProjection } from "../room/counterBridge"
+import type { CounterTaskPublic } from "../room/types"
+
+interface RoomAuth {
+  roomId: string
+  participantId: string
+  token: string
+}
+
+interface CounterResponse {
+  projection?: CounterProjection
+  error?: string
+}
+
+interface CounterExperimentProps {
+  counterTask?: CounterTaskPublic
+  auth: RoomAuth | null
+}
+
+export default function CounterExperiment({
+  counterTask,
+  auth,
+}: CounterExperimentProps) {
+  const [projection, setProjection] = useState<CounterProjection | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState("")
+  const roomId = auth?.roomId
+  const localParticipantId = auth?.participantId
+  const roomToken = auth?.token
+
+  const request = useCallback(
+    async (operation: "start" | "join" | "state" | "increment") => {
+      if (!roomId || !localParticipantId || !roomToken) return null
+      setBusy(true)
+      setError("")
+      try {
+        const response = await fetch("/api/room/experiments/counter", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Room-Id": roomId,
+            "X-Room-Participant-Id": localParticipantId,
+            "X-Room-Participant-Token": roomToken,
+          },
+          body: JSON.stringify({ operation }),
+        })
+        const payload = (await response
+          .json()
+          .catch(() => ({}))) as CounterResponse
+        if (!response.ok) {
+          setError(payload.error ?? `counter_${response.status}`)
+          return null
+        }
+        if (payload.projection) setProjection(payload.projection)
+        return payload
+      } catch {
+        setError("counter_unavailable")
+        return null
+      } finally {
+        setBusy(false)
+      }
+    },
+    [localParticipantId, roomId, roomToken]
+  )
+
+  const isAttached = Boolean(
+    counterTask &&
+      localParticipantId &&
+      counterTask.participants.some(
+        (participant) => participant.participantId === localParticipantId
+      )
+  )
+
+  useEffect(() => {
+    setError("")
+    if (
+      !counterTask ||
+      !roomId ||
+      !localParticipantId ||
+      !roomToken ||
+      !isAttached
+    ) {
+      setProjection(null)
+      return
+    }
+    void request("state")
+  }, [
+    counterTask,
+    counterTask?.taskId,
+    counterTask?.revision,
+    isAttached,
+    localParticipantId,
+    request,
+    roomId,
+    roomToken,
+  ])
+
+  if (!auth) return null
+
+  if (!counterTask) {
+    return (
+      <section
+        className="border-b border-gray-800 bg-gray-950/50 p-4"
+        data-testid="counter-experiment"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-100">
+              Counter experiment
+            </h2>
+            <p className="text-xs text-gray-400">
+              Start one shared deterministic task for this Room.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+            disabled={busy}
+            onClick={() => void request("start")}
+          >
+            {busy ? "Starting…" : "Start Counter"}
+          </button>
+        </div>
+        {error && <p className="mt-2 text-xs text-amber-300">{error}</p>}
+      </section>
+    )
+  }
+
+  if (!isAttached) {
+    return (
+      <section
+        className="border-b border-gray-800 bg-gray-950/50 p-4"
+        data-testid="counter-experiment"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-100">
+              {counterTask.surface.title}
+            </h2>
+            <p className="text-xs text-gray-400">
+              A Room participant is already running this shared task.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+            disabled={busy || counterTask.participants.length >= 2}
+            onClick={() => void request("join")}
+          >
+            {busy
+              ? "Joining…"
+              : counterTask.participants.length >= 2
+              ? "Full"
+              : "Join Counter"}
+          </button>
+        </div>
+        {error && <p className="mt-2 text-xs text-amber-300">{error}</p>}
+      </section>
+    )
+  }
+
+  const mayAct = projection?.participant.mayAct === true
+  return (
+    <section
+      className="border-b border-gray-800 bg-gray-950/50 p-4"
+      data-testid="counter-experiment"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-100">
+            {counterTask.surface.title}
+          </h2>
+          <p data-testid="counter-status" className="text-xs text-gray-400">
+            Count:{" "}
+            <span data-testid="counter-value">
+              {projection?.value ?? counterTask.value}
+            </span>
+            {" · "}
+            Revision: {projection?.revision ?? counterTask.revision}
+            {" · "}
+            {projection ? (mayAct ? "your turn" : "waiting") : "loading"}
+          </p>
+        </div>
+        <button
+          type="button"
+          data-testid="counter-increment"
+          className="rounded bg-blue-600 px-3 py-1.5 text-sm text-white disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={busy || !projection || !mayAct}
+          onClick={() => void request("increment")}
+        >
+          {busy ? "Updating…" : counterTask.surface.actions[0].label}
+        </button>
+      </div>
+      {error && (
+        <p className="mt-2 text-xs text-amber-300" role="alert">
+          {error}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router"
 import { LOCAL_PEER_ID } from "@common/consts"
 
 import AgentInviteControl from "./AgentInviteControl"
+import CounterExperiment from "./CounterExperiment"
 import { LiveTranscriptControl, LiveTranscriptSegments } from "./LiveTranscript"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
@@ -152,11 +153,14 @@ export default function RoomContent({
     runtimeConnectionStatus,
     leaveRoom,
     localParticipantId,
+    counterTask,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
   })
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
+  const counterExperimentEnabled =
+    process.env.NEXT_PUBLIC_ROOM_COUNTER_EXPERIMENT === "true"
 
   const toggleAgentVoice = useCallback(
     (participantId: string, enabled: boolean) => {
@@ -647,6 +651,12 @@ export default function RoomContent({
           className="room-panel room-participants-panel flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
+          {counterExperimentEnabled && (
+            <CounterExperiment
+              counterTask={counterTask}
+              auth={getLocalRoomAuth()}
+            />
+          )}
           {/* #111: Agent workspace snapshots — observation only, available in
               every room type; Human screen share is untouched below. */}
           <WorkspaceSnapshots

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -116,6 +116,7 @@ import {
   incrementCounter,
   joinCounter,
   readCounterProjection,
+  type CounterIncrementResult,
   type CounterProjection,
 } from "../room/counterBridge"
 import type {
@@ -1505,6 +1506,17 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
   }
 
+  private clearCounterTaskForHumanDeparture(
+    room: RoomRecord,
+    participant: RoomParticipant
+  ): void {
+    if (
+      participant.kind === "human" &&
+      room.counterTask?.capabilities[participant.id]
+    )
+      delete room.counterTask
+  }
+
   // The sole Room-side media-effect lifecycle. Every caller has already
   // staged the revocation and persisted that authoritative state before it
   // reaches here. This method then has exactly one temporal shape:
@@ -2564,11 +2576,30 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         }
       )
     )
-    const current =
-      projections[task.currentTurnParticipantId ?? ""] ??
-      Object.values(projections)[0]
-    if (current) this.applyCounterProjection(task, current)
     return projections
+  }
+
+  private counterProjectionAfterIncrement(
+    participantId: string,
+    result: CounterIncrementResult,
+    current: CounterProjection
+  ): CounterProjection {
+    const currentTurnParticipantId =
+      result.attention?.participantId ?? participantId
+    return {
+      value: result.value,
+      revision: result.revision,
+      participant: {
+        ...current.participant,
+        participantId,
+        mayAct: currentTurnParticipantId === participantId,
+      },
+      participants: current.participants.map((participant) => ({
+        ...participant,
+        isCurrentTurn: participant.participantId === currentTurnParticipantId,
+      })),
+      currentTurnParticipantId,
+    }
   }
 
   private counterProjectionResponse(
@@ -2610,6 +2641,19 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
         if (joined.projection.participant.participantId !== participant.id)
           return this.json({ error: "invalid_counter_projection" }, 502)
+        // Counter creation/join is external I/O. Never save the RoomRecord
+        // captured before it: a normal Room mutation may have committed while
+        // these requests were in flight.
+        const freshRoom = await this.activeRoom()
+        if (!freshRoom) return this.json({ error: "room_expired" }, 410)
+        const freshParticipant = this.counterParticipant(
+          freshRoom,
+          request.participantId,
+          request.token
+        )
+        if (freshParticipant instanceof Response) return freshParticipant
+        if (freshRoom.counterTask)
+          return this.json({ error: "counter_task_exists" }, 409)
         const task: CounterTaskRecord = {
           taskId: crypto.randomUUID(),
           instanceId,
@@ -2624,16 +2668,16 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           currentTurnParticipantId: joined.projection.currentTurnParticipantId,
           participants: joined.projection.participants,
           capabilities: {
-            [participant.id]: {
-              participantId: participant.id,
-              displayName: participant.name,
+            [freshParticipant.id]: {
+              participantId: freshParticipant.id,
+              displayName: freshParticipant.name,
               accessToken: joined.accessToken,
             },
           },
         }
-        room.counterTask = task
-        await this.saveRoom(room)
-        await this.broadcastState(room)
+        freshRoom.counterTask = task
+        await this.saveRoom(freshRoom)
+        await this.broadcastState(freshRoom)
         return this.counterProjectionResponse(task, joined.projection)
       }
 
@@ -2662,18 +2706,67 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
         if (joined.projection.participant.participantId !== participant.id)
           return this.json({ error: "invalid_counter_projection" }, 502)
-        task.capabilities[participant.id] = {
-          participantId: participant.id,
-          displayName: participant.name,
+        // The join response and every projection refresh are external I/O.
+        // Work on an in-memory candidate only, then reload again before the
+        // authoritative Room save.
+        const afterJoinRoom = await this.activeRoom()
+        if (!afterJoinRoom) return this.json({ error: "room_expired" }, 410)
+        const afterJoinParticipant = this.counterParticipant(
+          afterJoinRoom,
+          request.participantId,
+          request.token
+        )
+        if (afterJoinParticipant instanceof Response)
+          return afterJoinParticipant
+        const afterJoinTask = afterJoinRoom.counterTask
+        if (!afterJoinTask || afterJoinTask.taskId !== task.taskId)
+          return this.json({ error: "counter_task_changed" }, 409)
+        if (afterJoinTask.capabilities[participant.id])
+          return this.json({ error: "counter_already_joined" }, 409)
+        if (
+          Object.keys(afterJoinTask.capabilities).length >=
+          MAX_COUNTER_PARTICIPANTS
+        )
+          return this.json({ error: "counter_task_full" }, 409)
+        const joinedCapability = {
+          participantId: afterJoinParticipant.id,
+          displayName: afterJoinParticipant.name,
           accessToken: joined.accessToken,
         }
-        this.applyCounterProjection(task, joined.projection)
-        const projections = await this.refreshCounterProjections(task)
+        const candidateTask: CounterTaskRecord = {
+          ...afterJoinTask,
+          capabilities: {
+            ...afterJoinTask.capabilities,
+            [afterJoinParticipant.id]: joinedCapability,
+          },
+        }
+        const projections = await this.refreshCounterProjections(candidateTask)
         const callerProjection =
           projections[participant.id] ?? joined.projection
-        await this.saveRoom(room)
-        await this.broadcastState(room)
-        return this.counterProjectionResponse(task, callerProjection)
+        const sharedProjection =
+          Object.values(projections)[0] ?? joined.projection
+        const freshRoom = await this.activeRoom()
+        if (!freshRoom) return this.json({ error: "room_expired" }, 410)
+        const freshParticipant = this.counterParticipant(
+          freshRoom,
+          request.participantId,
+          request.token
+        )
+        if (freshParticipant instanceof Response) return freshParticipant
+        const freshTask = freshRoom.counterTask
+        if (!freshTask || freshTask.taskId !== task.taskId)
+          return this.json({ error: "counter_task_changed" }, 409)
+        if (freshTask.capabilities[freshParticipant.id])
+          return this.json({ error: "counter_already_joined" }, 409)
+        if (
+          Object.keys(freshTask.capabilities).length >= MAX_COUNTER_PARTICIPANTS
+        )
+          return this.json({ error: "counter_task_full" }, 409)
+        freshTask.capabilities[freshParticipant.id] = joinedCapability
+        this.applyCounterProjection(freshTask, sharedProjection)
+        await this.saveRoom(freshRoom)
+        await this.broadcastState(freshRoom)
+        return this.counterProjectionResponse(freshTask, callerProjection)
       }
 
       if (!existingCapability)
@@ -2697,26 +2790,79 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
       if (current.participant.participantId !== participant.id)
         return this.json({ error: "invalid_counter_projection" }, 502)
+      // The pre-action projection read is external I/O too. Re-load and
+      // re-authenticate before issuing the committed increment so this
+      // request never relies on a stale Room binding after that await.
+      const beforeIncrementRoom = await this.activeRoom()
+      if (!beforeIncrementRoom) return this.json({ error: "room_expired" }, 410)
+      const beforeIncrementParticipant = this.counterParticipant(
+        beforeIncrementRoom,
+        request.participantId,
+        request.token
+      )
+      if (beforeIncrementParticipant instanceof Response)
+        return beforeIncrementParticipant
+      const beforeIncrementTask = beforeIncrementRoom.counterTask
+      const beforeIncrementCapability =
+        beforeIncrementTask?.capabilities[beforeIncrementParticipant.id]
+      if (
+        !beforeIncrementTask ||
+        beforeIncrementTask.taskId !== task.taskId ||
+        beforeIncrementTask.instanceId !== task.instanceId ||
+        !beforeIncrementCapability ||
+        beforeIncrementCapability.accessToken !== existingCapability.accessToken
+      )
+        return this.json({ error: "counter_task_changed" }, 409)
       const result = await incrementCounter(
         baseUrl,
-        task.instanceId,
-        existingCapability.accessToken,
+        beforeIncrementTask.instanceId,
+        beforeIncrementCapability.accessToken,
         crypto.randomUUID(),
         current.revision
       )
-      const projections = await this.refreshCounterProjections(task)
-      const callerProjection = projections[participant.id]
-      if (!callerProjection) {
-        task.value = result.value
-        task.revision = result.revision
-      }
-      await this.saveRoom(room)
-      await this.broadcastState(room)
-      return this.json({
-        taskId: task.taskId,
-        surface: task.surface,
+      // The increment is committed externally. Projection reads are
+      // observation-only and may all fail, so derive a post-action fallback
+      // from the bounded Counter result rather than returning `current`.
+      const projections = await this.refreshCounterProjections(
+        beforeIncrementTask
+      )
+      const fallbackProjection = this.counterProjectionAfterIncrement(
+        beforeIncrementParticipant.id,
         result,
-        projection: callerProjection ?? current,
+        current
+      )
+      const callerProjection = projections[participant.id] ?? fallbackProjection
+      const sharedProjection =
+        Object.values(projections)[0] ?? fallbackProjection
+
+      // Do not save the pre-fetch RoomRecord. Re-authenticate the participant
+      // and task against the newest Room snapshot, then merge only the
+      // Counter-owned result into it.
+      const freshRoom = await this.activeRoom()
+      if (!freshRoom) return this.json({ error: "room_expired" }, 410)
+      const freshParticipant = this.counterParticipant(
+        freshRoom,
+        request.participantId,
+        request.token
+      )
+      if (freshParticipant instanceof Response) return freshParticipant
+      const freshTask = freshRoom.counterTask
+      if (
+        !freshTask ||
+        freshTask.taskId !== beforeIncrementTask.taskId ||
+        freshTask.instanceId !== beforeIncrementTask.instanceId ||
+        freshTask.capabilities[freshParticipant.id]?.accessToken !==
+          beforeIncrementCapability.accessToken
+      )
+        return this.json({ error: "counter_task_changed" }, 409)
+      this.applyCounterProjection(freshTask, sharedProjection)
+      await this.saveRoom(freshRoom)
+      await this.broadcastState(freshRoom)
+      return this.json({
+        taskId: freshTask.taskId,
+        surface: freshTask.surface,
+        result,
+        projection: callerProjection,
       })
     } catch (error) {
       return this.counterFailure(error)
@@ -4469,6 +4615,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       this.expirePermissionRequests(room, Date.now(), participant.id)
     if (participant.kind === "human")
       this.removeRuntimeHostProviderAuthorizationForHuman(room, participant.id)
+    this.clearCounterTaskForHumanDeparture(room, participant)
     delete room.participants[participant.id]
     this.garbageCollectRuntimeHostAuthorization(room)
     const pendingDuration = this.updateCollaborationActivity(room)
@@ -4999,6 +5146,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
         this.stageLiveTranscriptMediaRevocation(room)
       this.removeRuntimeHostProviderAuthorizationForHuman(room, participant.id)
+      this.clearCounterTaskForHumanDeparture(room, participant)
       delete room.participants[participant.id]
       this.garbageCollectRuntimeHostAuthorization(room)
       const pendingDuration = this.updateCollaborationActivity(room)
@@ -5734,6 +5882,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           })
         if (expiredHuman)
           this.removeRuntimeHostProviderAuthorizationForHuman(room, id)
+        if (expiredHuman)
+          this.clearCounterTaskForHumanDeparture(room, participant)
         if (expiredAgent && this.expirePermissionRequests(room, now, id)) {
           permissionExpired = true
           changed = true

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -340,6 +340,10 @@ function normalizeStoredCounterTask(value: unknown): {
     !Number.isSafeInteger(candidate.value) ||
     typeof candidate.revision !== "number" ||
     !Number.isSafeInteger(candidate.revision) ||
+    (candidate.pendingJoinParticipantId !== undefined &&
+      (typeof candidate.pendingJoinParticipantId !== "string" ||
+        candidate.pendingJoinParticipantId.length === 0 ||
+        candidate.pendingJoinParticipantId.length > 80)) ||
     !(
       candidate.currentTurnParticipantId === null ||
       typeof candidate.currentTurnParticipantId === "string"
@@ -397,6 +401,7 @@ function normalizeStoredCounterTask(value: unknown): {
     task: {
       taskId: candidate.taskId,
       instanceId: candidate.instanceId,
+      pendingJoinParticipantId: candidate.pendingJoinParticipantId,
       surface: {
         kind: "counter",
         version: 1,
@@ -1359,6 +1364,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     if (!task) return undefined
     const {
       instanceId: _instanceId,
+      pendingJoinParticipantId: _pendingJoinParticipantId,
       capabilities: _capabilities,
       ...publicTask
     } = task
@@ -1512,7 +1518,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   ): void {
     if (
       participant.kind === "human" &&
-      room.counterTask?.capabilities[participant.id]
+      (room.counterTask?.capabilities[participant.id] ||
+        room.counterTask?.pendingJoinParticipantId === participant.id)
     )
       delete room.counterTask
   }
@@ -2579,6 +2586,28 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return projections
   }
 
+  private async clearCounterJoinReservation(
+    taskId: string,
+    participantId: string
+  ): Promise<void> {
+    try {
+      const freshRoom = await this.activeRoom()
+      const task = freshRoom?.counterTask
+      if (
+        !freshRoom ||
+        !task ||
+        task.taskId !== taskId ||
+        task.pendingJoinParticipantId !== participantId
+      )
+        return
+      delete task.pendingJoinParticipantId
+      await this.saveRoom(freshRoom)
+    } catch {
+      // The original Counter failure is authoritative for the caller. A
+      // cleanup failure must not turn it into a different response.
+    }
+  }
+
   private counterProjectionAfterIncrement(
     participantId: string,
     result: CounterIncrementResult,
@@ -2627,6 +2656,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     )
     if (participant instanceof Response) return participant
     const baseUrl = this.env.COUNTER_BASE_URL ?? ""
+    let joinReservation: { taskId: string; participantId: string } | undefined
 
     try {
       if (request.action === "counter-start") {
@@ -2696,16 +2726,46 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             return this.json({ error: "invalid_counter_projection" }, 502)
           return this.counterProjectionResponse(task, projection)
         }
-        if (Object.keys(task.capabilities).length >= MAX_COUNTER_PARTICIPANTS)
+        // Re-load immediately before reserving. The reservation is durable
+        // Room state, so a concurrent join sees it and is rejected before it
+        // can reach the external Counter.
+        const reservationRoom = await this.activeRoom()
+        if (!reservationRoom) return this.json({ error: "room_expired" }, 410)
+        const reservationParticipant = this.counterParticipant(
+          reservationRoom,
+          request.participantId,
+          request.token
+        )
+        if (reservationParticipant instanceof Response)
+          return reservationParticipant
+        const reservationTask = reservationRoom.counterTask
+        if (!reservationTask || reservationTask.taskId !== task.taskId)
+          return this.json({ error: "counter_task_changed" }, 409)
+        if (reservationTask.pendingJoinParticipantId)
+          return this.json({ error: "counter_join_pending" }, 409)
+        if (
+          Object.keys(reservationTask.capabilities).length >=
+          MAX_COUNTER_PARTICIPANTS
+        )
           return this.json({ error: "counter_task_full" }, 409)
+        reservationTask.pendingJoinParticipantId = reservationParticipant.id
+        await this.saveRoom(reservationRoom)
+        joinReservation = {
+          taskId: reservationTask.taskId,
+          participantId: reservationParticipant.id,
+        }
         const joined = await joinCounter(
           baseUrl,
-          task.instanceId,
-          participant.id,
-          participant.name
+          reservationTask.instanceId,
+          reservationParticipant.id,
+          reservationParticipant.name
         )
         if (joined.projection.participant.participantId !== participant.id)
-          return this.json({ error: "invalid_counter_projection" }, 502)
+          throw new CounterBridgeError(
+            502,
+            "invalid_counter_projection",
+            "Counter projection is invalid"
+          )
         // The join response and every projection refresh are external I/O.
         // Work on an in-memory candidate only, then reload again before the
         // authoritative Room save.
@@ -2721,6 +2781,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         const afterJoinTask = afterJoinRoom.counterTask
         if (!afterJoinTask || afterJoinTask.taskId !== task.taskId)
           return this.json({ error: "counter_task_changed" }, 409)
+        if (afterJoinTask.pendingJoinParticipantId !== afterJoinParticipant.id)
+          return this.json({ error: "counter_join_changed" }, 409)
         if (afterJoinTask.capabilities[participant.id])
           return this.json({ error: "counter_already_joined" }, 409)
         if (
@@ -2756,6 +2818,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         const freshTask = freshRoom.counterTask
         if (!freshTask || freshTask.taskId !== task.taskId)
           return this.json({ error: "counter_task_changed" }, 409)
+        if (freshTask.pendingJoinParticipantId !== freshParticipant.id)
+          return this.json({ error: "counter_join_changed" }, 409)
         if (freshTask.capabilities[freshParticipant.id])
           return this.json({ error: "counter_already_joined" }, 409)
         if (
@@ -2763,6 +2827,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
           return this.json({ error: "counter_task_full" }, 409)
         freshTask.capabilities[freshParticipant.id] = joinedCapability
+        delete freshTask.pendingJoinParticipantId
         this.applyCounterProjection(freshTask, sharedProjection)
         await this.saveRoom(freshRoom)
         await this.broadcastState(freshRoom)
@@ -2865,6 +2930,11 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         projection: callerProjection,
       })
     } catch (error) {
+      if (joinReservation)
+        await this.clearCounterJoinReservation(
+          joinReservation.taskId,
+          joinReservation.participantId
+        )
       return this.counterFailure(error)
     }
   }

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -110,6 +110,14 @@ import {
   hashRuntimeProviderHandle,
   isRuntimeProviderClaimHash,
 } from "../common/runtimeProviderCredential"
+import {
+  CounterBridgeError,
+  createCounterInstance,
+  incrementCounter,
+  joinCounter,
+  readCounterProjection,
+  type CounterProjection,
+} from "../room/counterBridge"
 import type {
   AgentCapabilities,
   AgentEvent,
@@ -130,6 +138,8 @@ import type {
   PermissionEvent,
   PermissionRequestRecord,
   RuntimeHostProjection,
+  CounterTaskRecord,
+  CounterTaskPublic,
 } from "../room/types"
 
 const RECONNECT_GRACE_MS = 30 * 1000
@@ -140,6 +150,7 @@ const MAX_AGENT_ATTACHMENT_BYTES = 768 * 1024
 const ATTACHMENT_CHUNK_SIZE = 64 * 1024
 const MAX_TARGETS = 8
 const MAX_PENDING_PERMISSION_REQUESTS = 32
+const MAX_COUNTER_PARTICIPANTS = 2
 // The resident event stream is intentionally one bounded frame. The 2 MiB
 // cap covers the retained 100-message/8-attachment event window (including
 // worst-case UTF-8 text), plus JSON, roster, and Runtime Host overhead; the
@@ -229,6 +240,9 @@ export interface RoomSessionEnv {
   SFU_APP_ID?: string
   SFU_APP_SECRET?: string
   AGENT_MEDIA_ENABLED?: string
+  // Explicit local-only bridge gate and external Counter authority URL.
+  ROOM_COUNTER_EXPERIMENT?: string
+  COUNTER_BASE_URL?: string
   // #228: preconfigured production Worker secret for Room-authoritative
   // collaboration analytics (direct Mixpanel /import). Absent in
   // local/test environments: analytics safely no-ops.
@@ -289,6 +303,118 @@ interface StoredRoom
   runtimeHostProviders?: unknown
   runtimeHostProviderClaims?: unknown
   permissionRequests?: unknown
+}
+
+function normalizeStoredCounterTask(value: unknown): {
+  task?: CounterTaskRecord
+  changed: boolean
+} {
+  if (value === undefined) return { changed: false }
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return { changed: true }
+  const candidate = value as Partial<CounterTaskRecord>
+  const surface = candidate.surface
+  const actions = surface?.actions
+  if (
+    typeof candidate.taskId !== "string" ||
+    candidate.taskId.length === 0 ||
+    candidate.taskId.length > 128 ||
+    typeof candidate.instanceId !== "string" ||
+    candidate.instanceId.length === 0 ||
+    candidate.instanceId.length > 128 ||
+    !surface ||
+    surface.kind !== "counter" ||
+    surface.version !== 1 ||
+    typeof surface.title !== "string" ||
+    surface.title.length === 0 ||
+    surface.title.length > 120 ||
+    !Array.isArray(actions) ||
+    actions.length !== 1 ||
+    actions[0]?.id !== "increment" ||
+    actions[0]?.name !== "increment" ||
+    typeof actions[0]?.label !== "string" ||
+    actions[0].label.length === 0 ||
+    actions[0].label.length > 32 ||
+    typeof candidate.value !== "number" ||
+    !Number.isSafeInteger(candidate.value) ||
+    typeof candidate.revision !== "number" ||
+    !Number.isSafeInteger(candidate.revision) ||
+    !(
+      candidate.currentTurnParticipantId === null ||
+      typeof candidate.currentTurnParticipantId === "string"
+    ) ||
+    !Array.isArray(candidate.participants) ||
+    candidate.participants.length > MAX_COUNTER_PARTICIPANTS ||
+    !candidate.participants.every(
+      (participant) =>
+        participant &&
+        typeof participant.participantId === "string" &&
+        participant.participantId.length > 0 &&
+        participant.participantId.length <= 80 &&
+        typeof participant.displayName === "string" &&
+        typeof participant.isCurrentTurn === "boolean"
+    ) ||
+    !candidate.capabilities ||
+    typeof candidate.capabilities !== "object" ||
+    Array.isArray(candidate.capabilities)
+  )
+    return { changed: true }
+
+  const capabilities: CounterTaskRecord["capabilities"] = {}
+  for (const [participantId, rawCapability] of Object.entries(
+    candidate.capabilities
+  )) {
+    if (
+      Object.keys(capabilities).length >= MAX_COUNTER_PARTICIPANTS ||
+      !rawCapability ||
+      typeof rawCapability !== "object" ||
+      rawCapability.participantId !== participantId ||
+      typeof rawCapability.displayName !== "string" ||
+      typeof rawCapability.accessToken !== "string" ||
+      rawCapability.accessToken.length === 0
+    )
+      return { changed: true }
+    capabilities[participantId] = {
+      participantId,
+      displayName: rawCapability.displayName,
+      accessToken: rawCapability.accessToken,
+    }
+  }
+  const participantIds = new Set(
+    candidate.participants.map((participant) => participant.participantId)
+  )
+  if (
+    Object.keys(capabilities).length !== candidate.participants.length ||
+    Object.keys(capabilities).some(
+      (participantId) => !participantIds.has(participantId)
+    )
+  )
+    return { changed: true }
+
+  return {
+    changed: false,
+    task: {
+      taskId: candidate.taskId,
+      instanceId: candidate.instanceId,
+      surface: {
+        kind: "counter",
+        version: 1,
+        title: surface.title,
+        actions: [
+          { id: "increment", name: "increment", label: actions[0].label },
+        ],
+      },
+      value: candidate.value,
+      revision: candidate.revision,
+      currentTurnParticipantId: candidate.currentTurnParticipantId,
+      participants: candidate.participants.map((participant) => ({
+        participantId: participant.participantId,
+        displayName: participant.displayName,
+        isCurrentTurn: participant.isCurrentTurn,
+      })),
+      capabilities,
+    },
+  }
 }
 
 interface StoredLiveTranscript {
@@ -387,6 +513,26 @@ type ControlRequest =
       token: string
     }
   | { action: "room-info"; participantId?: string }
+  | {
+      action: "counter-start"
+      participantId: string
+      token: string
+    }
+  | {
+      action: "counter-join"
+      participantId: string
+      token: string
+    }
+  | {
+      action: "counter-state"
+      participantId: string
+      token: string
+    }
+  | {
+      action: "counter-increment"
+      participantId: string
+      token: string
+    }
   | {
       action: "agent-register"
       // #176 Phase A wire shape: the Runtime Host arrives as a full
@@ -968,6 +1114,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       changed = true
     }
 
+    const normalizedCounterTask = normalizeStoredCounterTask(stored.counterTask)
+    if (normalizedCounterTask.changed) changed = true
+
     // #170 migration deliberately ignores every legacy singleton
     // voiceReply as authorization. Before dropping that state, however,
     // durable-stage its known outbound mid: an established Cloudflare track
@@ -1057,6 +1206,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         meetingNotes,
         agentVoice,
         pendingMediaCleanup,
+        counterTask: normalizedCounterTask.task,
       },
       changed,
     }
@@ -1202,6 +1352,18 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }))
   }
 
+  private counterTaskPublic(
+    task: CounterTaskRecord | undefined
+  ): CounterTaskPublic | undefined {
+    if (!task) return undefined
+    const {
+      instanceId: _instanceId,
+      capabilities: _capabilities,
+      ...publicTask
+    } = task
+    return publicTask
+  }
+
   private stateFor(room: RoomRecord): RoomState {
     return {
       createdAt: room.createdAt,
@@ -1245,6 +1407,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       meetingNotesMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
       agentVoice: room.agentVoice,
       agentVoiceMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+      counterTask: this.counterTaskPublic(room.counterTask),
     }
   }
 
@@ -2346,7 +2509,225 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     })
   }
 
+  private counterFailure(error: unknown): Response {
+    if (error instanceof CounterBridgeError)
+      return this.json({ error: error.code }, error.status)
+    return this.json({ error: "counter_unavailable" }, 503)
+  }
+
+  private counterParticipant(
+    room: RoomRecord,
+    participantId: string,
+    token: string
+  ): RoomParticipant | Response {
+    const participant = this.findParticipant(room, participantId, token)
+    if (!participant) return this.json({ error: "unauthorized" }, 401)
+    if (participant.kind !== "human")
+      return this.json({ error: "human_only" }, 403)
+    return participant
+  }
+
+  private applyCounterProjection(
+    task: CounterTaskRecord,
+    projection: CounterProjection
+  ): void {
+    task.value = projection.value
+    task.revision = projection.revision
+    task.currentTurnParticipantId = projection.currentTurnParticipantId
+    task.participants = projection.participants.map((participant) => ({
+      participantId: participant.participantId,
+      displayName: participant.displayName,
+      isCurrentTurn: participant.isCurrentTurn,
+    }))
+  }
+
+  private async refreshCounterProjections(
+    task: CounterTaskRecord
+  ): Promise<Record<string, CounterProjection>> {
+    const projections: Record<string, CounterProjection> = {}
+    await Promise.all(
+      Object.entries(task.capabilities).map(
+        async ([participantId, capability]) => {
+          try {
+            const projection = await readCounterProjection(
+              this.env.COUNTER_BASE_URL ?? "",
+              task.instanceId,
+              capability.accessToken
+            )
+            if (projection.participant.participantId === participantId)
+              projections[participantId] = projection
+          } catch {
+            // A participant refresh is observation-only. The committed Counter
+            // action remains authoritative even if another refresh is transiently
+            // unavailable; the caller's projection is preferred below.
+          }
+        }
+      )
+    )
+    const current =
+      projections[task.currentTurnParticipantId ?? ""] ??
+      Object.values(projections)[0]
+    if (current) this.applyCounterProjection(task, current)
+    return projections
+  }
+
+  private counterProjectionResponse(
+    task: CounterTaskRecord,
+    projection: CounterProjection
+  ): Response {
+    return this.json({
+      taskId: task.taskId,
+      surface: task.surface,
+      projection,
+    })
+  }
+
+  private async handleCounterControl(
+    request: Extract<ControlRequest, { action: `counter-${string}` }>
+  ): Promise<Response> {
+    if (this.env.ROOM_COUNTER_EXPERIMENT !== "true")
+      return this.json({ error: "experiment_disabled" }, 404)
+    const room = await this.activeRoom()
+    if (!room) return this.json({ error: "room_expired" }, 410)
+    const participant = this.counterParticipant(
+      room,
+      request.participantId,
+      request.token
+    )
+    if (participant instanceof Response) return participant
+    const baseUrl = this.env.COUNTER_BASE_URL ?? ""
+
+    try {
+      if (request.action === "counter-start") {
+        if (room.counterTask)
+          return this.json({ error: "counter_task_exists" }, 409)
+        const instanceId = await createCounterInstance(baseUrl)
+        const joined = await joinCounter(
+          baseUrl,
+          instanceId,
+          participant.id,
+          participant.name
+        )
+        if (joined.projection.participant.participantId !== participant.id)
+          return this.json({ error: "invalid_counter_projection" }, 502)
+        const task: CounterTaskRecord = {
+          taskId: crypto.randomUUID(),
+          instanceId,
+          surface: {
+            kind: "counter",
+            version: 1,
+            title: "Shared Counter",
+            actions: [{ id: "increment", name: "increment", label: "+1" }],
+          },
+          value: joined.projection.value,
+          revision: joined.projection.revision,
+          currentTurnParticipantId: joined.projection.currentTurnParticipantId,
+          participants: joined.projection.participants,
+          capabilities: {
+            [participant.id]: {
+              participantId: participant.id,
+              displayName: participant.name,
+              accessToken: joined.accessToken,
+            },
+          },
+        }
+        room.counterTask = task
+        await this.saveRoom(room)
+        await this.broadcastState(room)
+        return this.counterProjectionResponse(task, joined.projection)
+      }
+
+      const task = room.counterTask
+      if (!task) return this.json({ error: "counter_task_missing" }, 404)
+      const existingCapability = task.capabilities[participant.id]
+
+      if (request.action === "counter-join") {
+        if (existingCapability) {
+          const projection = await readCounterProjection(
+            baseUrl,
+            task.instanceId,
+            existingCapability.accessToken
+          )
+          if (projection.participant.participantId !== participant.id)
+            return this.json({ error: "invalid_counter_projection" }, 502)
+          return this.counterProjectionResponse(task, projection)
+        }
+        if (Object.keys(task.capabilities).length >= MAX_COUNTER_PARTICIPANTS)
+          return this.json({ error: "counter_task_full" }, 409)
+        const joined = await joinCounter(
+          baseUrl,
+          task.instanceId,
+          participant.id,
+          participant.name
+        )
+        if (joined.projection.participant.participantId !== participant.id)
+          return this.json({ error: "invalid_counter_projection" }, 502)
+        task.capabilities[participant.id] = {
+          participantId: participant.id,
+          displayName: participant.name,
+          accessToken: joined.accessToken,
+        }
+        this.applyCounterProjection(task, joined.projection)
+        const projections = await this.refreshCounterProjections(task)
+        const callerProjection =
+          projections[participant.id] ?? joined.projection
+        await this.saveRoom(room)
+        await this.broadcastState(room)
+        return this.counterProjectionResponse(task, callerProjection)
+      }
+
+      if (!existingCapability)
+        return this.json({ error: "counter_not_joined" }, 403)
+
+      if (request.action === "counter-state") {
+        const projection = await readCounterProjection(
+          baseUrl,
+          task.instanceId,
+          existingCapability.accessToken
+        )
+        if (projection.participant.participantId !== participant.id)
+          return this.json({ error: "invalid_counter_projection" }, 502)
+        return this.counterProjectionResponse(task, projection)
+      }
+
+      const current = await readCounterProjection(
+        baseUrl,
+        task.instanceId,
+        existingCapability.accessToken
+      )
+      if (current.participant.participantId !== participant.id)
+        return this.json({ error: "invalid_counter_projection" }, 502)
+      const result = await incrementCounter(
+        baseUrl,
+        task.instanceId,
+        existingCapability.accessToken,
+        crypto.randomUUID(),
+        current.revision
+      )
+      const projections = await this.refreshCounterProjections(task)
+      const callerProjection = projections[participant.id]
+      if (!callerProjection) {
+        task.value = result.value
+        task.revision = result.revision
+      }
+      await this.saveRoom(room)
+      await this.broadcastState(room)
+      return this.json({
+        taskId: task.taskId,
+        surface: task.surface,
+        result,
+        projection: callerProjection ?? current,
+      })
+    } catch (error) {
+      return this.counterFailure(error)
+    }
+  }
+
   private async handleControl(request: ControlRequest): Promise<Response> {
+    if (request.action.startsWith("counter-"))
+      return this.handleCounterControl(
+        request as Extract<ControlRequest, { action: `counter-${string}` }>
+      )
     if (request.action === "room-info") {
       const room = await this.activeRoom()
       return this.json({

--- a/app/src/do/roomSessionCounterExperiment.test.ts
+++ b/app/src/do/roomSessionCounterExperiment.test.ts
@@ -16,6 +16,9 @@ type DomainState = {
 type SessionOptions = {
   deferFirstJoin?: Promise<void>
   onFirstJoinStarted?: () => void
+  deferJoinParticipantId?: string
+  onJoinStarted?: (participantId: string) => void
+  failNextJoinParticipantId?: string
   failStateReadsAfterIncrement?: boolean
 }
 
@@ -140,13 +143,21 @@ function makeSession(options: SessionOptions = {}) {
       const path = match[2]
       if (path === "/join") {
         joinCalls += 1
-        if (joinCalls === 1) {
-          options.onFirstJoinStarted?.()
-          if (options.deferFirstJoin) await options.deferFirstJoin
-        }
         const body = JSON.parse(String(init?.body)) as {
           participantId: string
           displayName: string
+        }
+        options.onJoinStarted?.(body.participantId)
+        if (joinCalls === 1) options.onFirstJoinStarted?.()
+        if (
+          options.deferFirstJoin &&
+          (options.deferJoinParticipantId === undefined ||
+            options.deferJoinParticipantId === body.participantId)
+        )
+          await options.deferFirstJoin
+        if (options.failNextJoinParticipantId === body.participantId) {
+          options.failNextJoinParticipantId = undefined
+          return Response.json({ code: "counter_unavailable" }, { status: 503 })
         }
         const accessToken = `domain-token-${body.participantId}`
         domain.tokens[body.participantId] = accessToken
@@ -412,6 +423,90 @@ describe("RoomSession Counter bridge experiment", () => {
     }
     expect(room.participants["room-b"]).toBeDefined()
     expect(room.counterTask?.instanceId).toBe("counter-instance")
+  })
+
+  it("reserves the second slot before concurrent joins reach Counter", async () => {
+    let releaseBJoin!: () => void
+    let signalBJoin!: () => void
+    const bJoinStarted = new Promise<void>((resolve) => {
+      signalBJoin = resolve
+    })
+    const bJoinGate = new Promise<void>((resolve) => {
+      releaseBJoin = resolve
+    })
+    const { store, domain, calls, control } = makeSession({
+      deferFirstJoin: bJoinGate,
+      deferJoinParticipantId: "room-b",
+      onJoinStarted: (participantId) => {
+        if (participantId === "room-b") signalBJoin()
+      },
+    })
+
+    expect((await startCounter(control)).response.status).toBe(200)
+    expect((await registerHuman(control, "room-b", "B")).response.status).toBe(
+      200
+    )
+    expect((await registerHuman(control, "room-c", "C")).response.status).toBe(
+      200
+    )
+
+    const bJoinPromise = joinCounterAsB(control)
+    await bJoinStarted
+    const rejectedC = await control({
+      action: "counter-join",
+      participantId: "room-c",
+      token: "room-token-c",
+    })
+    expect(rejectedC.response.status).toBe(409)
+    expect(rejectedC.json.error).toBe("counter_join_pending")
+
+    releaseBJoin()
+    const joinedB = await bJoinPromise
+    expect(joinedB.response.status).toBe(200)
+
+    const room = store.get("room") as {
+      participants: Record<string, unknown>
+      counterTask: {
+        pendingJoinParticipantId?: string
+        capabilities: Record<string, unknown>
+      }
+    }
+    expect(Object.keys(room.participants)).toHaveLength(3)
+    expect(Object.keys(room.counterTask.capabilities)).toEqual([
+      "room-a",
+      "room-b",
+    ])
+    expect(room.counterTask.pendingJoinParticipantId).toBeUndefined()
+    expect(Object.keys(domain.participants)).toEqual(["room-a", "room-b"])
+    expect(
+      calls
+        .filter((call) => call.url.endsWith("/join"))
+        .map(
+          (call) =>
+            (JSON.parse(String(call.init.body)) as { participantId: string })
+              .participantId
+        )
+    ).toEqual(["room-a", "room-b"])
+    expect(domain.currentTurnParticipantId).not.toBe("room-c")
+  })
+
+  it("clears a failed pre-commit join reservation", async () => {
+    const { store, control } = makeSession({
+      failNextJoinParticipantId: "room-b",
+    })
+    expect((await startCounter(control)).response.status).toBe(200)
+    expect((await registerHuman(control)).response.status).toBe(200)
+
+    const failed = await joinCounterAsB(control)
+    expect(failed.response.status).toBe(503)
+    expect(
+      (
+        store.get("room") as {
+          counterTask: { pendingJoinParticipantId?: string }
+        }
+      ).counterTask.pendingJoinParticipantId
+    ).toBeUndefined()
+    expect((await joinCounterAsB(control)).response.status).toBe(200)
   })
 
   it("clears the Counter task when an attached Human explicitly leaves", async () => {

--- a/app/src/do/roomSessionCounterExperiment.test.ts
+++ b/app/src/do/roomSessionCounterExperiment.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+
+const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
+
+type DomainState = {
+  instanceId: string
+  value: number
+  revision: number
+  currentTurnParticipantId: string | null
+  participants: Record<string, { participantId: string; displayName: string }>
+  tokens: Record<string, string>
+}
+
+function projection(state: DomainState, participantId: string) {
+  const participant = state.participants[participantId]
+  return {
+    instanceId: state.instanceId,
+    value: state.value,
+    revision: state.revision,
+    participant: {
+      participantId,
+      displayName: participant.displayName,
+      mayAct: state.currentTurnParticipantId === participantId,
+    },
+    participants: Object.values(state.participants).map((entry) => ({
+      participantId: entry.participantId,
+      displayName: entry.displayName,
+      isCurrentTurn: entry.participantId === state.currentTurnParticipantId,
+    })),
+    currentTurnParticipantId: state.currentTurnParticipantId,
+  }
+}
+
+function makeStoredRoom() {
+  return {
+    createdAt: Date.now(),
+    expiresAt: FAR_FUTURE,
+    participants: {
+      "room-a": {
+        id: "room-a",
+        name: "A",
+        kind: "human",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "room-token-a",
+        media: {
+          sessionId: "session-a",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+      },
+    },
+    messages: [],
+    nextMessageSequence: 0,
+    meetingNotes: { active: false },
+    agentVoice: {},
+    liveTranscript: { active: false },
+    pendingMediaCleanup: [],
+  }
+}
+
+function makeSession() {
+  const store = new Map<string, unknown>([["room", makeStoredRoom()]])
+  const domain: DomainState = {
+    instanceId: "counter-instance",
+    value: 0,
+    revision: 0,
+    currentTurnParticipantId: null,
+    participants: {},
+    tokens: {},
+  }
+  const calls: Array<{
+    url: string
+    init: RequestInit
+  }> = []
+  const fetchImpl = vi.fn(
+    async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      calls.push({ url, init: init ?? {} })
+      if (url.endsWith("/counter"))
+        return Response.json({ instanceId: domain.instanceId }, { status: 201 })
+
+      const match = url.match(/\/counter\/([^/]+)(\/.*)$/)
+      if (!match) return Response.json({ code: "not_found" }, { status: 404 })
+      const path = match[2]
+      if (path === "/join") {
+        const body = JSON.parse(String(init?.body)) as {
+          participantId: string
+          displayName: string
+        }
+        const accessToken = `domain-token-${body.participantId}`
+        domain.tokens[body.participantId] = accessToken
+        domain.participants[body.participantId] = {
+          participantId: body.participantId,
+          displayName: body.displayName,
+        }
+        domain.revision += 1
+        domain.currentTurnParticipantId ??= body.participantId
+        return Response.json(
+          {
+            accessToken,
+            projection: projection(domain, body.participantId),
+          },
+          { status: 201 }
+        )
+      }
+      const authorization = new Headers(init?.headers).get("Authorization")
+      const participantId = Object.entries(domain.tokens).find(
+        ([, token]) => authorization === `Bearer ${token}`
+      )?.[0]
+      if (!participantId)
+        return Response.json({ code: "unauthorized" }, { status: 401 })
+      if (path === "/state")
+        return Response.json(projection(domain, participantId))
+      if (path === "/actions/increment") {
+        const body = JSON.parse(String(init?.body)) as {
+          expectedRevision: number
+        }
+        if (domain.currentTurnParticipantId !== participantId)
+          return Response.json({ code: "not_your_turn" }, { status: 403 })
+        if (body.expectedRevision !== domain.revision)
+          return Response.json({ code: "stale_revision" }, { status: 409 })
+        domain.value += 1
+        domain.revision += 1
+        domain.currentTurnParticipantId =
+          Object.keys(domain.participants).find((id) => id !== participantId) ??
+          participantId
+        return Response.json({
+          value: domain.value,
+          revision: domain.revision,
+          participantId,
+          duplicate: false,
+        })
+      }
+      return Response.json({ code: "not_found" }, { status: 404 })
+    }
+  )
+  vi.stubGlobal("fetch", fetchImpl)
+
+  const ctx = {
+    storage: {
+      get: async (key: string) => store.get(key),
+      put: async (key: string, value: unknown) => void store.set(key, value),
+      delete: async (key: string) => void store.delete(key),
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+    getWebSockets: () => [] as WebSocket[],
+    waitUntil: (promise: Promise<unknown>) => void promise,
+    id: { name: "room-counter-test", toString: () => "room-counter-test" },
+  }
+  const session = new RoomSession(
+    ctx as never,
+    {
+      SFU_ROOM: {},
+      ROOM_COUNTER_EXPERIMENT: "true",
+      COUNTER_BASE_URL: "https://counter.test",
+    } as never
+  )
+  const control = async (body: Record<string, unknown>) => {
+    const response = await session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    )
+    return {
+      response,
+      json: (await response.json()) as Record<string, unknown>,
+    }
+  }
+  return { session, store, domain, calls, control }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("RoomSession Counter bridge experiment", () => {
+  it("reuses Room identities, isolates capabilities, and keeps actions off Agent waiters", async () => {
+    const { session, store, domain, calls, control } = makeSession()
+
+    const started = await control({
+      action: "counter-start",
+      participantId: "room-a",
+      token: "room-token-a",
+    })
+    expect(started.response.status).toBe(200)
+    expect(
+      (started.json.projection as { participant: { participantId: string } })
+        .participant.participantId
+    ).toBe("room-a")
+
+    const startedRoom = store.get("room") as {
+      counterTask: Record<string, unknown>
+    }
+    const startedTask = startedRoom.counterTask
+    expect(startedTask.instanceId).toBe("counter-instance")
+    expect(
+      JSON.stringify(
+        (session as any).stateFor(await (session as any).activeRoom())
+      )
+    ).not.toContain("domain-token")
+    expect(
+      JSON.stringify(
+        (session as any).stateFor(await (session as any).activeRoom())
+      )
+    ).not.toContain("room-token")
+
+    const joinedRoomB = await control({
+      action: "register",
+      participant: {
+        id: "room-b",
+        name: "B",
+        kind: "human",
+        joinedAt: Date.now(),
+        token: "room-token-b",
+        media: {
+          sessionId: "session-b",
+          muted: false,
+          fileChannelReady: false,
+          tracks: [],
+        },
+      },
+    })
+    expect(joinedRoomB.response.status).toBe(200)
+
+    const joined = await control({
+      action: "counter-join",
+      participantId: "room-b",
+      token: "room-token-b",
+    })
+    expect(joined.response.status).toBe(200)
+    expect(
+      (joined.json.projection as { participant: { participantId: string } })
+        .participant.participantId
+    ).toBe("room-b")
+    expect(domain.participants).toEqual({
+      "room-a": { participantId: "room-a", displayName: "A" },
+      "room-b": { participantId: "room-b", displayName: "B" },
+    })
+    expect(
+      calls.filter((call) => call.url.endsWith("/join")).map((call) => call.url)
+    ).toEqual([
+      "https://counter.test/counter/counter-instance/join",
+      "https://counter.test/counter/counter-instance/join",
+    ])
+
+    const task = (
+      store.get("room") as {
+        counterTask: { capabilities: Record<string, { accessToken: string }> }
+      }
+    ).counterTask
+    expect(task.capabilities["room-a"]?.accessToken).not.toBe(
+      task.capabilities["room-b"]?.accessToken
+    )
+    expect(
+      JSON.stringify(
+        (session as any).stateFor(await (session as any).activeRoom())
+      )
+    ).not.toContain("domain-token")
+
+    const rejected = await control({
+      action: "counter-increment",
+      participantId: "room-b",
+      token: "room-token-b",
+    })
+    expect(rejected.response.status).toBe(403)
+    expect(domain.value).toBe(0)
+
+    const incrementedByA = await control({
+      action: "counter-increment",
+      participantId: "room-a",
+      token: "room-token-a",
+    })
+    expect(incrementedByA.response.status).toBe(200)
+    expect(domain.value).toBe(1)
+    expect(domain.currentTurnParticipantId).toBe("room-b")
+
+    const incrementedByB = await control({
+      action: "counter-increment",
+      participantId: "room-b",
+      token: "room-token-b",
+    })
+    expect(incrementedByB.response.status).toBe(200)
+    expect(domain.value).toBe(2)
+    expect(domain.currentTurnParticipantId).toBe("room-a")
+
+    const publicState = (session as any).stateFor(
+      await (session as any).activeRoom()
+    ) as {
+      counterTask?: { value: number; revision: number; participants: unknown[] }
+      messages: unknown[]
+    }
+    expect(publicState.counterTask).toMatchObject({ value: 2, revision: 4 })
+    expect(publicState.counterTask?.participants).toHaveLength(2)
+    expect(publicState.messages).toHaveLength(0)
+    expect((session as any).agentWaiters.size).toBe(0)
+
+    const serializedCalls = JSON.stringify(calls)
+    expect(serializedCalls).not.toContain("room-token-a")
+    expect(serializedCalls).not.toContain("room-token-b")
+    expect(
+      calls
+        .filter((call) => call.url.endsWith("/actions/increment"))
+        .map((call) => new Headers(call.init.headers).get("Authorization"))
+    ).toEqual([
+      "Bearer domain-token-room-b",
+      "Bearer domain-token-room-a",
+      "Bearer domain-token-room-b",
+    ])
+  })
+})

--- a/app/src/do/roomSessionCounterExperiment.test.ts
+++ b/app/src/do/roomSessionCounterExperiment.test.ts
@@ -13,6 +13,55 @@ type DomainState = {
   tokens: Record<string, string>
 }
 
+type SessionOptions = {
+  deferFirstJoin?: Promise<void>
+  onFirstJoinStarted?: () => void
+  failStateReadsAfterIncrement?: boolean
+}
+
+type Control = (
+  body: Record<string, unknown>
+) => Promise<{ response: Response; json: Record<string, unknown> }>
+
+function humanParticipant(id: string, name: string) {
+  return {
+    id,
+    name,
+    kind: "human",
+    joinedAt: Date.now(),
+    token: `room-token-${id.slice(-1)}`,
+    media: {
+      sessionId: `session-${id.slice(-1)}`,
+      muted: false,
+      fileChannelReady: false,
+      tracks: [],
+    },
+  }
+}
+
+async function registerHuman(control: Control, id = "room-b", name = "B") {
+  return control({
+    action: "register",
+    participant: humanParticipant(id, name),
+  })
+}
+
+async function startCounter(control: Control) {
+  return control({
+    action: "counter-start",
+    participantId: "room-a",
+    token: "room-token-a",
+  })
+}
+
+async function joinCounterAsB(control: Control) {
+  return control({
+    action: "counter-join",
+    participantId: "room-b",
+    token: "room-token-b",
+  })
+}
+
 function projection(state: DomainState, participantId: string) {
   const participant = state.participants[participantId]
   return {
@@ -63,7 +112,7 @@ function makeStoredRoom() {
   }
 }
 
-function makeSession() {
+function makeSession(options: SessionOptions = {}) {
   const store = new Map<string, unknown>([["room", makeStoredRoom()]])
   const domain: DomainState = {
     instanceId: "counter-instance",
@@ -77,6 +126,8 @@ function makeSession() {
     url: string
     init: RequestInit
   }> = []
+  let joinCalls = 0
+  let incrementCommitted = false
   const fetchImpl = vi.fn(
     async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
@@ -88,6 +139,11 @@ function makeSession() {
       if (!match) return Response.json({ code: "not_found" }, { status: 404 })
       const path = match[2]
       if (path === "/join") {
+        joinCalls += 1
+        if (joinCalls === 1) {
+          options.onFirstJoinStarted?.()
+          if (options.deferFirstJoin) await options.deferFirstJoin
+        }
         const body = JSON.parse(String(init?.body)) as {
           participantId: string
           displayName: string
@@ -114,8 +170,11 @@ function makeSession() {
       )?.[0]
       if (!participantId)
         return Response.json({ code: "unauthorized" }, { status: 401 })
-      if (path === "/state")
+      if (path === "/state") {
+        if (options.failStateReadsAfterIncrement && incrementCommitted)
+          return Response.json({ code: "state_unavailable" }, { status: 503 })
         return Response.json(projection(domain, participantId))
+      }
       if (path === "/actions/increment") {
         const body = JSON.parse(String(init?.body)) as {
           expectedRevision: number
@@ -129,11 +188,19 @@ function makeSession() {
         domain.currentTurnParticipantId =
           Object.keys(domain.participants).find((id) => id !== participantId) ??
           participantId
+        incrementCommitted = true
         return Response.json({
           value: domain.value,
           revision: domain.revision,
           participantId,
           duplicate: false,
+          attention: domain.currentTurnParticipantId
+            ? {
+                type: "your_turn",
+                participantId: domain.currentTurnParticipantId,
+                revision: domain.revision,
+              }
+            : null,
         })
       }
       return Response.json({ code: "not_found" }, { status: 404 })
@@ -314,5 +381,129 @@ describe("RoomSession Counter bridge experiment", () => {
       "Bearer domain-token-room-a",
       "Bearer domain-token-room-b",
     ])
+  })
+
+  it("reloads the Room after slow Counter start I/O", async () => {
+    let releaseFirstJoin!: () => void
+    let signalFirstJoin!: () => void
+    const firstJoinStarted = new Promise<void>((resolve) => {
+      signalFirstJoin = resolve
+    })
+    const firstJoinGate = new Promise<void>((resolve) => {
+      releaseFirstJoin = resolve
+    })
+    const { store, control } = makeSession({
+      onFirstJoinStarted: signalFirstJoin,
+      deferFirstJoin: firstJoinGate,
+    })
+
+    const startPromise = startCounter(control)
+    await firstJoinStarted
+
+    const ordinaryMutation = await registerHuman(control)
+    expect(ordinaryMutation.response.status).toBe(200)
+    releaseFirstJoin()
+
+    const started = await startPromise
+    expect(started.response.status).toBe(200)
+    const room = store.get("room") as {
+      participants: Record<string, unknown>
+      counterTask?: { instanceId: string }
+    }
+    expect(room.participants["room-b"]).toBeDefined()
+    expect(room.counterTask?.instanceId).toBe("counter-instance")
+  })
+
+  it("clears the Counter task when an attached Human explicitly leaves", async () => {
+    const { store, control } = makeSession()
+    expect((await startCounter(control)).response.status).toBe(200)
+    expect((await registerHuman(control)).response.status).toBe(200)
+    expect((await joinCounterAsB(control)).response.status).toBe(200)
+
+    const left = await control({
+      action: "leave",
+      participantId: "room-b",
+      token: "room-token-b",
+    })
+    expect(left.response.status).toBe(200)
+    const room = store.get("room") as {
+      participants: Record<string, unknown>
+      counterTask?: unknown
+      messages: unknown[]
+    }
+    expect(room.counterTask).toBeUndefined()
+    expect(room.participants["room-a"]).toBeDefined()
+    expect(room.participants["room-b"]).toBeUndefined()
+    expect(room.messages).toHaveLength(0)
+  })
+
+  it("keeps Counter during reconnect grace, then clears it on Human expiry", async () => {
+    const { session, store, control } = makeSession()
+    expect((await startCounter(control)).response.status).toBe(200)
+    expect((await registerHuman(control)).response.status).toBe(200)
+    expect((await joinCounterAsB(control)).response.status).toBe(200)
+
+    const room = store.get("room") as {
+      participants: Record<string, { connected: boolean; lastSeenAt: number }>
+      counterTask?: unknown
+    }
+    room.participants["room-b"]!.connected = false
+    room.participants["room-b"]!.lastSeenAt = Date.now()
+    await (session as any).alarm()
+    expect(room.counterTask).toBeDefined()
+    expect(room.participants["room-b"]).toBeDefined()
+
+    room.participants["room-b"]!.lastSeenAt = Date.now() - 31_000
+    await (session as any).alarm()
+    const expiredRoom = store.get("room") as {
+      participants: Record<string, unknown>
+      counterTask?: unknown
+    }
+    expect(expiredRoom.counterTask).toBeUndefined()
+    expect(expiredRoom.participants["room-a"]).toBeDefined()
+    expect(expiredRoom.participants["room-b"]).toBeUndefined()
+  })
+
+  it("returns post-increment turn state when all projection reads fail", async () => {
+    const { store, domain, control } = makeSession({
+      failStateReadsAfterIncrement: true,
+    })
+    expect((await startCounter(control)).response.status).toBe(200)
+    expect((await registerHuman(control)).response.status).toBe(200)
+    expect((await joinCounterAsB(control)).response.status).toBe(200)
+
+    const incremented = await control({
+      action: "counter-increment",
+      participantId: "room-a",
+      token: "room-token-a",
+    })
+    expect(incremented.response.status).toBe(200)
+    expect(incremented.json.result).toMatchObject({ value: 1, revision: 3 })
+    expect(incremented.json.projection).toMatchObject({
+      value: 1,
+      revision: 3,
+      currentTurnParticipantId: "room-b",
+      participant: { participantId: "room-a", mayAct: false },
+    })
+    expect(
+      (
+        incremented.json.projection as {
+          participants: Array<{
+            participantId: string
+            isCurrentTurn: boolean
+          }>
+        }
+      ).participants
+    ).toContainEqual({
+      participantId: "room-b",
+      displayName: "B",
+      isCurrentTurn: true,
+    })
+    expect(domain.currentTurnParticipantId).toBe("room-b")
+    expect((store.get("room") as any).counterTask).toMatchObject({
+      value: 1,
+      revision: 3,
+      currentTurnParticipantId: "room-b",
+    })
   })
 })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -481,6 +481,7 @@ export function useSfuChatRoom(
   const [agentVoice, setAgentVoiceState] = useState<SfuAgentVoiceState>({})
   const [agentVoiceMediaAvailable, setAgentVoiceMediaAvailable] =
     useState(false)
+  const [counterTask, setCounterTask] = useState<SfuRoomState["counterTask"]>()
   const [runtimeConnectionStatus, setRuntimeConnectionStatus] = useState<
     "idle" | "preparing" | "copied"
   >("idle")
@@ -2225,6 +2226,7 @@ export function useSfuChatRoom(
       setLiveTranscriptMediaAvailable(state.meetingNotesMediaAvailable)
       setAgentVoiceState(state.agentVoice)
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
+      setCounterTask(state.counterTask)
       const localParticipantId = sessionRef.current?.participantId
       const currentParticipantIds = new Set(
         state.participants.map((participant) => participant.id)
@@ -3370,5 +3372,6 @@ export function useSfuChatRoom(
     createRuntimeProviderClaim,
     connectLocalRuntime,
     runtimeConnectionStatus,
+    counterTask,
   }
 }

--- a/app/src/room/counterBridge.ts
+++ b/app/src/room/counterBridge.ts
@@ -1,0 +1,285 @@
+export interface CounterParticipantProjection {
+  participantId: string
+  displayName: string
+  mayAct: boolean
+}
+
+export interface CounterProjection {
+  value: number
+  revision: number
+  participant: CounterParticipantProjection
+  participants: Array<{
+    participantId: string
+    displayName: string
+    isCurrentTurn: boolean
+  }>
+  currentTurnParticipantId: string | null
+}
+
+export interface CounterIncrementResult {
+  value: number
+  revision: number
+  participantId: string
+  duplicate: boolean
+}
+
+export class CounterBridgeError extends Error {
+  readonly status: number
+  readonly code: string
+
+  constructor(status: number, code: string, message: string) {
+    super(message)
+    this.name = "CounterBridgeError"
+    this.status = status
+    this.code = code
+  }
+}
+
+interface CounterCreateResponse {
+  instanceId?: unknown
+}
+
+interface CounterJoinResponse {
+  accessToken?: unknown
+  projection?: unknown
+}
+
+interface CounterIncrementResponse {
+  value?: unknown
+  revision?: unknown
+  participantId?: unknown
+  duplicate?: unknown
+}
+
+const PARTICIPANT_ID_PATTERN = /^[a-zA-Z0-9._:-]{1,80}$/
+
+function endpoint(baseUrl: string, path: string): string {
+  const root = baseUrl.trim()
+  if (!root)
+    throw new CounterBridgeError(
+      503,
+      "counter_unconfigured",
+      "Counter is not configured"
+    )
+  return new URL(
+    path.replace(/^\//, ""),
+    `${root.replace(/\/$/, "")}/`
+  ).toString()
+}
+
+async function requestJson<T>(
+  baseUrl: string,
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  let response: Response
+  try {
+    response = await fetch(endpoint(baseUrl, path), {
+      ...init,
+      headers: {
+        Accept: "application/json",
+        ...(init?.headers ?? {}),
+      },
+    })
+  } catch {
+    throw new CounterBridgeError(
+      503,
+      "counter_unavailable",
+      "Counter is unavailable"
+    )
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    code?: unknown
+    message?: unknown
+  } | null
+  if (!response.ok) {
+    const code =
+      typeof payload?.code === "string" ? payload.code : "counter_error"
+    const message =
+      typeof payload?.message === "string"
+        ? payload.message
+        : "Counter request failed"
+    throw new CounterBridgeError(response.status, code, message.slice(0, 160))
+  }
+  return payload as T
+}
+
+function validateParticipantId(participantId: string): void {
+  if (!PARTICIPANT_ID_PATTERN.test(participantId))
+    throw new CounterBridgeError(
+      400,
+      "invalid_participant",
+      "Invalid participant id"
+    )
+}
+
+function validateProjection(value: unknown): CounterProjection {
+  if (!value || typeof value !== "object")
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_projection",
+      "Counter projection is invalid"
+    )
+  const projection = value as Partial<CounterProjection>
+  const participant = projection.participant
+  const participants = projection.participants
+  if (
+    typeof projection.value !== "number" ||
+    !Number.isSafeInteger(projection.value) ||
+    typeof projection.revision !== "number" ||
+    !Number.isSafeInteger(projection.revision) ||
+    !participant ||
+    typeof participant !== "object" ||
+    typeof participant.participantId !== "string" ||
+    typeof participant.displayName !== "string" ||
+    typeof participant.mayAct !== "boolean" ||
+    !Array.isArray(participants) ||
+    !participants.every(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        typeof entry.participantId === "string" &&
+        typeof entry.displayName === "string" &&
+        typeof entry.isCurrentTurn === "boolean"
+    ) ||
+    !(
+      projection.currentTurnParticipantId === null ||
+      typeof projection.currentTurnParticipantId === "string"
+    )
+  )
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_projection",
+      "Counter projection is invalid"
+    )
+
+  return {
+    value: projection.value,
+    revision: projection.revision,
+    participant: {
+      participantId: participant.participantId,
+      displayName: participant.displayName,
+      mayAct: participant.mayAct,
+    },
+    participants: participants.map((entry) => ({
+      participantId: entry.participantId,
+      displayName: entry.displayName,
+      isCurrentTurn: entry.isCurrentTurn,
+    })),
+    currentTurnParticipantId: projection.currentTurnParticipantId ?? null,
+  }
+}
+
+export async function createCounterInstance(baseUrl: string): Promise<string> {
+  const response = await requestJson<CounterCreateResponse>(
+    baseUrl,
+    "/counter",
+    {
+      method: "POST",
+    }
+  )
+  if (typeof response.instanceId !== "string" || !response.instanceId)
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_instance",
+      "Counter instance is invalid"
+    )
+  return response.instanceId
+}
+
+export async function joinCounter(
+  baseUrl: string,
+  instanceId: string,
+  participantId: string,
+  displayName: string
+): Promise<{ accessToken: string; projection: CounterProjection }> {
+  validateParticipantId(participantId)
+  const response = await requestJson<CounterJoinResponse>(
+    baseUrl,
+    `/counter/${encodeURIComponent(instanceId)}/join`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        participantId,
+        displayName: displayName.trim().slice(0, 80) || participantId,
+      }),
+    }
+  )
+  if (typeof response.accessToken !== "string" || !response.accessToken)
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_capability",
+      "Counter capability is invalid"
+    )
+  return {
+    accessToken: response.accessToken,
+    projection: validateProjection(response.projection),
+  }
+}
+
+export async function readCounterProjection(
+  baseUrl: string,
+  instanceId: string,
+  accessToken: string
+): Promise<CounterProjection> {
+  if (!accessToken)
+    throw new CounterBridgeError(
+      401,
+      "unauthorized",
+      "Counter capability is missing"
+    )
+  const response = await requestJson<unknown>(
+    baseUrl,
+    `/counter/${encodeURIComponent(instanceId)}/state`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  )
+  return validateProjection(response)
+}
+
+export async function incrementCounter(
+  baseUrl: string,
+  instanceId: string,
+  accessToken: string,
+  idempotencyKey: string,
+  expectedRevision: number
+): Promise<CounterIncrementResult> {
+  if (!accessToken)
+    throw new CounterBridgeError(
+      401,
+      "unauthorized",
+      "Counter capability is missing"
+    )
+  const response = await requestJson<CounterIncrementResponse>(
+    baseUrl,
+    `/counter/${encodeURIComponent(instanceId)}/actions/increment`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ idempotencyKey, expectedRevision }),
+    }
+  )
+  if (
+    typeof response.value !== "number" ||
+    !Number.isSafeInteger(response.value) ||
+    typeof response.revision !== "number" ||
+    !Number.isSafeInteger(response.revision) ||
+    typeof response.participantId !== "string" ||
+    typeof response.duplicate !== "boolean"
+  )
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_result",
+      "Counter result is invalid"
+    )
+  return {
+    value: response.value,
+    revision: response.revision,
+    participantId: response.participantId,
+    duplicate: response.duplicate,
+  }
+}

--- a/app/src/room/counterBridge.ts
+++ b/app/src/room/counterBridge.ts
@@ -16,11 +16,18 @@ export interface CounterProjection {
   currentTurnParticipantId: string | null
 }
 
+export interface CounterAttention {
+  type: "your_turn"
+  participantId: string
+  revision: number
+}
+
 export interface CounterIncrementResult {
   value: number
   revision: number
   participantId: string
   duplicate: boolean
+  attention: CounterAttention | null
 }
 
 export class CounterBridgeError extends Error {
@@ -49,6 +56,7 @@ interface CounterIncrementResponse {
   revision?: unknown
   participantId?: unknown
   duplicate?: unknown
+  attention?: unknown
 }
 
 const PARTICIPANT_ID_PATTERN = /^[a-zA-Z0-9._:-]{1,80}$/
@@ -171,6 +179,34 @@ function validateProjection(value: unknown): CounterProjection {
   }
 }
 
+function validateAttention(value: unknown): CounterAttention | null {
+  if (value === null) return null
+  if (!value || typeof value !== "object")
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_result",
+      "Counter attention is invalid"
+    )
+  const attention = value as Partial<CounterAttention>
+  if (
+    attention.type !== "your_turn" ||
+    typeof attention.participantId !== "string" ||
+    !PARTICIPANT_ID_PATTERN.test(attention.participantId) ||
+    typeof attention.revision !== "number" ||
+    !Number.isSafeInteger(attention.revision)
+  )
+    throw new CounterBridgeError(
+      502,
+      "invalid_counter_result",
+      "Counter attention is invalid"
+    )
+  return {
+    type: "your_turn",
+    participantId: attention.participantId,
+    revision: attention.revision,
+  }
+}
+
 export async function createCounterInstance(baseUrl: string): Promise<string> {
   const response = await requestJson<CounterCreateResponse>(
     baseUrl,
@@ -269,7 +305,8 @@ export async function incrementCounter(
     typeof response.revision !== "number" ||
     !Number.isSafeInteger(response.revision) ||
     typeof response.participantId !== "string" ||
-    typeof response.duplicate !== "boolean"
+    typeof response.duplicate !== "boolean" ||
+    !(response.attention === null || typeof response.attention === "object")
   )
     throw new CounterBridgeError(
       502,
@@ -281,5 +318,6 @@ export async function incrementCounter(
     revision: response.revision,
     participantId: response.participantId,
     duplicate: response.duplicate,
+    attention: validateAttention(response.attention),
   }
 }

--- a/app/src/room/server.test.ts
+++ b/app/src/room/server.test.ts
@@ -17,6 +17,7 @@ const ORIGIN = "http://localhost:3000"
 describe("Worker Room route dispatch", () => {
   it("dispatches the Runtime permission request path to the Room handler", () => {
     expect(isRoomRequestPath("/api/room/permissions/request")).toBe(true)
+    expect(isRoomRequestPath("/api/room/experiments/counter")).toBe(true)
     expect(isRoomRequestPath("/api/room/not-a-protocol-route")).toBe(false)
   })
 })
@@ -418,5 +419,54 @@ describe("Runtime provider connection gate", () => {
     const env = liveTranscriptEnv([])
     const response = await handleRoomRequest(request, env)
     expect(response.status).toBe(400)
+  })
+})
+
+describe("Counter experiment transport gate", () => {
+  it("forwards only the Room-authenticated control envelope", async () => {
+    const captured: CapturedControl[] = []
+    const base = liveTranscriptEnv(captured)
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/experiments/counter", {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          "Content-Type": "application/json",
+          "X-Room-Id": "room-counter",
+          "X-Room-Participant-Id": "room-a",
+          "X-Room-Participant-Token": "room-token-a",
+        },
+        body: JSON.stringify({
+          operation: "increment",
+          accessToken: "must-not-forward",
+        }),
+      }),
+      { ...base, ROOM_COUNTER_EXPERIMENT: "true" }
+    )
+    expect(response.status).toBe(200)
+    expect(captured[0]?.body).toEqual({
+      action: "counter-increment",
+      participantId: "room-a",
+      token: "room-token-a",
+    })
+    expect(JSON.stringify(captured[0]?.body)).not.toContain("must-not-forward")
+  })
+
+  it("keeps the experiment disabled unless explicitly enabled", async () => {
+    const env = liveTranscriptEnv([])
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/experiments/counter", {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          "X-Room-Id": "room-counter",
+          "X-Room-Participant-Id": "room-a",
+          "X-Room-Participant-Token": "room-token-a",
+        },
+        body: JSON.stringify({ operation: "start" }),
+      }),
+      env
+    )
+    expect(response.status).toBe(404)
   })
 })

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -7,6 +7,7 @@ const MAX_ROOM_LENGTH = 64
 const MAX_AGENT_ATTACHMENT_BYTES = 768 * 1024
 const MAX_PERMISSION_REQUEST_BODY_BYTES = 64 * 1024
 const AGENT_EVENT_PATH = "/api/room/agent-events"
+const COUNTER_EXPERIMENT_PATH = "/api/room/experiments/counter"
 const ROOM_REQUEST_PATHS = new Set([
   "/api/room/attachments",
   "/api/room/live-transcript/append",
@@ -15,6 +16,7 @@ const ROOM_REQUEST_PATHS = new Set([
   "/api/room/runtime-provider/connect",
   "/api/room/surfaces/read",
   "/api/room/attachments/read",
+  COUNTER_EXPERIMENT_PATH,
 ])
 const SUPPORTED_IMAGE_TYPES = new Set([
   "image/jpeg",
@@ -31,6 +33,7 @@ const SUPPORTED_IMAGE_TYPES = new Set([
 
 export interface RoomProtocolEnv {
   SFU_ROOM: DurableObjectNamespace<RoomSession>
+  ROOM_COUNTER_EXPERIMENT?: string
 }
 
 // Keep the Worker entrypoint and the protocol handler on the same allowlist.
@@ -91,6 +94,44 @@ export async function handleRoomRequest(
     const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
     const doRequest = new Request("https://room/agent-events", request)
     return stub.fetch(doRequest)
+  }
+
+  // Explicitly gated local experiment. Room admission proves the caller to
+  // the DO; the DO performs the separate external Counter join and keeps its
+  // downstream capability private.
+  if (pathname === COUNTER_EXPERIMENT_PATH) {
+    if (env.ROOM_COUNTER_EXPERIMENT !== "true")
+      return json({ error: "experiment_disabled" }, 404)
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const room = request.headers.get("X-Room-Id")?.trim() ?? ""
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    if (!room || room.length > MAX_ROOM_LENGTH || !participantId || !token)
+      return json({ error: "missing_room_capability" }, 400)
+    let body: { operation?: unknown }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return json({ error: "invalid_request" }, 400)
+    }
+    if (
+      body.operation !== "start" &&
+      body.operation !== "join" &&
+      body.operation !== "state" &&
+      body.operation !== "increment"
+    )
+      return json({ error: "invalid_request" }, 400)
+    const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+    return stub.fetch("https://room/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: `counter-${body.operation}`,
+        participantId,
+        token,
+      }),
+    })
   }
 
   // Runtime-only control transport for a committed STT result. This is not

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -397,6 +397,42 @@ export interface RoomState {
   // Coarse Worker media admission switch. Per-Agent UI availability still
   // comes from the Runtime Host's TTS readiness, never from this field.
   agentVoiceMediaAvailable: boolean
+  // Experimental Room-rendezvous fixture. This is the shared, secret-free
+  // task description and Counter state; participant capabilities stay in the
+  // RoomSession record and are only used through the authenticated bridge.
+  counterTask?: CounterTaskPublic
+}
+
+export interface CounterTaskSurface {
+  kind: "counter"
+  version: 1
+  title: string
+  actions: [{ id: "increment"; name: "increment"; label: string }]
+}
+
+export interface CounterTaskParticipant {
+  participantId: string
+  displayName: string
+  isCurrentTurn: boolean
+}
+
+export interface CounterTaskPublic {
+  taskId: string
+  surface: CounterTaskSurface
+  value: number
+  revision: number
+  currentTurnParticipantId: string | null
+  participants: CounterTaskParticipant[]
+}
+
+// Server-private RoomSession state for the local Counter experiment. The
+// access tokens are never passed to RoomState, Room messages, or Agent input.
+export interface CounterTaskRecord extends CounterTaskPublic {
+  instanceId: string
+  capabilities: Record<
+    string,
+    { participantId: string; displayName: string; accessToken: string }
+  >
 }
 
 // A Cloudflare Realtime track-close attempt that hasn't been confirmed
@@ -450,6 +486,9 @@ export interface RoomRecord {
   meetingNotes: MeetingNotesState
   agentVoice: AgentVoiceState
   pendingMediaCleanup: PendingMediaCleanup[]
+  // Optional so existing Room records remain valid when the experiment is
+  // disabled or when a room predates this field.
+  counterTask?: CounterTaskRecord
 }
 
 export interface RoomCapabilities {

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -429,6 +429,7 @@ export interface CounterTaskPublic {
 // access tokens are never passed to RoomState, Room messages, or Agent input.
 export interface CounterTaskRecord extends CounterTaskPublic {
   instanceId: string
+  pendingJoinParticipantId?: string
   capabilities: Record<
     string,
     { participantId: string; displayName: string; accessToken: string }


### PR DESCRIPTION
## Summary

Unmerged local experiment for the existing Free4Chat Room as a temporary trust/rendezvous boundary around the already-proven external Counter fixture.

- Reuses real Room participant IDs as Counter participant IDs.
- Creates one Room-scoped task and one shared deterministic Counter Surface.
- Keeps per-participant Counter access tokens private inside RoomSession storage. Room bearer tokens never reach Counter.
- Adds only an explicitly gated /api/room/experiments/counter control route; Counter actions do not append Room messages or wake Agent waiters.
- Adds a two-browser Playwright acceptance flow using the lab Counter at http://127.0.0.1:8787.

## Verification

- yarn test — 72 files, 659 tests passed
- eslint src — passed
- yarn type-check — passed
- yarn cf-build — passed (existing local DO/OpenNext warnings only)
- yarn e2e:room — passed
- yarn e2e:room-counter — passed

Browser evidence: two real Chromium contexts joined the same Room, used the same external Counter instance with distinct capabilities, saw B rejected at 403 before A acted, observed A then B increment to count 2 with both projections refreshed, and exchanged ordinary Room text afterward.

This PR is intentionally not merged or production-enabled.