### PR TITLE
Experiment: scoped resident Agent Harness sessions

### DIFF
--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -199,6 +199,12 @@ type pendingPermission struct {
 	request ACPPermissionRequest
 }
 
+type acpSession struct {
+	sessionID  string
+	caps       *ACPCapabilities
+	generation int64
+}
+
 // harnessProcess owns the ONE cmd.Wait() call for a child lifecycle. Both
 // the death watcher and closeInternal observe the same exit signal, so the
 // shutdown path can reliably distinguish "terminated" from "ignored TERM"
@@ -246,15 +252,18 @@ type ACPAdapter struct {
 	// Unlike gen it is meaningful to the Runtime: a replacement session has
 	// no retained conversation memory, while a transport reconnect alone does
 	// not change it.
-	sessionGeneration int64
-	sessionID         string
-	caps              *ACPCapabilities
-	onFailure         types.AdapterFailureHandler
-	closing           bool
-	promptActive      bool
-	turnChunks        []string
-	turnContext       context.Context
-	turnCancel        context.CancelFunc
+	sessionGeneration   int64
+	sessionID           string
+	caps                *ACPCapabilities
+	sessions            map[string]*acpSession
+	nextScopeGeneration int64
+	onFailure           types.AdapterFailureHandler
+	closing             bool
+	promptActive        bool
+	turnChunks          []string
+	turnContext         context.Context
+	turnCancel          context.CancelFunc
+	turnSessionID       string
 }
 
 // NewACPAdapter creates an adapter bound to one workspace directory. It does
@@ -273,6 +282,7 @@ func NewACPAdapter(launcher types.AgentLauncher, workingDir string, options Adap
 		name:               launcher.ID,
 		pending:            make(map[string]*pendingCall),
 		pendingPermissions: make(map[string]*pendingPermission),
+		sessions:           make(map[string]*acpSession),
 	}
 }
 
@@ -426,6 +436,21 @@ func (a *ACPAdapter) SessionGeneration() int64 {
 	return a.sessionGeneration
 }
 
+// SessionGenerationFor returns the generation of one opaque logical scope.
+// A process restart invalidates every scoped ACP conversation; the next
+// EnsureSessionFor creates a new generation for that scope.
+func (a *ACPAdapter) SessionGenerationFor(scope string) int64 {
+	if scope == "room" || strings.TrimSpace(scope) == "" {
+		return a.SessionGeneration()
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if session := a.sessions[scope]; session != nil {
+		return session.generation
+	}
+	return 0
+}
+
 // OnFailure registers the handler invoked on unexpected process death.
 func (a *ACPAdapter) OnFailure(handler types.AdapterFailureHandler) {
 	a.mu.Lock()
@@ -457,7 +482,7 @@ func (a *ACPAdapter) markProcessDead(gen int64, err error) {
 		a.mu.Unlock()
 		return
 	}
-	live := a.proc != nil || a.stdin != nil || a.sessionID != "" || a.caps != nil || len(a.pending) > 0 || len(a.pendingPermissions) > 0
+	live := a.proc != nil || a.stdin != nil || a.sessionID != "" || a.caps != nil || len(a.sessions) > 0 || len(a.pending) > 0 || len(a.pendingPermissions) > 0
 	if !live {
 		a.mu.Unlock()
 		return
@@ -466,6 +491,7 @@ func (a *ACPAdapter) markProcessDead(gen int64, err error) {
 	a.stdin = nil
 	a.sessionID = ""
 	a.caps = nil
+	a.sessions = make(map[string]*acpSession)
 	for _, call := range a.pending {
 		close(call.result)
 	}
@@ -474,6 +500,7 @@ func (a *ACPAdapter) markProcessDead(gen int64, err error) {
 	turnCancel = a.turnCancel
 	a.turnContext = nil
 	a.turnCancel = nil
+	a.turnSessionID = ""
 	a.promptActive = false
 	a.turnChunks = nil
 	a.mu.Unlock()
@@ -558,6 +585,65 @@ func (a *ACPAdapter) EnsureSession() error {
 	a.sessionGeneration++
 	a.mu.Unlock()
 	return nil
+}
+
+// EnsureSessionFor creates one additional ACP conversation in the already
+// resident Harness process. The default Room conversation remains the
+// compatibility path above; task scopes share the process but never share its
+// ACP session id or retained conversation.
+func (a *ACPAdapter) EnsureSessionFor(scope string) error {
+	if strings.TrimSpace(scope) == "" {
+		return errors.New("ACP logical scope is empty")
+	}
+	if scope == "room" {
+		return a.EnsureSession()
+	}
+	if err := a.EnsureSession(); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	if session := a.sessions[scope]; session != nil && session.sessionID != "" && a.proc != nil && a.stdin != nil {
+		a.mu.Unlock()
+		return nil
+	}
+	base := cloneACPCapabilities(a.caps)
+	a.mu.Unlock()
+	if base == nil {
+		return errors.New("ACP default session is unavailable")
+	}
+	newParams, _ := json.Marshal(map[string]any{"cwd": a.workingDir, "mcpServers": []any{}})
+	raw, err := a.request("session/new", newParams)
+	if err != nil {
+		return err
+	}
+	var sessionResponse struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(raw.Result, &sessionResponse); err != nil || sessionResponse.SessionID == "" {
+		return errors.New("ACP agent did not return a sessionId")
+	}
+	base.SessionControls = parseSessionControls(raw.Result)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.proc == nil || a.stdin == nil {
+		return errors.New("ACP process exited while creating scoped session")
+	}
+	a.nextScopeGeneration++
+	a.sessions[scope] = &acpSession{
+		sessionID:  sessionResponse.SessionID,
+		caps:       base,
+		generation: a.nextScopeGeneration,
+	}
+	return nil
+}
+
+func cloneACPCapabilities(caps *ACPCapabilities) *ACPCapabilities {
+	if caps == nil {
+		return nil
+	}
+	clone := *caps
+	clone.SessionControls = cloneSessionControls(caps.SessionControls)
+	return &clone
 }
 
 // handshake performs initialize + session/new synchronously.
@@ -842,7 +928,7 @@ func (a *ACPAdapter) dispatchPermission(message *acpMessage) {
 
 	key := message.idKey()
 	a.mu.Lock()
-	if a.closing || !a.promptActive || a.turnContext == nil || a.sessionID == "" || request.SessionID != a.sessionID {
+	if a.closing || !a.promptActive || a.turnContext == nil || a.turnSessionID == "" || request.SessionID != a.turnSessionID {
 		a.mu.Unlock()
 		_ = a.writeFrame(cancelPermissionFrame(message.ID))
 		return
@@ -1027,13 +1113,23 @@ func (a *ACPAdapter) applySessionUpdate(params json.RawMessage) {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.caps == nil || a.caps.SessionControls == nil || (a.sessionID != "" && update.SessionID != "" && update.SessionID != a.sessionID) {
+	caps := a.caps
+	if update.SessionID != "" && update.SessionID != a.sessionID {
+		caps = nil
+		for _, session := range a.sessions {
+			if session.sessionID == update.SessionID {
+				caps = session.caps
+				break
+			}
+		}
+	}
+	if caps == nil || caps.SessionControls == nil {
 		return
 	}
 	switch update.Update.SessionUpdate {
 	case "current_mode_update":
-		if a.caps.SessionControls.Modes != nil && update.Update.CurrentModeID != "" {
-			a.caps.SessionControls.Modes.CurrentModeID = update.Update.CurrentModeID
+		if caps.SessionControls.Modes != nil && update.Update.CurrentModeID != "" {
+			caps.SessionControls.Modes.CurrentModeID = update.Update.CurrentModeID
 		}
 	case "config_option_update":
 		if len(update.Update.ConfigOptions) == 0 {
@@ -1041,7 +1137,7 @@ func (a *ACPAdapter) applySessionUpdate(params json.RawMessage) {
 		}
 		controls := parseSessionControls(mustJSON(map[string]any{"configOptions": update.Update.ConfigOptions}))
 		if controls != nil && len(controls.ConfigOptions) > 0 {
-			a.caps.SessionControls.ConfigOptions = controls.ConfigOptions
+			caps.SessionControls.ConfigOptions = controls.ConfigOptions
 		}
 	}
 }
@@ -1206,17 +1302,30 @@ func promptBlocks(input types.HarnessTurnInput, supportsImages bool) []map[strin
 	return blocks
 }
 
-// RunTurn executes one addressed turn against the exact retained session
-// generation prepared by the Runtime. In particular, this method must not
-// call EnsureSession: doing so could respawn a Harness after the Runtime had
-// already rendered a non-bootstrap prompt for the dead conversation.
+// RunTurn keeps the original default Room adapter contract.
 func (a *ACPAdapter) RunTurn(input types.HarnessTurnInput, expectedSessionGeneration int64) (types.HarnessTurnResult, error) {
+	return a.RunTurnFor("room", input, expectedSessionGeneration)
+}
+
+// RunTurnFor executes one addressed turn against the exact retained session
+// generation prepared by the Runtime. In particular, this method must not
+// call EnsureSessionFor: doing so could create or switch conversations after
+// the Runtime rendered a prompt for a specific generation.
+func (a *ACPAdapter) RunTurnFor(scope string, input types.HarnessTurnInput, expectedSessionGeneration int64) (types.HarnessTurnResult, error) {
 	a.mu.Lock()
-	if expectedSessionGeneration <= 0 || a.sessionGeneration != expectedSessionGeneration {
+	var sessionID string
+	var caps *ACPCapabilities
+	var generation int64
+	if scope == "room" || strings.TrimSpace(scope) == "" {
+		sessionID, caps, generation = a.sessionID, a.caps, a.sessionGeneration
+	} else if session := a.sessions[scope]; session != nil {
+		sessionID, caps, generation = session.sessionID, session.caps, session.generation
+	}
+	if expectedSessionGeneration <= 0 || generation != expectedSessionGeneration {
 		a.mu.Unlock()
 		return types.HarnessTurnResult{}, types.ErrHarnessSessionGenerationChanged
 	}
-	if a.sessionID == "" || a.stdin == nil {
+	if sessionID == "" || a.stdin == nil {
 		a.mu.Unlock()
 		return types.HarnessTurnResult{}, errors.New("ACP session is unavailable")
 	}
@@ -1227,9 +1336,10 @@ func (a *ACPAdapter) RunTurn(input types.HarnessTurnInput, expectedSessionGenera
 	a.promptActive = true
 	a.turnChunks = nil
 	a.turnContext, a.turnCancel = context.WithCancel(context.Background())
-	blocks := promptBlocks(input, a.caps != nil && a.caps.Images)
+	a.turnSessionID = sessionID
+	blocks := promptBlocks(input, caps != nil && caps.Images)
 	params, _ := json.Marshal(map[string]any{
-		"sessionId": a.sessionID,
+		"sessionId": sessionID,
 		"prompt":    blocks,
 	})
 	a.nextID++
@@ -1312,6 +1422,7 @@ func (a *ACPAdapter) resetPrompt(key string) {
 	turnCancel := a.turnCancel
 	a.turnContext = nil
 	a.turnCancel = nil
+	a.turnSessionID = ""
 	permissions := a.takePendingPermissionsLocked()
 	a.promptActive = false
 	a.turnChunks = nil
@@ -1373,11 +1484,11 @@ func (a *ACPAdapter) recoverTimedOutTurn(call *pendingCall, key string, graceMs 
 // CancelTurn notifies the Harness to cancel the active prompt.
 func (a *ACPAdapter) CancelTurn() error {
 	a.mu.Lock()
-	if a.sessionID == "" || a.stdin == nil || !a.promptActive {
+	if a.turnSessionID == "" || a.stdin == nil || !a.promptActive {
 		a.mu.Unlock()
 		return nil
 	}
-	params, _ := json.Marshal(map[string]any{"sessionId": a.sessionID})
+	params, _ := json.Marshal(map[string]any{"sessionId": a.turnSessionID})
 	envelope, _ := json.Marshal(acpMessage{
 		JSONRPC: "2.0",
 		Method:  "session/cancel",
@@ -1415,12 +1526,18 @@ func (a *ACPAdapter) closeInternal(force bool) error {
 	a.closing = true
 	proc := a.proc
 	writer := a.stdin
-	sessionID := a.sessionID
-	closePresent := a.caps != nil && a.caps.ClosePresent
-	nextID := a.nextID + 1
-	a.nextID = nextID
+	closeFrames := make([][]byte, 0, 1+len(a.sessions))
+	if !force && a.caps != nil && a.caps.ClosePresent && a.sessionID != "" {
+		closeFrames = append(closeFrames, a.sessionCloseFrameLocked(a.sessionID))
+	}
+	for _, session := range a.sessions {
+		if !force && session.caps != nil && session.caps.ClosePresent && session.sessionID != "" {
+			closeFrames = append(closeFrames, a.sessionCloseFrameLocked(session.sessionID))
+		}
+	}
 	a.sessionID = ""
 	a.caps = nil
+	a.sessions = make(map[string]*acpSession)
 	a.stdin = nil
 	a.proc = nil
 	a.promptActive = false
@@ -1428,6 +1545,7 @@ func (a *ACPAdapter) closeInternal(force bool) error {
 	turnCancel = a.turnCancel
 	a.turnContext = nil
 	a.turnCancel = nil
+	a.turnSessionID = ""
 	for _, call := range a.pending {
 		close(call.result)
 	}
@@ -1449,22 +1567,13 @@ func (a *ACPAdapter) closeInternal(force bool) error {
 
 	/* Graceful session/close only when not force-tearing down a stuck
 	 * Harness; process termination below remains the final boundary. */
-	var envelope []byte
-	if !force && writer != nil && sessionID != "" && closePresent {
-		id, _ := json.Marshal(nextID)
-		params, _ := json.Marshal(map[string]any{"sessionId": sessionID})
-		envelope, _ = json.Marshal(acpMessage{
-			JSONRPC: "2.0",
-			ID:      id,
-			Method:  "session/close",
-			Params:  params,
-		})
-	}
 	if writer != nil {
-		if envelope != nil {
+		if len(closeFrames) > 0 {
 			done := make(chan struct{})
 			go func() {
-				_, _ = writer.Write(append(envelope, '\n'))
+				for _, frame := range closeFrames {
+					_, _ = writer.Write(append(frame, '\n'))
+				}
 				close(done)
 			}()
 			select {
@@ -1495,6 +1604,19 @@ func (a *ACPAdapter) closeInternal(force bool) error {
 		}
 	}
 	return nil
+}
+
+func (a *ACPAdapter) sessionCloseFrameLocked(sessionID string) []byte {
+	a.nextID++
+	id, _ := json.Marshal(a.nextID)
+	params, _ := json.Marshal(map[string]any{"sessionId": sessionID})
+	frame, _ := json.Marshal(acpMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  "session/close",
+		Params:  params,
+	})
+	return frame
 }
 
 // environmentSlice converts a filtered map into exec.Env form (sorted for

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -242,6 +242,7 @@ type ACPAdapter struct {
 
 	mu                 sync.Mutex
 	writeMu            sync.Mutex // serializes every stdin frame
+	scopedSessionMu    sync.Mutex // serializes bounded scoped session creation
 	proc               *harnessProcess
 	stdin              io.WriteCloser
 	pending            map[string]*pendingCall
@@ -592,12 +593,28 @@ func (a *ACPAdapter) EnsureSession() error {
 // compatibility path above; task scopes share the process but never share its
 // ACP session id or retained conversation.
 func (a *ACPAdapter) EnsureSessionFor(scope string) error {
-	if strings.TrimSpace(scope) == "" {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
 		return errors.New("ACP logical scope is empty")
 	}
 	if scope == "room" {
 		return a.EnsureSession()
 	}
+	if len(scope) > types.MaxLogicalScopeLength {
+		return errors.New("ACP logical scope is too long")
+	}
+	a.scopedSessionMu.Lock()
+	defer a.scopedSessionMu.Unlock()
+	a.mu.Lock()
+	if session := a.sessions[scope]; session != nil && session.sessionID != "" && a.proc != nil && a.stdin != nil {
+		a.mu.Unlock()
+		return nil
+	}
+	if len(a.sessions) >= types.MaxLogicalTaskScopes {
+		a.mu.Unlock()
+		return errors.New("ACP logical scope capacity reached")
+	}
+	a.mu.Unlock()
 	if err := a.EnsureSession(); err != nil {
 		return err
 	}

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -257,6 +257,43 @@ func TestACPScopesRetainMultipleConversationsInOneProcess(t *testing.T) {
 	}
 }
 
+func TestACPScopesAreBoundedAndExistingConversationRemainsReusable(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "acp-bound-trace.log")
+	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{
+		"FAKE_TRACE": tracePath,
+	}), AdapterOptions{})
+	defer adapter.Close()
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure Room session failed: %v", err)
+	}
+	for index := 0; index < types.MaxLogicalTaskScopes; index++ {
+		if err := adapter.EnsureSessionFor("task:" + strconv.Itoa(index+1)); err != nil {
+			t.Fatalf("ensure scoped session %d failed: %v", index+1, err)
+		}
+	}
+	if err := adapter.EnsureSessionFor("task:1"); err != nil {
+		t.Fatalf("existing scope was rejected at capacity: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:overflow"); err == nil {
+		t.Fatal("scope above the bound was accepted")
+	}
+
+	data, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read ACP trace: %v", err)
+	}
+	newCount := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, `"method":"session/new"`) {
+			newCount++
+		}
+	}
+	if newCount != 1+types.MaxLogicalTaskScopes {
+		t.Fatalf("scope capacity changed ACP session/new count: got=%d want=%d", newCount, 1+types.MaxLogicalTaskScopes)
+	}
+}
+
 func TestACPRetainsAndAppliesAdvertisedSessionControls(t *testing.T) {
 	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{
 		"FAKE_POLICY_CAP": "1",

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -185,6 +186,74 @@ func TestACPNegotiatesOnceAndReusesOneSession(t *testing.T) {
 	result, err = adapter.RunTurn(turnInput("second"), adapter.SessionGeneration())
 	if err != nil || result.Text != "reply-2" {
 		t.Fatalf("session reuse broken: %+v %v", result, err)
+	}
+}
+
+func TestACPScopesRetainMultipleConversationsInOneProcess(t *testing.T) {
+	tracePath := filepath.Join(t.TempDir(), "acp-trace.log")
+	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{
+		"FAKE_TRACE": tracePath,
+	}), AdapterOptions{})
+	defer adapter.Close()
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure Room session failed: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:T"); err != nil {
+		t.Fatalf("ensure T session failed: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:U"); err != nil {
+		t.Fatalf("ensure U session failed: %v", err)
+	}
+	tGeneration := adapter.SessionGenerationFor("task:T")
+	uGeneration := adapter.SessionGenerationFor("task:U")
+	if tGeneration <= 0 || uGeneration <= 0 || tGeneration == uGeneration {
+		t.Fatalf("scoped generations were not independent: T=%d U=%d", tGeneration, uGeneration)
+	}
+
+	for _, turn := range []struct {
+		scope      string
+		generation int64
+	}{
+		{scope: "task:T", generation: tGeneration},
+		{scope: "task:U", generation: uGeneration},
+		{scope: "task:T", generation: tGeneration},
+		{scope: "task:U", generation: uGeneration},
+	} {
+		if result, err := adapter.RunTurnFor(turn.scope, turnInput(turn.scope), turn.generation); err != nil || result.Text == "" {
+			t.Fatalf("scoped turn failed for %s: %+v %v", turn.scope, result, err)
+		}
+	}
+	if adapter.SessionGenerationFor("task:T") != tGeneration || adapter.SessionGenerationFor("task:U") != uGeneration {
+		t.Fatal("alternating scoped turns created a new conversation")
+	}
+
+	data, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read ACP trace: %v", err)
+	}
+	var promptSessions []string
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) != "IN" {
+			continue
+		}
+		var message struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if json.Unmarshal([]byte(parts[1]), &message) != nil || message.Method != "session/prompt" {
+			continue
+		}
+		var params struct {
+			SessionID string `json:"sessionId"`
+		}
+		if json.Unmarshal(message.Params, &params) == nil {
+			promptSessions = append(promptSessions, params.SessionID)
+		}
+	}
+	if !reflect.DeepEqual(promptSessions, []string{"session-2", "session-3", "session-2", "session-3"}) {
+		t.Fatalf("ACP prompts did not stay bound to scoped conversations: %v", promptSessions)
 	}
 }
 

--- a/agent/internal/harness/testdata/fakeagent/main.go
+++ b/agent/internal/harness/testdata/fakeagent/main.go
@@ -44,9 +44,11 @@ type frame struct {
 }
 
 type agent struct {
-	mode        string
-	promptCount int
-	pending     []byte // id of a held prompt waiting for cancellation
+	mode             string
+	promptCount      int
+	pending          []byte // id of a held prompt waiting for cancellation
+	pendingSessionID string
+	nextSessionID    int
 }
 
 var tracePath string
@@ -136,7 +138,6 @@ func main() {
 		}
 	}
 	a := &agent{mode: mode}
-	sessionID := ""
 	// A FIRST-life stuck process must also survive stdin EOF (the adapter
 	// closes the pipe before escalating): only SIGKILL may end it, which is
 	// exactly what the adapter's bounded escalation tests verify.
@@ -189,7 +190,8 @@ func main() {
 			})
 
 		case message.Method == "session/new":
-			sessionID = "session-" + strconv.Itoa(1)
+			a.nextSessionID++
+			sessionID := "session-" + strconv.Itoa(a.nextSessionID)
 			response := map[string]any{"sessionId": sessionID}
 			if os.Getenv("FAKE_POLICY_CAP") == "1" {
 				response["modes"] = map[string]any{
@@ -216,11 +218,12 @@ func main() {
 				continue
 			}
 			var params struct {
-				ModeID string `json:"modeId"`
+				SessionID string `json:"sessionId"`
+				ModeID    string `json:"modeId"`
 			}
 			_ = json.Unmarshal(message.Params, &params)
 			notify("session/update", map[string]any{
-				"sessionId": sessionID,
+				"sessionId": params.SessionID,
 				"update":    map[string]any{"sessionUpdate": "current_mode_update", "currentModeId": params.ModeID},
 			})
 			reply(message.ID, map[string]any{})
@@ -231,8 +234,9 @@ func main() {
 				continue
 			}
 			var params struct {
-				ConfigID string `json:"configId"`
-				Value    string `json:"value"`
+				SessionID string `json:"sessionId"`
+				ConfigID  string `json:"configId"`
+				Value     string `json:"value"`
 			}
 			_ = json.Unmarshal(message.Params, &params)
 			configOptions := []any{map[string]any{
@@ -244,7 +248,7 @@ func main() {
 				},
 			}}
 			notify("session/update", map[string]any{
-				"sessionId": sessionID,
+				"sessionId": params.SessionID,
 				"update":    map[string]any{"sessionUpdate": "config_option_update", "configOptions": configOptions},
 			})
 			reply(message.ID, map[string]any{"configOptions": configOptions})
@@ -253,24 +257,29 @@ func main() {
 			reply(message.ID, map[string]any{})
 
 		case message.Method == "session/cancel":
+			var cancelParams struct {
+				SessionID string `json:"sessionId"`
+			}
+			_ = json.Unmarshal(message.Params, &cancelParams)
 			switch a.mode {
 			case "cancel":
 				if a.pending != nil {
-					updateChunk(sessionID, "cancelled")
+					updateChunk(cancelParams.SessionID, "cancelled")
 					reply(a.pending, map[string]any{"stopReason": "cancelled"})
 					a.pending = nil
+					a.pendingSessionID = ""
 				}
 			case "thought":
 				// Emits internal reasoning that must NEVER surface in the
 				// runtime's published reply, then the real message.
 				notify("session/update", map[string]any{
-					"sessionId": sessionID,
+					"sessionId": cancelParams.SessionID,
 					"update": map[string]any{
 						"sessionUpdate": "agent_thought_chunk",
 						"content":       map[string]any{"type": "text", "text": "SECRET-THINKING-0123456789"},
 					},
 				})
-				updateChunk(sessionID, "public-reply")
+				updateChunk(cancelParams.SessionID, "public-reply")
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "timeout_stuck":
 				if marker := os.Getenv("FAKE_CANCEL_MARKER"); marker != "" && !fileExists(marker) {
@@ -279,6 +288,11 @@ func main() {
 			}
 
 		case message.Method == "session/prompt":
+			var promptParams struct {
+				SessionID string `json:"sessionId"`
+			}
+			_ = json.Unmarshal(message.Params, &promptParams)
+			promptSessionID := promptParams.SessionID
 			prompt := promptText(message.Params)
 			switch a.mode {
 			case "env":
@@ -289,20 +303,20 @@ func main() {
 				if name == "" {
 					name = "FREE4CHAT_AGENT_DIR"
 				}
-				updateChunk(sessionID, os.Getenv(name))
+				updateChunk(promptSessionID, os.Getenv(name))
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "context_read":
 				runtimeBinary := os.Getenv("FREE4CHAT_AGENT_BIN")
 				if runtimeBinary == "" {
-					updateChunk(sessionID, "context-read-error: exact Runtime executable is unavailable")
+					updateChunk(promptSessionID, "context-read-error: exact Runtime executable is unavailable")
 					reply(message.ID, map[string]any{"stopReason": "end_turn"})
 					continue
 				}
 				output, err := exec.Command(runtimeBinary, "context", "read", "--before-sequence", "2", "--limit", "10").CombinedOutput()
 				if err != nil {
-					updateChunk(sessionID, "context-read-error: "+string(output))
+					updateChunk(promptSessionID, "context-read-error: "+string(output))
 				} else {
-					updateChunk(sessionID, string(output))
+					updateChunk(promptSessionID, string(output))
 				}
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "permission":
@@ -314,7 +328,7 @@ func main() {
 						ID:      json.RawMessage("77"),
 						Method:  "session/request_permission",
 						Params: mustJSON(map[string]any{
-							"sessionId": sessionID,
+							"sessionId": promptSessionID,
 							"toolCall": map[string]any{
 								"toolCallId": "tool-1",
 								"title":      "unsafe operation",
@@ -327,9 +341,10 @@ func main() {
 					// Wait for the runtime's auto-cancelled response; the
 					// response handler below drives completion. Stash the id.
 					a.pending = append([]byte(nil), message.ID...)
+					a.pendingSessionID = promptSessionID
 					continue
 				}
-				a.finishNormal(&message, sessionID)
+				a.finishNormal(&message, promptSessionID)
 			case "permission_wait":
 				if len(prompt) > 0 && contains(prompt, "permission-test") {
 					send(&frame{
@@ -337,7 +352,7 @@ func main() {
 						ID:      json.RawMessage("78"),
 						Method:  "session/request_permission",
 						Params: mustJSON(map[string]any{
-							"sessionId": sessionID,
+							"sessionId": promptSessionID,
 							"toolCall": map[string]any{
 								"toolCallId": "tool-delayed",
 								"title":      "delayed harmless operation",
@@ -362,17 +377,19 @@ func main() {
 						}),
 					})
 					a.pending = append([]byte(nil), message.ID...)
+					a.pendingSessionID = promptSessionID
 					continue
 				}
-				a.finishNormal(&message, sessionID)
+				a.finishNormal(&message, promptSessionID)
 			case "cancel":
 				if len(prompt) > 0 && contains(prompt, "cancel-test") {
 					a.pending = append([]byte(nil), message.ID...)
+					a.pendingSessionID = promptSessionID
 					continue
 				}
-				a.finishNormal(&message, sessionID)
+				a.finishNormal(&message, promptSessionID)
 			case "exit":
-				a.finishNormal(&message, sessionID)
+				a.finishNormal(&message, promptSessionID)
 				a.killAfter(10*time.Millisecond, "FAKE_EXIT_MARKER")
 			case "restart":
 				marker := os.Getenv("FAKE_RESTART_MARKER")
@@ -384,7 +401,7 @@ func main() {
 				if !restarted {
 					text = "reply-1"
 				}
-				updateChunk(sessionID, text)
+				updateChunk(promptSessionID, text)
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 				if !restarted {
 					a.killAfter(10*time.Millisecond, "FAKE_RESTART_MARKER")
@@ -395,19 +412,19 @@ func main() {
 				if text == "" {
 					text = fmt.Sprintf("reply-%d", a.promptCount)
 				}
-				updateChunk(sessionID, text)
+				updateChunk(promptSessionID, text)
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "thought":
 				// Emits internal reasoning that must NEVER surface in the
 				// runtime's published reply, then the real message.
 				notify("session/update", map[string]any{
-					"sessionId": sessionID,
+					"sessionId": promptSessionID,
 					"update": map[string]any{
 						"sessionUpdate": "agent_thought_chunk",
 						"content":       map[string]any{"type": "text", "text": "SECRET-THINKING-0123456789"},
 					},
 				})
-				updateChunk(sessionID, "public-reply")
+				updateChunk(promptSessionID, "public-reply")
 				reply(message.ID, map[string]any{"stopReason": "end_turn"})
 			case "timeout_stuck":
 				stateMarker := os.Getenv("FAKE_STATE_MARKER")
@@ -416,7 +433,7 @@ func main() {
 					wasStuck = fileExists(stateMarker)
 				}
 				if wasStuck {
-					updateChunk(sessionID, "recovered")
+					updateChunk(promptSessionID, "recovered")
 					reply(message.ID, map[string]any{"stopReason": "end_turn"})
 					continue
 				}
@@ -428,7 +445,7 @@ func main() {
 				}
 				continue
 			default:
-				a.finishNormal(&message, sessionID)
+				a.finishNormal(&message, promptSessionID)
 			}
 
 		case len(message.ID) > 0 && message.Result != nil:
@@ -443,13 +460,14 @@ func main() {
 				}
 				_ = json.Unmarshal(message.Result, &permissionResult)
 				if a.mode == "permission_wait" && permissionResult.Outcome.Outcome == "selected" && permissionResult.Outcome.OptionID == "allow-once" {
-					updateChunk(sessionID, "permission-approved")
+					updateChunk(a.pendingSessionID, "permission-approved")
 					reply(a.pending, map[string]any{"stopReason": "end_turn"})
 				} else {
-					updateChunk(sessionID, "permission-cancelled")
+					updateChunk(a.pendingSessionID, "permission-cancelled")
 					reply(a.pending, map[string]any{"stopReason": "cancelled"})
 				}
 				a.pending = nil
+				a.pendingSessionID = ""
 			}
 
 		default:

--- a/agent/internal/runtime/helpers.go
+++ b/agent/internal/runtime/helpers.go
@@ -19,6 +19,8 @@ type pendingTurnContext struct {
 	events []types.RoomEvent
 }
 
+var errScopedHarnessUnsupported = errors.New("scoped Harness adapter is unavailable")
+
 type logicalSessionRef struct {
 	deliveredThrough               *int64
 	roomDeliveryFloor              *int64
@@ -196,26 +198,35 @@ func (r *ResidentRuntime) currentParticipantID() string {
 
 func (r *ResidentRuntime) ensureHarnessSession(scope string) error {
 	scope = normalizeScope(scope)
+	if scope == roomScope {
+		return r.options.Adapter.EnsureSession()
+	}
 	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
 		return adapter.EnsureSessionFor(scope)
 	}
-	return r.options.Adapter.EnsureSession()
+	return errScopedHarnessUnsupported
 }
 
-func (r *ResidentRuntime) harnessSessionGeneration(scope string) int64 {
+func (r *ResidentRuntime) harnessSessionGeneration(scope string) (int64, error) {
 	scope = normalizeScope(scope)
-	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
-		return adapter.SessionGenerationFor(scope)
+	if scope == roomScope {
+		return r.options.Adapter.SessionGeneration(), nil
 	}
-	return r.options.Adapter.SessionGeneration()
+	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
+		return adapter.SessionGenerationFor(scope), nil
+	}
+	return 0, errScopedHarnessUnsupported
 }
 
 func (r *ResidentRuntime) runHarnessTurn(scope string, input types.HarnessTurnInput, generation int64) (types.HarnessTurnResult, error) {
 	scope = normalizeScope(scope)
+	if scope == roomScope {
+		return r.options.Adapter.RunTurn(input, generation)
+	}
 	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
 		return adapter.RunTurnFor(scope, input, generation)
 	}
-	return r.options.Adapter.RunTurn(input, generation)
+	return types.HarnessTurnResult{}, errScopedHarnessUnsupported
 }
 
 func (r *ResidentRuntime) isStopped() bool {

--- a/agent/internal/runtime/helpers.go
+++ b/agent/internal/runtime/helpers.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/i365dev/free4chat/agent/internal/types"
@@ -16,6 +17,104 @@ type pendingTurnContext struct {
 	after  int64
 	target int64
 	events []types.RoomEvent
+}
+
+const maxLogicalScopeLength = 128
+
+type logicalSessionRef struct {
+	deliveredThrough               *int64
+	roomDeliveryFloor              *int64
+	pendingAddressed               *[]int64
+	pendingContexts                *map[int64]pendingTurnContext
+	observedHarnessGeneration      *int64
+	bootstrappedHarnessGeneration  *int64
+	meetingDeliveredThrough        *int64
+	meetingDeliveryFloor           *int64
+	liveTranscriptDeliveredThrough *int64
+	liveTranscriptDeliveryFloor    *int64
+	sourceCursors                  *map[string]int64
+}
+
+func normalizeScope(scope string) string {
+	scope = strings.TrimSpace(scope)
+	if scope == "" || len(scope) > maxLogicalScopeLength {
+		return roomScope
+	}
+	return scope
+}
+
+func newLogicalSessionState() *logicalSessionState {
+	return &logicalSessionState{
+		pendingContexts: make(map[int64]pendingTurnContext),
+		sourceCursors:   make(map[string]int64),
+	}
+}
+
+// sessionRefLocked keeps the default Room scope on the existing fields while
+// giving task/request scopes their own delivery and source checkpoints.
+// Callers must hold r.mu.
+func (r *ResidentRuntime) sessionRefLocked(scope string) *logicalSessionRef {
+	scope = normalizeScope(scope)
+	if scope == roomScope {
+		return &logicalSessionRef{
+			deliveredThrough:               &r.deliveredThrough,
+			roomDeliveryFloor:              &r.roomDeliveryFloor,
+			pendingAddressed:               &r.pendingAddressed,
+			pendingContexts:                &r.pendingContexts,
+			observedHarnessGeneration:      &r.observedHarnessGeneration,
+			bootstrappedHarnessGeneration:  &r.bootstrappedHarnessGeneration,
+			meetingDeliveredThrough:        &r.meetingDeliveredThrough,
+			meetingDeliveryFloor:           &r.meetingDeliveryFloor,
+			liveTranscriptDeliveredThrough: &r.liveTranscriptDeliveredThrough,
+			liveTranscriptDeliveryFloor:    &r.liveTranscriptDeliveryFloor,
+			sourceCursors:                  nil,
+		}
+	}
+	if r.scopedSessions == nil {
+		r.scopedSessions = make(map[string]*logicalSessionState)
+	}
+	state := r.scopedSessions[scope]
+	if state == nil {
+		state = newLogicalSessionState()
+		r.scopedSessions[scope] = state
+		r.scopeOrder = append(r.scopeOrder, scope)
+	}
+	return &logicalSessionRef{
+		deliveredThrough:               &state.deliveredThrough,
+		roomDeliveryFloor:              &state.roomDeliveryFloor,
+		pendingAddressed:               &state.pendingAddressed,
+		pendingContexts:                &state.pendingContexts,
+		observedHarnessGeneration:      &state.observedHarnessGeneration,
+		bootstrappedHarnessGeneration:  &state.bootstrappedHarnessGeneration,
+		meetingDeliveredThrough:        &state.meetingDeliveredThrough,
+		meetingDeliveryFloor:           &state.meetingDeliveryFloor,
+		liveTranscriptDeliveredThrough: &state.liveTranscriptDeliveredThrough,
+		liveTranscriptDeliveryFloor:    &state.liveTranscriptDeliveryFloor,
+		sourceCursors:                  &state.sourceCursors,
+	}
+}
+
+func (r *ResidentRuntime) scopeStateExistsLocked(scope string) bool {
+	scope = normalizeScope(scope)
+	return scope == roomScope || r.scopedSessions != nil && r.scopedSessions[scope] != nil
+}
+
+func scopeForRoomEvent(event types.RoomEvent) string {
+	if scope := normalizeScope(event.ScopeID); scope != roomScope {
+		return scope
+	}
+	// A bounded action producer may carry the same hint without requiring a
+	// wider wire model. taskId is deliberately namespaced so it cannot collide
+	// with the default Room conversation.
+	if event.ActionPayload != nil {
+		if scope := strings.TrimSpace(event.ActionPayload["scopeId"]); scope != "" {
+			return normalizeScope("task:" + scope)
+		}
+		if taskID := strings.TrimSpace(event.ActionPayload["taskId"]); taskID != "" {
+			return normalizeScope("task:" + taskID)
+		}
+	}
+	return roomScope
 }
 
 func containsSequence(items []int64, sequence int64) bool {
@@ -54,6 +153,30 @@ func (r *ResidentRuntime) currentParticipantID() string {
 	return r.participantID
 }
 
+func (r *ResidentRuntime) ensureHarnessSession(scope string) error {
+	scope = normalizeScope(scope)
+	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
+		return adapter.EnsureSessionFor(scope)
+	}
+	return r.options.Adapter.EnsureSession()
+}
+
+func (r *ResidentRuntime) harnessSessionGeneration(scope string) int64 {
+	scope = normalizeScope(scope)
+	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
+		return adapter.SessionGenerationFor(scope)
+	}
+	return r.options.Adapter.SessionGeneration()
+}
+
+func (r *ResidentRuntime) runHarnessTurn(scope string, input types.HarnessTurnInput, generation int64) (types.HarnessTurnResult, error) {
+	scope = normalizeScope(scope)
+	if adapter, ok := r.options.Adapter.(types.ScopedHarnessAdapter); ok {
+		return adapter.RunTurnFor(scope, input, generation)
+	}
+	return r.options.Adapter.RunTurn(input, generation)
+}
+
 func (r *ResidentRuntime) isStopped() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -82,89 +205,149 @@ func (r *ResidentRuntime) setLastError(state State, message string) {
 }
 
 func (r *ResidentRuntime) pendingAddressedSnapshot() []int64 {
+	return r.pendingAddressedSnapshotFor(roomScope)
+}
+
+func (r *ResidentRuntime) pendingAddressedSnapshotFor(scope string) []int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return append([]int64(nil), r.pendingAddressed...)
+	ref := r.sessionRefLocked(scope)
+	return append([]int64(nil), (*ref.pendingAddressed)...)
+}
+
+func (r *ResidentRuntime) pendingScopes() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pendingAddressed) > 0 {
+		out := []string{roomScope}
+		for _, scope := range r.scopeOrder {
+			if state := r.scopedSessions[scope]; state != nil && len(state.pendingAddressed) > 0 {
+				out = append(out, scope)
+			}
+		}
+		return out
+	}
+	var out []string
+	for _, scope := range r.scopeOrder {
+		if state := r.scopedSessions[scope]; state != nil && len(state.pendingAddressed) > 0 {
+			out = append(out, scope)
+		}
+	}
+	return out
 }
 
 // peekPending returns the next addressed target without acknowledging it.
 // A target remains retryable until the Harness has successfully consumed the
 // corresponding turn; Room transport receipt is deliberately insufficient.
 func (r *ResidentRuntime) peekPending() (int64, bool) {
+	return r.peekPendingFor(roomScope)
+}
+
+func (r *ResidentRuntime) peekPendingFor(scope string) (int64, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if len(r.pendingAddressed) == 0 {
+	ref := r.sessionRefLocked(scope)
+	if len(*ref.pendingAddressed) == 0 {
 		return 0, false
 	}
-	return r.pendingAddressed[0], true
+	return (*ref.pendingAddressed)[0], true
 }
 
 // ackPending removes one successfully-delivered target. It intentionally
 // matches by sequence rather than blindly popping so an unexpected queue
 // mutation cannot acknowledge a different addressed turn.
 func (r *ResidentRuntime) ackPending(sequence int64) {
+	r.ackPendingFor(roomScope, sequence)
+}
+
+func (r *ResidentRuntime) ackPendingFor(scope string, sequence int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for index, pending := range r.pendingAddressed {
+	ref := r.sessionRefLocked(scope)
+	for index, pending := range *ref.pendingAddressed {
 		if pending != sequence {
 			continue
 		}
-		r.pendingAddressed = append(r.pendingAddressed[:index], r.pendingAddressed[index+1:]...)
-		delete(r.pendingContexts, sequence)
+		*ref.pendingAddressed = append((*ref.pendingAddressed)[:index], (*ref.pendingAddressed)[index+1:]...)
+		delete(*ref.pendingContexts, sequence)
 		return
 	}
 }
 
 func (r *ResidentRuntime) deliveredSeq() int64 {
+	return r.deliveredSeqFor(roomScope)
+}
+
+func (r *ResidentRuntime) deliveredSeqFor(scope string) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.deliveredThrough
+	return *r.sessionRefLocked(scope).deliveredThrough
 }
 
 // effectiveDeliveryStart is the automatic-push boundary. A new ACP session
 // deliberately advances its floor to the current trigger without pretending
 // the earlier retained Room history was consumed; that history stays pullable.
 func (r *ResidentRuntime) effectiveDeliveryStart() int64 {
+	return r.effectiveDeliveryStartFor(roomScope)
+}
+
+func (r *ResidentRuntime) effectiveDeliveryStartFor(scope string) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return max(r.deliveredThrough, r.roomDeliveryFloor)
+	ref := r.sessionRefLocked(scope)
+	return max(*ref.deliveredThrough, *ref.roomDeliveryFloor)
 }
 
 // acknowledgeHarnessDelivery advances the successful Harness-delivery
 // cursor only after RunTurn returned successfully, and only then removes the
 // addressed trigger. Callers must keep outbound Room reply delivery separate.
 func (r *ResidentRuntime) acknowledgeHarnessDelivery(target, through, generation int64) {
+	r.acknowledgeHarnessDeliveryFor(roomScope, target, through, generation)
+}
+
+func (r *ResidentRuntime) acknowledgeHarnessDeliveryFor(scope string, target, through, generation int64) {
 	r.mu.Lock()
-	if through > r.deliveredThrough {
-		r.deliveredThrough = through
+	ref := r.sessionRefLocked(scope)
+	if through > *ref.deliveredThrough {
+		*ref.deliveredThrough = through
 	}
-	if generation > 0 && generation == r.observedHarnessGeneration {
-		r.bootstrappedHarnessGeneration = generation
+	if generation > 0 && generation == *ref.observedHarnessGeneration {
+		*ref.bootstrappedHarnessGeneration = generation
 	}
-	for index, pending := range r.pendingAddressed {
+	for index, pending := range *ref.pendingAddressed {
 		if pending != target {
 			continue
 		}
-		r.pendingAddressed = append(r.pendingAddressed[:index], r.pendingAddressed[index+1:]...)
-		delete(r.pendingContexts, target)
+		*ref.pendingAddressed = append((*ref.pendingAddressed)[:index], (*ref.pendingAddressed)[index+1:]...)
+		delete(*ref.pendingContexts, target)
 		break
 	}
 	r.mu.Unlock()
 }
 
 func (r *ResidentRuntime) transcriptDeliveryMarkers() (meeting, live int64) {
+	return r.transcriptDeliveryMarkersFor(roomScope)
+}
+
+func (r *ResidentRuntime) transcriptDeliveryMarkersFor(scope string) (meeting, live int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return max(r.meetingDeliveryFloor, r.meetingDeliveredThrough), max(r.liveTranscriptDeliveryFloor, r.liveTranscriptDeliveredThrough)
+	ref := r.sessionRefLocked(scope)
+	return max(*ref.meetingDeliveryFloor, *ref.meetingDeliveredThrough), max(*ref.liveTranscriptDeliveryFloor, *ref.liveTranscriptDeliveredThrough)
 }
 
 func (r *ResidentRuntime) acknowledgeTranscriptDelivery(meeting, live int64) {
+	r.acknowledgeTranscriptDeliveryFor(roomScope, meeting, live)
+}
+
+func (r *ResidentRuntime) acknowledgeTranscriptDeliveryFor(scope string, meeting, live int64) {
 	r.mu.Lock()
-	if meeting > r.meetingDeliveredThrough {
-		r.meetingDeliveredThrough = meeting
+	ref := r.sessionRefLocked(scope)
+	if meeting > *ref.meetingDeliveredThrough {
+		*ref.meetingDeliveredThrough = meeting
 	}
-	if live > r.liveTranscriptDeliveredThrough {
-		r.liveTranscriptDeliveredThrough = live
+	if live > *ref.liveTranscriptDeliveredThrough {
+		*ref.liveTranscriptDeliveredThrough = live
 	}
 	r.mu.Unlock()
 }
@@ -175,35 +358,40 @@ func (r *ResidentRuntime) acknowledgeTranscriptDelivery(meeting, live int64) {
 // with its current addressed trigger only; older bounded context stays
 // available through the explicit Runtime-mediated history read.
 func (r *ResidentRuntime) observeHarnessSession(generation, target int64) bool {
+	return r.observeHarnessSessionFor(roomScope, generation, target)
+}
+
+func (r *ResidentRuntime) observeHarnessSessionFor(scope string, generation, target int64) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	ref := r.sessionRefLocked(scope)
 	if generation <= 0 {
 		return false
 	}
-	if r.observedHarnessGeneration == 0 {
-		r.observedHarnessGeneration = generation
-		return r.bootstrappedHarnessGeneration != generation
+	if *ref.observedHarnessGeneration == 0 {
+		*ref.observedHarnessGeneration = generation
+		return *ref.bootstrappedHarnessGeneration != generation
 	}
-	if r.observedHarnessGeneration == generation {
-		return r.bootstrappedHarnessGeneration != generation
+	if *ref.observedHarnessGeneration == generation {
+		return *ref.bootstrappedHarnessGeneration != generation
 	}
-	r.observedHarnessGeneration = generation
+	*ref.observedHarnessGeneration = generation
 	if target > 0 {
 		// Reset the current session's actual delivery knowledge. The separate
 		// floor suppresses automatic replay of old history, without treating it
 		// as acknowledged by a Harness that has never seen it.
-		r.deliveredThrough = 0
-		r.roomDeliveryFloor = target - 1
+		*ref.deliveredThrough = 0
+		*ref.roomDeliveryFloor = target - 1
 	}
 	// A replacement ACP session has no private conversation memory. Keep a
 	// floor at the old successful marker so old bounded transcript history is
 	// explicitly pull-only, while any segment that failed delivery remains a
 	// proactive retry for the new session.
-	r.meetingDeliveryFloor = max(r.meetingDeliveryFloor, r.meetingDeliveredThrough)
-	r.liveTranscriptDeliveryFloor = max(r.liveTranscriptDeliveryFloor, r.liveTranscriptDeliveredThrough)
-	r.meetingDeliveredThrough = 0
-	r.liveTranscriptDeliveredThrough = 0
-	return r.bootstrappedHarnessGeneration != generation
+	*ref.meetingDeliveryFloor = max(*ref.meetingDeliveryFloor, *ref.meetingDeliveredThrough)
+	*ref.liveTranscriptDeliveryFloor = max(*ref.liveTranscriptDeliveryFloor, *ref.liveTranscriptDeliveredThrough)
+	*ref.meetingDeliveredThrough = 0
+	*ref.liveTranscriptDeliveredThrough = 0
+	return *ref.bootstrappedHarnessGeneration != generation
 }
 
 func (r *ResidentRuntime) bufferSince(after, through int64) []types.RoomEvent {
@@ -220,19 +408,24 @@ func (r *ResidentRuntime) bufferSince(after, through int64) []types.RoomEvent {
 // case recover it from the bounded authenticated Room history rather than
 // treating a local EventBuffer eviction as a permanent delivery failure.
 func (r *ResidentRuntime) pendingContext(target int64) ([]types.RoomEvent, error) {
+	return r.pendingContextFor(roomScope, target)
+}
+
+func (r *ResidentRuntime) pendingContextFor(scope string, target int64) ([]types.RoomEvent, error) {
 	r.mu.Lock()
-	pending, ok := r.pendingContexts[target]
+	ref := r.sessionRefLocked(scope)
+	pending, ok := (*ref.pendingContexts)[target]
 	if !ok {
-		start := max(r.deliveredThrough, r.roomDeliveryFloor)
+		start := max(*ref.deliveredThrough, *ref.roomDeliveryFloor)
 		pending = pendingTurnContext{
 			after:  start,
 			target: target,
-			events: cloneRoomEvents(r.eventBuffer.Since(start, target)),
+			events: r.eventsForScopeLocked(scope, start, target),
 		}
-		if r.pendingContexts == nil {
-			r.pendingContexts = make(map[int64]pendingTurnContext)
+		if *ref.pendingContexts == nil {
+			*ref.pendingContexts = make(map[int64]pendingTurnContext)
 		}
-		r.pendingContexts[target] = pending
+		(*ref.pendingContexts)[target] = pending
 	}
 	if len(pending.events) > 0 {
 		events := cloneRoomEvents(pending.events)
@@ -268,7 +461,9 @@ func (r *ResidentRuntime) pendingContext(target int64) ([]types.RoomEvent, error
 		last := cursor
 		for _, event := range context.Room.Events {
 			if event.Sequence > cursor && event.Sequence <= pending.target {
-				events = append(events, event)
+				if scopeForRoomEvent(event) == normalizeScope(scope) {
+					events = append(events, event)
+				}
 				last = event.Sequence
 			}
 		}
@@ -281,12 +476,53 @@ func (r *ResidentRuntime) pendingContext(target int64) ([]types.RoomEvent, error
 		return nil, fmt.Errorf("room context for sequence %d is unavailable", pending.target)
 	}
 	r.mu.Lock()
-	if current, exists := r.pendingContexts[target]; exists && len(current.events) == 0 {
+	ref = r.sessionRefLocked(scope)
+	if current, exists := (*ref.pendingContexts)[target]; exists && len(current.events) == 0 {
 		current.events = cloneRoomEvents(events)
-		r.pendingContexts[target] = current
+		(*ref.pendingContexts)[target] = current
 	}
 	r.mu.Unlock()
 	return events, nil
+}
+
+func (r *ResidentRuntime) eventsForScopeLocked(scope string, after, through int64) []types.RoomEvent {
+	all := r.eventBuffer.Since(after, through)
+	scope = normalizeScope(scope)
+	filtered := make([]types.RoomEvent, 0, len(all))
+	for _, event := range all {
+		if scopeForRoomEvent(event) == scope {
+			filtered = append(filtered, event)
+		}
+	}
+	return cloneRoomEvents(filtered)
+}
+
+// observeLogicalSource records an independent source checkpoint. It is an
+// observation only: no pending Room turn is created and no Harness call is
+// made. Source adapters can use the same narrow helper when this spike gains
+// another bounded source.
+func (r *ResidentRuntime) observeLogicalSource(scope, source string, cursor int64) {
+	scope = normalizeScope(scope)
+	source = strings.TrimSpace(source)
+	if source == "" || cursor < 0 {
+		return
+	}
+	r.mu.Lock()
+	ref := r.sessionRefLocked(scope)
+	if ref.sourceCursors != nil && cursor > (*ref.sourceCursors)[source] {
+		(*ref.sourceCursors)[source] = cursor
+	}
+	r.mu.Unlock()
+}
+
+func (r *ResidentRuntime) logicalSourceCursor(scope, source string) int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ref := r.sessionRefLocked(scope)
+	if ref.sourceCursors == nil {
+		return 0
+	}
+	return (*ref.sourceCursors)[source]
 }
 
 func (r *ResidentRuntime) rosterSnapshot() []types.ParticipantRosterEntry {

--- a/agent/internal/runtime/helpers.go
+++ b/agent/internal/runtime/helpers.go
@@ -19,8 +19,6 @@ type pendingTurnContext struct {
 	events []types.RoomEvent
 }
 
-const maxLogicalScopeLength = 128
-
 type logicalSessionRef struct {
 	deliveredThrough               *int64
 	roomDeliveryFloor              *int64
@@ -37,8 +35,11 @@ type logicalSessionRef struct {
 
 func normalizeScope(scope string) string {
 	scope = strings.TrimSpace(scope)
-	if scope == "" || len(scope) > maxLogicalScopeLength {
-		return roomScope
+	if scope == "" {
+		return ""
+	}
+	if len(scope) > types.MaxLogicalScopeLength {
+		return ""
 	}
 	return scope
 }
@@ -51,10 +52,13 @@ func newLogicalSessionState() *logicalSessionState {
 }
 
 // sessionRefLocked keeps the default Room scope on the existing fields while
-// giving task/request scopes their own delivery and source checkpoints.
-// Callers must hold r.mu.
+// reading an already-admitted task/request scope. It never creates a new
+// scope. Callers must hold r.mu.
 func (r *ResidentRuntime) sessionRefLocked(scope string) *logicalSessionRef {
 	scope = normalizeScope(scope)
+	if scope == "" {
+		return nil
+	}
 	if scope == roomScope {
 		return &logicalSessionRef{
 			deliveredThrough:               &r.deliveredThrough,
@@ -71,13 +75,11 @@ func (r *ResidentRuntime) sessionRefLocked(scope string) *logicalSessionRef {
 		}
 	}
 	if r.scopedSessions == nil {
-		r.scopedSessions = make(map[string]*logicalSessionState)
+		return nil
 	}
 	state := r.scopedSessions[scope]
 	if state == nil {
-		state = newLogicalSessionState()
-		r.scopedSessions[scope] = state
-		r.scopeOrder = append(r.scopeOrder, scope)
+		return nil
 	}
 	return &logicalSessionRef{
 		deliveredThrough:               &state.deliveredThrough,
@@ -94,13 +96,52 @@ func (r *ResidentRuntime) sessionRefLocked(scope string) *logicalSessionRef {
 	}
 }
 
+// ensureSessionRefLocked is the only creation path for non-Room logical
+// scopes. A full resident rejects the new scope instead of falling back to
+// the Room session or allocating an unbounded local/ACP conversation.
+func (r *ResidentRuntime) ensureSessionRefLocked(scope string) (*logicalSessionRef, bool) {
+	scope = normalizeScope(scope)
+	if scope == "" {
+		return nil, false
+	}
+	if ref := r.sessionRefLocked(scope); ref != nil {
+		return ref, true
+	}
+	if scope == roomScope || len(r.scopeOrder) >= types.MaxLogicalTaskScopes {
+		return nil, false
+	}
+	if r.scopedSessions == nil {
+		r.scopedSessions = make(map[string]*logicalSessionState)
+	}
+	state := newLogicalSessionState()
+	r.scopedSessions[scope] = state
+	r.scopeOrder = append(r.scopeOrder, scope)
+	return &logicalSessionRef{
+		deliveredThrough:               &state.deliveredThrough,
+		roomDeliveryFloor:              &state.roomDeliveryFloor,
+		pendingAddressed:               &state.pendingAddressed,
+		pendingContexts:                &state.pendingContexts,
+		observedHarnessGeneration:      &state.observedHarnessGeneration,
+		bootstrappedHarnessGeneration:  &state.bootstrappedHarnessGeneration,
+		meetingDeliveredThrough:        &state.meetingDeliveredThrough,
+		meetingDeliveryFloor:           &state.meetingDeliveryFloor,
+		liveTranscriptDeliveredThrough: &state.liveTranscriptDeliveredThrough,
+		liveTranscriptDeliveryFloor:    &state.liveTranscriptDeliveryFloor,
+		sourceCursors:                  &state.sourceCursors,
+	}, true
+}
+
 func (r *ResidentRuntime) scopeStateExistsLocked(scope string) bool {
 	scope = normalizeScope(scope)
-	return scope == roomScope || r.scopedSessions != nil && r.scopedSessions[scope] != nil
+	return scope == roomScope || scope != "" && r.scopedSessions != nil && r.scopedSessions[scope] != nil
 }
 
 func scopeForRoomEvent(event types.RoomEvent) string {
-	if scope := normalizeScope(event.ScopeID); scope != roomScope {
+	if rawScope := strings.TrimSpace(event.ScopeID); rawScope != "" {
+		scope := normalizeScope(rawScope)
+		if scope == "" {
+			return ""
+		}
 		return scope
 	}
 	// A bounded action producer may carry the same hint without requiring a
@@ -212,6 +253,9 @@ func (r *ResidentRuntime) pendingAddressedSnapshotFor(scope string) []int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return nil
+	}
 	return append([]int64(nil), (*ref.pendingAddressed)...)
 }
 
@@ -247,6 +291,9 @@ func (r *ResidentRuntime) peekPendingFor(scope string) (int64, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return 0, false
+	}
 	if len(*ref.pendingAddressed) == 0 {
 		return 0, false
 	}
@@ -264,6 +311,9 @@ func (r *ResidentRuntime) ackPendingFor(scope string, sequence int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return
+	}
 	for index, pending := range *ref.pendingAddressed {
 		if pending != sequence {
 			continue
@@ -281,7 +331,11 @@ func (r *ResidentRuntime) deliveredSeq() int64 {
 func (r *ResidentRuntime) deliveredSeqFor(scope string) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return *r.sessionRefLocked(scope).deliveredThrough
+	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return 0
+	}
+	return *ref.deliveredThrough
 }
 
 // effectiveDeliveryStart is the automatic-push boundary. A new ACP session
@@ -295,6 +349,9 @@ func (r *ResidentRuntime) effectiveDeliveryStartFor(scope string) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return 0
+	}
 	return max(*ref.deliveredThrough, *ref.roomDeliveryFloor)
 }
 
@@ -308,6 +365,10 @@ func (r *ResidentRuntime) acknowledgeHarnessDelivery(target, through, generation
 func (r *ResidentRuntime) acknowledgeHarnessDeliveryFor(scope string, target, through, generation int64) {
 	r.mu.Lock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		r.mu.Unlock()
+		return
+	}
 	if through > *ref.deliveredThrough {
 		*ref.deliveredThrough = through
 	}
@@ -333,6 +394,9 @@ func (r *ResidentRuntime) transcriptDeliveryMarkersFor(scope string) (meeting, l
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return 0, 0
+	}
 	return max(*ref.meetingDeliveryFloor, *ref.meetingDeliveredThrough), max(*ref.liveTranscriptDeliveryFloor, *ref.liveTranscriptDeliveredThrough)
 }
 
@@ -343,6 +407,10 @@ func (r *ResidentRuntime) acknowledgeTranscriptDelivery(meeting, live int64) {
 func (r *ResidentRuntime) acknowledgeTranscriptDeliveryFor(scope string, meeting, live int64) {
 	r.mu.Lock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		r.mu.Unlock()
+		return
+	}
 	if meeting > *ref.meetingDeliveredThrough {
 		*ref.meetingDeliveredThrough = meeting
 	}
@@ -365,6 +433,9 @@ func (r *ResidentRuntime) observeHarnessSessionFor(scope string, generation, tar
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return false
+	}
 	if generation <= 0 {
 		return false
 	}
@@ -414,6 +485,10 @@ func (r *ResidentRuntime) pendingContext(target int64) ([]types.RoomEvent, error
 func (r *ResidentRuntime) pendingContextFor(scope string, target int64) ([]types.RoomEvent, error) {
 	r.mu.Lock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		r.mu.Unlock()
+		return nil, errors.New("logical scope is unavailable")
+	}
 	pending, ok := (*ref.pendingContexts)[target]
 	if !ok {
 		start := max(*ref.deliveredThrough, *ref.roomDeliveryFloor)
@@ -477,6 +552,10 @@ func (r *ResidentRuntime) pendingContextFor(scope string, target int64) ([]types
 	}
 	r.mu.Lock()
 	ref = r.sessionRefLocked(scope)
+	if ref == nil {
+		r.mu.Unlock()
+		return nil, errors.New("logical scope is unavailable")
+	}
 	if current, exists := (*ref.pendingContexts)[target]; exists && len(current.events) == 0 {
 		current.events = cloneRoomEvents(events)
 		(*ref.pendingContexts)[target] = current
@@ -508,7 +587,19 @@ func (r *ResidentRuntime) observeLogicalSource(scope, source string, cursor int6
 		return
 	}
 	r.mu.Lock()
-	ref := r.sessionRefLocked(scope)
+	ref, admitted := r.ensureSessionRefLocked(scope)
+	if !admitted || ref == nil {
+		r.mu.Unlock()
+		return
+	}
+	if ref.sourceCursors == nil {
+		r.mu.Unlock()
+		return
+	}
+	if _, exists := (*ref.sourceCursors)[source]; !exists && len(*ref.sourceCursors) >= types.MaxLogicalSourceCursors {
+		r.mu.Unlock()
+		return
+	}
 	if ref.sourceCursors != nil && cursor > (*ref.sourceCursors)[source] {
 		(*ref.sourceCursors)[source] = cursor
 	}
@@ -519,6 +610,9 @@ func (r *ResidentRuntime) logicalSourceCursor(scope, source string) int64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	ref := r.sessionRefLocked(scope)
+	if ref == nil {
+		return 0
+	}
 	if ref.sourceCursors == nil {
 		return 0
 	}

--- a/agent/internal/runtime/live_transcript.go
+++ b/agent/internal/runtime/live_transcript.go
@@ -176,6 +176,10 @@ func (r *ResidentRuntime) publishLiveTranscriptSegment(generation uint64, source
 // delivered to the retained Harness. A refresh failure never blocks ordinary
 // collaboration and a returned marker is acknowledged only after RunTurn.
 func (r *ResidentRuntime) attachLiveTranscript(input *types.HarnessTurnInput) int64 {
+	return r.attachLiveTranscriptFor(roomScope, input)
+}
+
+func (r *ResidentRuntime) attachLiveTranscriptFor(scope string, input *types.HarnessTurnInput) int64 {
 	roomID := r.activeRoomID()
 	if roomID == "" {
 		return 0
@@ -188,7 +192,7 @@ func (r *ResidentRuntime) attachLiveTranscript(input *types.HarnessTurnInput) in
 	if len(info.LiveTranscriptSegments) == 0 {
 		return 0
 	}
-	_, delivered := r.transcriptDeliveryMarkers()
+	_, delivered := r.transcriptDeliveryMarkersFor(scope)
 	segments := make([]types.LiveTranscriptSegment, 0, len(info.LiveTranscriptSegments))
 	var through int64
 	for _, segment := range info.LiveTranscriptSegments {

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -256,10 +256,14 @@ func (r *ResidentRuntime) voiceOutput() *voice.Speaker {
 // so failed/ambiguous prompts retry the same local speech while unchanged
 // (including empty) snapshots do not consume prompt context.
 func (r *ResidentRuntime) attachTranscript(input *types.HarnessTurnInput) int64 {
+	return r.attachTranscriptFor(roomScope, input)
+}
+
+func (r *ResidentRuntime) attachTranscriptFor(scope string, input *types.HarnessTurnInput) int64 {
 	if r.transcript == nil {
 		return 0
 	}
-	meetingDelivered, _ := r.transcriptDeliveryMarkers()
+	meetingDelivered, _ := r.transcriptDeliveryMarkersFor(scope)
 	snapshot := r.transcript.Snapshot()
 	segments := make([]types.HarnessTranscriptSegment, 0, len(snapshot.Segments))
 	var through int64

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -26,6 +26,25 @@ const (
 	StateStopped      State = "stopped"
 )
 
+const roomScope = "room"
+
+// logicalSessionState is Runtime-local cognition state for one logical
+// scope. Room transport, participant credentials, roster, and the bounded
+// source event buffer remain ResidentRuntime-level state.
+type logicalSessionState struct {
+	deliveredThrough               int64
+	roomDeliveryFloor              int64
+	pendingAddressed               []int64
+	pendingContexts                map[int64]pendingTurnContext
+	observedHarnessGeneration      int64
+	bootstrappedHarnessGeneration  int64
+	meetingDeliveredThrough        int64
+	meetingDeliveryFloor           int64
+	liveTranscriptDeliveredThrough int64
+	liveTranscriptDeliveryFloor    int64
+	sourceCursors                  map[string]int64
+}
+
 // Status is the side-effect-free status projection returned over IPC.
 type Status struct {
 	InstanceID    string `json:"instanceId"`
@@ -144,9 +163,14 @@ type ResidentRuntime struct {
 	liveTranscriptDeliveredThrough int64
 	liveTranscriptDeliveryFloor    int64
 	eventBuffer                    *EventBuffer
-	advertisedCaps                 []string
-	roster                         []types.ParticipantRosterEntry
-	resolvedRoomID                 string
+	// scopedSessions contains only non-default logical scopes. The legacy
+	// fields above remain the Room scope so the proven #223 delivery path and
+	// its invariants stay structurally unchanged.
+	scopedSessions map[string]*logicalSessionState
+	scopeOrder     []string
+	advertisedCaps []string
+	roster         []types.ParticipantRosterEntry
+	resolvedRoomID string
 	// participatingSince is set once on the lifecycle's first successful
 	// adoptJoin and preserved across transient retries/reconnects (#228).
 	participatingSince int64
@@ -579,6 +603,8 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 		r.eventBuffer.Clear()
 		r.pendingAddressed = nil
 		r.pendingContexts = nil
+		r.scopedSessions = nil
+		r.scopeOrder = nil
 	}
 	r.state = StateWaiting
 	r.lastError = ""
@@ -654,7 +680,7 @@ func (r *ResidentRuntime) waitLoop() {
 
 		retryAttempt = 0
 		r.advanceFromWait(result)
-		if len(r.pendingAddressedSnapshot()) > 0 && !r.isStopped() {
+		if len(r.pendingScopes()) > 0 && !r.isStopped() {
 			r.drainTurns()
 		}
 	}
@@ -795,7 +821,7 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 			return err
 		}
 		r.advanceFromWait(result)
-		if len(r.pendingAddressedSnapshot()) > 0 && !r.isStopped() {
+		if len(r.pendingScopes()) > 0 && !r.isStopped() {
 			r.drainTurns()
 		}
 	}
@@ -906,24 +932,34 @@ func (r *ResidentRuntime) advanceFromWait(result types.WaitResult) {
 func (r *ResidentRuntime) acceptEvent(event types.RoomEvent) {
 	r.mu.Lock()
 	r.eventBuffer.Add(event)
-	if event.Addressed && !containsSequence(r.pendingAddressed, event.Sequence) {
+	scope := scopeForRoomEvent(event)
+	newScope := scope != roomScope && !r.scopeStateExistsLocked(scope)
+	ref := r.sessionRefLocked(scope)
+	if newScope {
+		// A task scope starts at its first task-correlated trigger. Earlier
+		// private Room conversation remains pull-only and is not copied into a
+		// new Harness conversation implicitly.
+		*ref.deliveredThrough = event.Sequence - 1
+		*ref.roomDeliveryFloor = event.Sequence - 1
+	}
+	if event.Addressed && !containsSequence(*ref.pendingAddressed, event.Sequence) {
 		// Do not use BoundedPush here. An addressed trigger remains unacknowledged
 		// until RunTurn succeeds, so front eviction would silently lose a failed
 		// turn. When the bounded queue is full, keep every already-accepted
 		// context intact rather than silently acknowledging or replacing it.
-		if len(r.pendingAddressed) < MaxPendingTurns {
-			after := max(r.deliveredThrough, r.roomDeliveryFloor)
-			if pending := len(r.pendingAddressed); pending > 0 {
-				after = r.pendingAddressed[pending-1]
+		if len(*ref.pendingAddressed) < MaxPendingTurns {
+			after := max(*ref.deliveredThrough, *ref.roomDeliveryFloor)
+			if pending := len(*ref.pendingAddressed); pending > 0 {
+				after = (*ref.pendingAddressed)[pending-1]
 			}
-			if r.pendingContexts == nil {
-				r.pendingContexts = make(map[int64]pendingTurnContext)
+			if *ref.pendingContexts == nil {
+				*ref.pendingContexts = make(map[int64]pendingTurnContext)
 			}
-			r.pendingAddressed = append(r.pendingAddressed, event.Sequence)
-			r.pendingContexts[event.Sequence] = pendingTurnContext{
+			*ref.pendingAddressed = append(*ref.pendingAddressed, event.Sequence)
+			(*ref.pendingContexts)[event.Sequence] = pendingTurnContext{
 				after:  after,
 				target: event.Sequence,
-				events: cloneRoomEvents(r.eventBuffer.Since(after, event.Sequence)),
+				events: r.eventsForScopeLocked(scope, after, event.Sequence),
 			}
 		}
 	}
@@ -973,13 +1009,18 @@ func (r *ResidentRuntime) drainTurns() {
 	}()
 
 	for !r.isStopped() {
-		target, ok := r.peekPending()
-		if !ok {
+		scopes := r.pendingScopes()
+		if len(scopes) == 0 {
 			return
+		}
+		scope := scopes[0]
+		target, ok := r.peekPendingFor(scope)
+		if !ok {
+			continue
 		}
 		// Ensure before rendering so the prompt accurately knows whether this
 		// is the same retained ACP conversation or a real session/new.
-		if err := r.options.Adapter.EnsureSession(); err != nil {
+		if err := r.ensureHarnessSession(scope); err != nil {
 			r.mu.Lock()
 			r.lastError = err.Error()
 			r.lastErrorSource = "harness"
@@ -988,9 +1029,9 @@ func (r *ResidentRuntime) drainTurns() {
 			r.log("turn_failed", nil)
 			return
 		}
-		generation := r.options.Adapter.SessionGeneration()
-		newSession := r.observeHarnessSession(generation, target)
-		events, contextErr := r.pendingContext(target)
+		generation := r.harnessSessionGeneration(scope)
+		newSession := r.observeHarnessSessionFor(scope, generation, target)
+		events, contextErr := r.pendingContextFor(scope, target)
 		if contextErr != nil {
 			r.mu.Lock()
 			r.lastError = contextErr.Error()
@@ -1005,8 +1046,8 @@ func (r *ResidentRuntime) drainTurns() {
 			// successful-delivery cursor already covers it. Otherwise bounded
 			// local context was lost, so retain the trigger for a later retry
 			// rather than silently claiming Harness delivery.
-			if target <= r.effectiveDeliveryStart() {
-				r.ackPending(target)
+			if target <= r.effectiveDeliveryStartFor(scope) {
+				r.ackPendingFor(scope, target)
 				continue
 			}
 			r.log("turn_context_unavailable", nil)
@@ -1031,8 +1072,8 @@ func (r *ResidentRuntime) drainTurns() {
 			CurrentRoomSequence: maxSeq,
 		}
 		r.enrichAttachments(input)
-		meetingThrough := r.attachTranscript(input)
-		liveThrough := r.attachLiveTranscript(input)
+		meetingThrough := r.attachTranscriptFor(scope, input)
+		liveThrough := r.attachLiveTranscriptFor(scope, input)
 
 		// A newly addressed turn wins the speaker: stale audio from the
 		// previous response must never keep playing over the new one.
@@ -1040,7 +1081,7 @@ func (r *ResidentRuntime) drainTurns() {
 			voiceOutput.Cancel()
 		}
 
-		result, err := r.options.Adapter.RunTurn(*input, generation)
+		result, err := r.runHarnessTurn(scope, *input, generation)
 		if err != nil {
 			r.mu.Lock()
 			r.lastError = err.Error()
@@ -1057,8 +1098,8 @@ func (r *ResidentRuntime) drainTurns() {
 		// RunTurn succeeded: commit every delivery marker before lifecycle
 		// handling or text persistence. If either of those later operations
 		// fails, replaying this already-consumed Harness prompt would be wrong.
-		r.acknowledgeHarnessDelivery(target, maxSeq, generation)
-		r.acknowledgeTranscriptDelivery(meetingThrough, liveThrough)
+		r.acknowledgeHarnessDeliveryFor(scope, target, maxSeq, generation)
+		r.acknowledgeTranscriptDeliveryFor(scope, meetingThrough, liveThrough)
 		r.mu.Lock()
 		r.harnessFailed = false
 		// #228: a successful turn proves the Harness recovered — clear ONLY

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -1039,7 +1039,16 @@ func (r *ResidentRuntime) drainTurns() {
 			r.log("turn_failed", nil)
 			return
 		}
-		generation := r.harnessSessionGeneration(scope)
+		generation, err := r.harnessSessionGeneration(scope)
+		if err != nil {
+			r.mu.Lock()
+			r.lastError = err.Error()
+			r.lastErrorSource = "harness"
+			r.state = StateReconnecting
+			r.mu.Unlock()
+			r.log("turn_failed", nil)
+			return
+		}
 		newSession := r.observeHarnessSessionFor(scope, generation, target)
 		events, contextErr := r.pendingContextFor(scope, target)
 		if contextErr != nil {

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -931,10 +931,20 @@ func (r *ResidentRuntime) advanceFromWait(result types.WaitResult) {
 
 func (r *ResidentRuntime) acceptEvent(event types.RoomEvent) {
 	r.mu.Lock()
-	r.eventBuffer.Add(event)
 	scope := scopeForRoomEvent(event)
+	if scope == "" {
+		r.mu.Unlock()
+		r.log("logical_scope_rejected", map[string]string{"reason": "invalid"})
+		return
+	}
 	newScope := scope != roomScope && !r.scopeStateExistsLocked(scope)
-	ref := r.sessionRefLocked(scope)
+	ref, admitted := r.ensureSessionRefLocked(scope)
+	if !admitted {
+		r.mu.Unlock()
+		r.log("logical_scope_rejected", map[string]string{"reason": "capacity"})
+		return
+	}
+	r.eventBuffer.Add(event)
 	if newScope {
 		// A task scope starts at its first task-correlated trigger. Earlier
 		// private Room conversation remains pull-only and is not copied into a

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -812,9 +812,13 @@ type fakeAdapter struct {
 	generation  int64
 	// replaceBeforeRun simulates a process/session replacement in the narrow
 	// interval after Runtime.EnsureSession but before it can bind RunTurn.
-	replaceBeforeRun bool
-	stopped          bool
-	delay            time.Duration
+	replaceBeforeRun  bool
+	stopped           bool
+	delay             time.Duration
+	scopedGenerations map[string]int64
+	scopedRuns        []string
+	scopedTurnDetails map[string][]string
+	scopedSessionNews map[string][]bool
 }
 
 // adapterRunTurnHook lets individual tests observe the exact enriched turn
@@ -838,6 +842,30 @@ func (a *fakeAdapter) SessionGeneration() int64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.generation
+}
+
+func (a *fakeAdapter) EnsureSessionFor(scope string) error {
+	if scope == roomScope {
+		return a.EnsureSession()
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.scopedGenerations == nil {
+		a.scopedGenerations = make(map[string]int64)
+	}
+	if a.scopedGenerations[scope] == 0 {
+		a.scopedGenerations[scope] = int64(len(a.scopedGenerations) + 1)
+	}
+	return nil
+}
+
+func (a *fakeAdapter) SessionGenerationFor(scope string) int64 {
+	if scope == roomScope {
+		return a.SessionGeneration()
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.scopedGenerations[scope]
 }
 
 func (a *fakeAdapter) RunTurn(input types.HarnessTurnInput, expectedGeneration int64) (types.HarnessTurnResult, error) {
@@ -890,6 +918,66 @@ func (a *fakeAdapter) RunTurn(input types.HarnessTurnInput, expectedGeneration i
 		Text:                 "reply-" + itoa(int64(count)),
 		TargetParticipantIDs: targets,
 	}, nil
+}
+
+func (a *fakeAdapter) RunTurnFor(scope string, input types.HarnessTurnInput, expectedGeneration int64) (types.HarnessTurnResult, error) {
+	if scope == roomScope {
+		return a.RunTurn(input, expectedGeneration)
+	}
+	a.mu.Lock()
+	if a.scopedGenerations[scope] != expectedGeneration {
+		a.mu.Unlock()
+		return types.HarnessTurnResult{}, types.ErrHarnessSessionGenerationChanged
+	}
+	if a.scopedTurnDetails == nil {
+		a.scopedTurnDetails = make(map[string][]string)
+	}
+	if a.scopedSessionNews == nil {
+		a.scopedSessionNews = make(map[string][]bool)
+	}
+	texts := make([]string, 0, len(input.Events))
+	for _, event := range input.Events {
+		if event.Text != "" {
+			texts = append(texts, event.Text)
+		}
+	}
+	combined := strings.Join(texts, ",")
+	a.scopedRuns = append(a.scopedRuns, scope)
+	a.scopedTurnDetails[scope] = append(a.scopedTurnDetails[scope], combined)
+	a.scopedSessionNews[scope] = append(a.scopedSessionNews[scope], input.Session != nil && input.Session.New)
+	if a.turnErr != nil {
+		err := a.turnErr
+		a.mu.Unlock()
+		return types.HarnessTurnResult{}, err
+	}
+	a.mu.Unlock()
+	return types.HarnessTurnResult{Text: "reply-" + scope}, nil
+}
+
+func (a *fakeAdapter) scopedRunSnapshot() ([]string, map[string][]string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	runs := append([]string(nil), a.scopedRuns...)
+	details := make(map[string][]string, len(a.scopedTurnDetails))
+	for scope, entries := range a.scopedTurnDetails {
+		details[scope] = append([]string(nil), entries...)
+	}
+	return runs, details
+}
+
+func (a *fakeAdapter) recreateScopedSession(scope string) {
+	a.mu.Lock()
+	if a.scopedGenerations == nil {
+		a.scopedGenerations = make(map[string]int64)
+	}
+	a.scopedGenerations[scope]++
+	a.mu.Unlock()
+}
+
+func (a *fakeAdapter) scopedSessionNewSnapshot(scope string) []bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]bool(nil), a.scopedSessionNews[scope]...)
 }
 
 func (a *fakeAdapter) sessionsInt() int {

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -1,0 +1,198 @@
+package runtime
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+func newScopedRuntimeFixture(t *testing.T, adapter *fakeAdapter) *ResidentRuntime {
+	t.Helper()
+	rt := NewResidentRuntime(Options{
+		InstanceID: "scoped-test",
+		RoomID:     "room-scoped",
+		Name:       "Agent",
+		Client:     &fakeClient{},
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	return rt
+}
+
+func scopedEvent(sequence int64, scope, text string) types.RoomEvent {
+	event := roomEvent(sequence, true)
+	event.ScopeID = scope
+	event.Text = text
+	return event
+}
+
+func TestLogicalScopesReuseIsolatedHarnessSessions(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+
+	for _, event := range []types.RoomEvent{
+		{Sequence: 1, Type: "text", Participant: types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}, Text: "ROOM_MARKER", Addressed: true},
+		scopedEvent(2, "task:T", "TASK_T_MARKER"),
+		scopedEvent(3, "task:U", "TASK_U_MARKER"),
+	} {
+		rt.acceptEvent(event)
+	}
+	rt.drainTurns()
+
+	runs, details := adapter.scopedRunSnapshot()
+	if !reflect.DeepEqual(runs, []string{"task:T", "task:U"}) {
+		t.Fatalf("unexpected task session routing: %v", runs)
+	}
+	if !reflect.DeepEqual(details["task:T"], []string{"TASK_T_MARKER"}) ||
+		!reflect.DeepEqual(details["task:U"], []string{"TASK_U_MARKER"}) {
+		t.Fatalf("task contexts crossed scopes: %#v", details)
+	}
+	adapter.mu.Lock()
+	roomTurns := append([]string(nil), adapter.turnDtls...)
+	adapter.mu.Unlock()
+	if !reflect.DeepEqual(roomTurns, []string{"ROOM_MARKER"}) {
+		t.Fatalf("Room scope inherited task context: %v", roomTurns)
+	}
+
+	for _, event := range []types.RoomEvent{
+		scopedEvent(4, "task:T", "TASK_T_MARKER_2"),
+		scopedEvent(5, "task:U", "TASK_U_MARKER_2"),
+	} {
+		rt.acceptEvent(event)
+	}
+	rt.drainTurns()
+	runs, details = adapter.scopedRunSnapshot()
+	if !reflect.DeepEqual(runs, []string{"task:T", "task:U", "task:T", "task:U"}) {
+		t.Fatalf("alternating turns did not return to retained scopes: %v", runs)
+	}
+	if !reflect.DeepEqual(details["task:T"], []string{"TASK_T_MARKER", "TASK_T_MARKER_2"}) ||
+		!reflect.DeepEqual(details["task:U"], []string{"TASK_U_MARKER", "TASK_U_MARKER_2"}) {
+		t.Fatalf("alternating scope context was not retained: %#v", details)
+	}
+}
+
+func TestScopedDeliveryFailureDoesNotAdvanceAnotherScope(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("T failed")}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+	rt.acceptEvent(scopedEvent(1, "task:T", "T1"))
+	rt.acceptEvent(scopedEvent(2, "task:U", "U1"))
+
+	rt.drainTurns()
+	if got := rt.deliveredSeqFor("task:U"); got != 1 {
+		t.Fatalf("U delivery advanced while T failed: %d", got)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:U"); !reflect.DeepEqual(got, []int64{2}) {
+		t.Fatalf("U pending delivery was acknowledged by T failure: %v", got)
+	}
+
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	rt.drainTurns()
+	if got := rt.deliveredSeqFor("task:T"); got != 1 {
+		t.Fatalf("T retry did not acknowledge its own delivery: %d", got)
+	}
+	if got := rt.deliveredSeqFor("task:U"); got != 2 {
+		t.Fatalf("U delivery did not advance after its own success: %d", got)
+	}
+}
+
+func TestScopedSessionGenerationAndRoomReconnectAreTruthful(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+
+	rt.acceptEvent(scopedEvent(1, "task:T", "T1"))
+	rt.drainTurns()
+	rt.acceptEvent(scopedEvent(2, "task:T", "T2"))
+	rt.drainTurns()
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false}) {
+		t.Fatalf("same scope did not reuse its retained conversation: %v", got)
+	}
+
+	// A Room reconnect replaces transport credentials but does not create a
+	// new ACP conversation for the surviving task scope.
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent-rejoined",
+		ParticipantHandle: "room-secret-2",
+		Cursor:            10,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	rt.acceptEvent(scopedEvent(3, "task:T", "T3"))
+	rt.drainTurns()
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false}) {
+		t.Fatalf("Room reconnect reset task Harness session: %v", got)
+	}
+
+	adapter.recreateScopedSession("task:T")
+	rt.acceptEvent(scopedEvent(4, "task:T", "T4"))
+	rt.drainTurns()
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false, true}) {
+		t.Fatalf("scoped Harness replacement did not request bootstrap: %v", got)
+	}
+	_, details := adapter.scopedRunSnapshot()
+	if !reflect.DeepEqual(details["task:T"], []string{"T1", "T2", "T3", "T4"}) {
+		t.Fatalf("new session replayed unrelated private context: %#v", details)
+	}
+}
+
+func TestLogicalTaskSourceCursorsAreIndependentAndObservationDoesNotRunTurn(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+
+	rt.observeLogicalSource("task:T", "domain-a", 7)
+	rt.observeLogicalSource("task:T", "domain-b", 19)
+	rt.observeLogicalSource("task:T", "domain-a", 6)
+	if got := rt.logicalSourceCursor("task:T", "domain-a"); got != 7 {
+		t.Fatalf("domain-a cursor regressed: %d", got)
+	}
+	if got := rt.logicalSourceCursor("task:T", "domain-b"); got != 19 {
+		t.Fatalf("domain-b cursor changed unexpectedly: %d", got)
+	}
+	if runs, _ := adapter.scopedRunSnapshot(); len(runs) != 0 {
+		t.Fatalf("source observation triggered a Harness turn: %v", runs)
+	}
+
+	taskAttention := roomEvent(1, true)
+	taskAttention.Text = "explicit task attention"
+	taskAttention.ActionPayload = map[string]string{"taskId": "T"}
+	rt.acceptEvent(taskAttention)
+	rt.drainTurns()
+	if runs, _ := adapter.scopedRunSnapshot(); !reflect.DeepEqual(runs, []string{"task:T"}) {
+		t.Fatalf("explicit task attention was not routed to task scope: %v", runs)
+	}
+}
+
+func TestSameTaskAcrossTwoResidentsUsesSeparateHarnessBindings(t *testing.T) {
+	adapterA := &fakeAdapter{name: "pi-a"}
+	adapterB := &fakeAdapter{name: "pi-b"}
+	runtimeA := newScopedRuntimeFixture(t, adapterA)
+	runtimeB := newScopedRuntimeFixture(t, adapterB)
+	defer runtimeA.Stop()
+	defer runtimeB.Stop()
+
+	runtimeA.acceptEvent(scopedEvent(1, "task:T", "AGENT_A_PRIVATE"))
+	runtimeB.acceptEvent(scopedEvent(1, "task:T", "AGENT_B_PRIVATE"))
+	runtimeA.drainTurns()
+	runtimeB.drainTurns()
+
+	if runs, details := adapterA.scopedRunSnapshot(); !reflect.DeepEqual(runs, []string{"task:T"}) ||
+		!reflect.DeepEqual(details["task:T"], []string{"AGENT_A_PRIVATE"}) {
+		t.Fatalf("Agent A task session mismatch: runs=%v details=%#v", runs, details)
+	}
+	if runs, details := adapterB.scopedRunSnapshot(); !reflect.DeepEqual(runs, []string{"task:T"}) ||
+		!reflect.DeepEqual(details["task:T"], []string{"AGENT_B_PRIVATE"}) {
+		t.Fatalf("Agent B task session mismatch: runs=%v details=%#v", runs, details)
+	}
+}

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -194,5 +195,94 @@ func TestSameTaskAcrossTwoResidentsUsesSeparateHarnessBindings(t *testing.T) {
 	if runs, details := adapterB.scopedRunSnapshot(); !reflect.DeepEqual(runs, []string{"task:T"}) ||
 		!reflect.DeepEqual(details["task:T"], []string{"AGENT_B_PRIVATE"}) {
 		t.Fatalf("Agent B task session mismatch: runs=%v details=%#v", runs, details)
+	}
+}
+
+func TestSerializedRoomWireScopeIDRoutesToRetainedTaskSessions(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+
+	for _, raw := range []string{
+		`{"sequence":1,"type":"action","participant":{"id":"human","name":"Human","kind":"human"},"scopeId":"task:T","actionType":"collab","collab":{"requestId":"T","kind":"request","fromParticipantId":"human","targetParticipantId":"agent"},"addressed":true,"createdAt":1}`,
+		`{"sequence":2,"type":"action","participant":{"id":"human","name":"Human","kind":"human"},"scopeId":"task:U","actionType":"collab","collab":{"requestId":"U","kind":"request","fromParticipantId":"human","targetParticipantId":"agent"},"addressed":true,"createdAt":2}`,
+	} {
+		var event types.RoomEvent
+		if err := json.Unmarshal([]byte(raw), &event); err != nil {
+			t.Fatalf("serialized Room event did not decode: %v", err)
+		}
+		rt.acceptEvent(event)
+	}
+	rt.drainTurns()
+
+	runs, details := adapter.scopedRunSnapshot()
+	if !reflect.DeepEqual(runs, []string{"task:T", "task:U"}) {
+		t.Fatalf("serialized Room scopes did not route independently: %v", runs)
+	}
+	if !reflect.DeepEqual(details["task:T"], []string{""}) || !reflect.DeepEqual(details["task:U"], []string{""}) {
+		t.Fatalf("unexpected collab task contexts: %#v", details)
+	}
+
+	ordinary := roomEvent(3, true)
+	rt.acceptEvent(ordinary)
+	rt.drainTurns()
+	adapter.mu.Lock()
+	roomTurns := append([]string(nil), adapter.turnDtls...)
+	adapter.mu.Unlock()
+	if !reflect.DeepEqual(roomTurns, []string{"message-3"}) {
+		t.Fatalf("ordinary Room event did not stay in Room scope: %v", roomTurns)
+	}
+}
+
+func TestLogicalTaskScopeCapacityFailsClosedWithoutRoomFallback(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	rt := newScopedRuntimeFixture(t, adapter)
+	defer rt.Stop()
+
+	for index := 0; index < types.MaxLogicalTaskScopes; index++ {
+		scope := "task:" + itoa(int64(index+1))
+		rt.acceptEvent(scopedEvent(int64(index+1), scope, "scope-"+itoa(int64(index+1))))
+	}
+	rt.drainTurns()
+	rt.mu.Lock()
+	if len(rt.scopedSessions) != types.MaxLogicalTaskScopes || len(rt.scopeOrder) != types.MaxLogicalTaskScopes {
+		rt.mu.Unlock()
+		t.Fatalf("scope bound was not admitted exactly: sessions=%d order=%d", len(rt.scopedSessions), len(rt.scopeOrder))
+	}
+	rt.mu.Unlock()
+	initialRuns, initialDetails := adapter.scopedRunSnapshot()
+
+	// The ninth scope is rejected before it can enter EventBuffer, pending
+	// delivery, the Room session, or ACP session creation.
+	rt.acceptEvent(scopedEvent(100, "task:overflow", "MUST-NOT-LEAK"))
+	rt.drainTurns()
+	runs, details := adapter.scopedRunSnapshot()
+	if !reflect.DeepEqual(runs, initialRuns) || !reflect.DeepEqual(details, initialDetails) {
+		t.Fatalf("rejected scope changed Harness state: before=%v/%v after=%v/%v", initialRuns, initialDetails, runs, details)
+	}
+	if got := adapter.scopedSessionNewSnapshot("task:overflow"); got != nil {
+		t.Fatalf("rejected scope created a scoped session: %v", got)
+	}
+
+	// Existing scopes remain reusable at capacity and retain their conversation.
+	rt.acceptEvent(scopedEvent(101, "task:1", "scope-1-again"))
+	rt.drainTurns()
+	runs, details = adapter.scopedRunSnapshot()
+	if len(runs) != types.MaxLogicalTaskScopes+1 || !reflect.DeepEqual(details["task:1"], []string{"scope-1", "scope-1-again"}) {
+		t.Fatalf("existing scope was not reusable at capacity: runs=%v details=%#v", runs, details)
+	}
+	if got := adapter.scopedSessionNewSnapshot("task:1"); !reflect.DeepEqual(got, []bool{true, false}) {
+		t.Fatalf("existing scope did not retain its ACP conversation: %v", got)
+	}
+
+	// A later ordinary Room event still works, but it cannot contain the
+	// rejected scope's private trigger.
+	rt.acceptEvent(roomEvent(102, true))
+	rt.drainTurns()
+	adapter.mu.Lock()
+	roomTurns := append([]string(nil), adapter.turnDtls...)
+	adapter.mu.Unlock()
+	if !reflect.DeepEqual(roomTurns, []string{"message-102"}) {
+		t.Fatalf("rejected task fell back into Room context: %v", roomTurns)
 	}
 }

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,49 @@ func scopedEvent(sequence int64, scope, text string) types.RoomEvent {
 	event.Text = text
 	return event
 }
+
+type legacyOnlyAdapter struct {
+	ensureCalls     int
+	generationCalls int
+	runCalls        int
+	generation      int64
+	turns           []string
+}
+
+func (a *legacyOnlyAdapter) Name() string { return "legacy-only" }
+
+func (a *legacyOnlyAdapter) Capabilities() *types.HarnessCapabilities {
+	return &types.HarnessCapabilities{Text: true}
+}
+
+func (a *legacyOnlyAdapter) EnsureSession() error {
+	a.ensureCalls++
+	if a.generation == 0 {
+		a.generation = 1
+	}
+	return nil
+}
+
+func (a *legacyOnlyAdapter) SessionGeneration() int64 {
+	a.generationCalls++
+	return a.generation
+}
+
+func (a *legacyOnlyAdapter) RunTurn(input types.HarnessTurnInput, _ int64) (types.HarnessTurnResult, error) {
+	a.runCalls++
+	texts := make([]string, 0, len(input.Events))
+	for _, event := range input.Events {
+		if event.Text != "" {
+			texts = append(texts, event.Text)
+		}
+	}
+	a.turns = append(a.turns, strings.Join(texts, ","))
+	return types.HarnessTurnResult{Text: "legacy-reply"}, nil
+}
+
+func (a *legacyOnlyAdapter) OnFailure(types.AdapterFailureHandler) {}
+func (a *legacyOnlyAdapter) CancelTurn() error                     { return nil }
+func (a *legacyOnlyAdapter) Close() error                          { return nil }
 
 func TestLogicalScopesReuseIsolatedHarnessSessions(t *testing.T) {
 	adapter := &fakeAdapter{name: "pi"}
@@ -78,6 +122,54 @@ func TestLogicalScopesReuseIsolatedHarnessSessions(t *testing.T) {
 	if !reflect.DeepEqual(details["task:T"], []string{"TASK_T_MARKER", "TASK_T_MARKER_2"}) ||
 		!reflect.DeepEqual(details["task:U"], []string{"TASK_U_MARKER", "TASK_U_MARKER_2"}) {
 		t.Fatalf("alternating scope context was not retained: %#v", details)
+	}
+}
+
+func TestLegacyAdapterFailsClosedForTaskScope(t *testing.T) {
+	adapter := &legacyOnlyAdapter{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "legacy-only-test",
+		RoomID:     "room-legacy-only",
+		Name:       "Agent",
+		Client:     &fakeClient{},
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	rt.acceptEvent(roomEvent(1, true))
+	rt.acceptEvent(scopedEvent(2, "task:T", "TASK_PRIVATE"))
+	rt.drainTurns()
+
+	if !reflect.DeepEqual(adapter.turns, []string{"message-1"}) {
+		t.Fatalf("legacy adapter received task context or missed Room context: %v", adapter.turns)
+	}
+	if adapter.ensureCalls != 1 || adapter.generationCalls != 1 || adapter.runCalls != 1 {
+		t.Fatalf("task scope called legacy adapter methods: ensure=%d generation=%d run=%d", adapter.ensureCalls, adapter.generationCalls, adapter.runCalls)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); !reflect.DeepEqual(got, []int64{2}) {
+		t.Fatalf("unsupported task turn was incorrectly acknowledged: %v", got)
+	}
+	if status := rt.Status(); status.LastError != errScopedHarnessUnsupported.Error() {
+		t.Fatalf("unsupported task scope was not reported explicitly: %+v", status)
+	}
+
+	if err := rt.ensureHarnessSession("task:T"); !errors.Is(err, errScopedHarnessUnsupported) {
+		t.Fatalf("ensure helper did not fail closed: %v", err)
+	}
+	if _, err := rt.harnessSessionGeneration("task:T"); !errors.Is(err, errScopedHarnessUnsupported) {
+		t.Fatalf("generation helper did not fail closed: %v", err)
+	}
+	if _, err := rt.runHarnessTurn("task:T", types.HarnessTurnInput{}, 1); !errors.Is(err, errScopedHarnessUnsupported) {
+		t.Fatalf("turn helper did not fail closed: %v", err)
+	}
+	if adapter.ensureCalls != 1 || adapter.generationCalls != 1 || adapter.runCalls != 1 {
+		t.Fatalf("direct task helper calls reached legacy adapter: ensure=%d generation=%d run=%d", adapter.ensureCalls, adapter.generationCalls, adapter.runCalls)
 	}
 }
 

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -17,6 +17,21 @@ import (
 
 const runtimeProviderClaimDomain = "free4chat-runtime-provider-v1"
 
+// MaxLogicalTaskScopes bounds the resident-local non-Room cognition
+// conversations retained by one Agent process. It is a safety limit for this
+// spike, not a product entitlement or a task lifecycle policy.
+const MaxLogicalTaskScopes = 8
+
+// MaxLogicalScopeLength bounds the opaque scope label carried by the narrow
+// Agent wire projection. Producers must reject longer labels rather than
+// silently rewriting them into the ordinary Room scope.
+const MaxLogicalScopeLength = 128
+
+// MaxLogicalSourceCursors bounds the source-local checkpoints retained per
+// logical scope. Current producers are a small fixed set; this keeps an
+// accidental arbitrary source label from becoming another unbounded map.
+const MaxLogicalSourceCursors = 8
+
 // ValidRuntimeProviderCredential accepts an opaque 256-bit base64url value.
 // It is deliberately distinct from the public Runtime Host id grammar.
 func ValidRuntimeProviderCredential(value string) bool {

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -228,9 +228,14 @@ type RoomPermissionEvent struct {
 
 // RoomEvent is one room event delivered through wait_for_events.
 type RoomEvent struct {
-	Sequence      int64                   `json:"sequence"`
-	Type          string                  `json:"type"` // text | action | image
-	Participant   ParticipantIdentity     `json:"participant"`
+	Sequence    int64               `json:"sequence"`
+	Type        string              `json:"type"` // text | action | image
+	Participant ParticipantIdentity `json:"participant"`
+	// ScopeID is an optional bounded cognition-routing hint. Empty means the
+	// ordinary Room conversation; task/request producers may set it to route
+	// an addressed event to one logical Agent scope without changing Room
+	// transport ownership.
+	ScopeID       string                  `json:"scopeId,omitempty"`
 	Text          string                  `json:"text,omitempty"`
 	ActionType    string                  `json:"actionType,omitempty"`
 	ActionPayload map[string]string       `json:"actionPayload,omitempty"`
@@ -472,6 +477,17 @@ type HarnessAdapter interface {
 	OnFailure(handler AdapterFailureHandler)
 	CancelTurn() error
 	Close() error
+}
+
+// ScopedHarnessAdapter is the small optional seam for one resident Agent to
+// retain more than one logical Harness conversation. Scope is an opaque
+// Runtime-owned value; ACP session ids never leave the adapter.
+// Implementations may serialize turns across scopes while preserving each
+// scope's conversation and generation independently.
+type ScopedHarnessAdapter interface {
+	EnsureSessionFor(scope string) error
+	SessionGenerationFor(scope string) int64
+	RunTurnFor(scope string, input HarnessTurnInput, expectedSessionGeneration int64) (HarnessTurnResult, error)
 }
 
 // JoinResult is what join_room returns; the participantHandle is the bearer

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1736,9 +1736,19 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     message: RoomMessage,
     participantId: string
   ): AgentEvent {
+    // #303: reuse the already validated structured collaboration correlation
+    // instead of storing a second scope field in Room state. Only the target
+    // Agent receives this task scope; ordinary text and non-target context
+    // remain in the default Room conversation.
+    const scopeId =
+      message.collab?.targetParticipantId === participantId &&
+      message.collab.requestId
+        ? `task:${message.collab.requestId}`
+        : undefined
     return {
       sequence: message.sequence,
       type: message.type,
+      ...(scopeId === undefined ? {} : { scopeId }),
       participant: {
         id: message.peerId,
         name: message.name,

--- a/app/src/do/roomSessionAgentScope.test.ts
+++ b/app/src/do/roomSessionAgentScope.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+
+describe("RoomSession AgentEvent task scope projection (#303)", () => {
+  it("derives task scopes from targeted collab requestIds and leaves ordinary text in Room scope", () => {
+    const session = new RoomSession({} as never, { SFU_ROOM: {} } as never)
+    const project = (message: unknown, participantId: string) =>
+      (
+        session as unknown as {
+          toAgentEvent: (message: unknown, participantId: string) => unknown
+        }
+      ).toAgentEvent(message, participantId) as Record<string, unknown>
+
+    const messages = [
+      {
+        sequence: 1,
+        type: "action",
+        peerId: "human",
+        name: "Human",
+        kind: "human",
+        actionType: "collab",
+        collab: {
+          requestId: "T",
+          kind: "request",
+          fromParticipantId: "human",
+          targetParticipantId: "agent-a",
+        },
+        targets: ["agent-a"],
+        createdAt: 1,
+      },
+      {
+        sequence: 2,
+        type: "action",
+        peerId: "human",
+        name: "Human",
+        kind: "human",
+        actionType: "collab",
+        collab: {
+          requestId: "U",
+          kind: "request",
+          fromParticipantId: "human",
+          targetParticipantId: "agent-a",
+        },
+        targets: ["agent-a"],
+        createdAt: 2,
+      },
+      {
+        sequence: 3,
+        type: "text",
+        peerId: "human",
+        name: "Human",
+        kind: "human",
+        text: "ordinary Room message",
+        targets: ["agent-a"],
+        createdAt: 3,
+      },
+    ]
+
+    const projected = messages.map((message) => project(message, "agent-a"))
+    expect(projected.map((event) => event.scopeId)).toEqual([
+      "task:T",
+      "task:U",
+      undefined,
+    ])
+    expect(projected.every((event) => event.addressed === true)).toBe(true)
+
+    const serialized = JSON.parse(JSON.stringify(projected[0])) as Record<
+      string,
+      unknown
+    >
+    expect(serialized.scopeId).toBe("task:T")
+    expect(project(messages[0], "agent-b").scopeId).toBeUndefined()
+  })
+})

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -465,6 +465,9 @@ export interface RoomCapabilities {
 export interface AgentEvent {
   sequence: number
   type: "text" | "action" | "image"
+  // #303: only the sanitized addressed projection of a structured collab
+  // event carries its task correlation scope. Ordinary Room text has none.
+  scopeId?: string
   participant: {
     id: string
     name: string


### PR DESCRIPTION
Closes #303

Related architecture context: #299, #300, and retained ACP delivery semantics from #223.

## Decision under test

One resident Agent keeps one Room participant/transport while retaining multiple isolated logical Harness conversations. Room remains the default scope; task-correlated addressed events route to a bounded task scope. No Thread, workflow, event bus, database, or generic session platform is introduced.

## Implementation

- Added the optional, Runtime-specific `ScopedHarnessAdapter` seam: `EnsureSessionFor(scope)`, `SessionGenerationFor(scope)`, and `RunTurnFor(scope, ...)`. Existing `HarnessAdapter` callers remain compatible and default Room turns use the original methods.
- `ResidentRuntime` keeps participant-level transport/capability/roster/event-buffer state singleton. The existing Room delivery fields remain the Room scope; non-default scopes receive isolated pending queues, frozen contexts, delivery acknowledgements, ACP generation/bootstrap markers, transcript markers, and source-local cursors.
- An addressed event routes to exactly one scope: explicit `scopeId`, bounded `taskId` action correlation, or default `room`. Task scopes filter Room event context by scope, so a task does not inherit private Room conversation deltas implicitly.
- Source observation stores keyed per-scope cursors only; observing a source does not enqueue or run a Harness turn.
- `ACPAdapter` retains one OS Harness process and creates one ACP `session/new` conversation per logical scope. Prompt execution remains serialized across scopes by the existing `promptActive` boundary. ACP session ids stay adapter-private.
- Process death clears every ACP conversation binding. The next needed scope creates a truthful new ACP session/generation; Room reconnect does not reset surviving scoped conversations. No SQLite was added.

## Required report

Current singleton Runtime model: one Room participant, one Room transport/event buffer, one Harness adapter/process, one retained Room ACP session, and singleton Room delivery fields.

New logical session key: `(roomId, agentParticipantId, scopeId)`; the Runtime map is keyed by `scopeId` because the Room and Agent participant are already owned by the ResidentRuntime.

Scope routing rule: `event.scopeId` → bounded task/action `taskId` correlation → `room`; each addressed trigger is queued in exactly one scope.

Room/default scope: `room`, using the existing delivery and ACP compatibility methods.

Task scope: `task:<bounded correlation>`, with isolated Harness conversation and delivery state.

Harness process count: one per ResidentRuntime/ACPAdapter.

ACP sessions per process: one retained `session/new` conversation per logical scope.

How scoped ACP sessions are created/reused: `EnsureSessionFor(scope)` ensures the default ACP process, sends one `session/new` for a new non-room scope, stores an opaque adapter-local binding, and reuses it on later turns.

How SessionGeneration works per scope: each ACP scope has its own generation; a successful process/session replacement invalidates all bindings and the next scope creation gets a new generation. Runtime acknowledges delivery only for the generation that actually completed the turn.

Participant-level state that remains singleton: Room participant capability, Room WebSocket/transport cursor, lease/reconnect lifecycle, roster, Room event buffer, media ownership, and adapter process.

Session-level state: pending addressed queue/context, deliveredThrough, delivery floor, observed/bootstrap generation, transcript delivery markers, and source-local cursors.

Source-local cursor representation: `map[source]cursor` inside each non-default logical scope; no global sequence is introduced.

Global event sequence introduced: NO

One Harness session per event stream: NO

Room vs task isolation: PASS

Two tasks same Agent isolation: PASS

Alternating T/U retained-session test: PASS

Same task / two Agent session isolation: PASS (focused fake adapter test; each ResidentRuntime owns a separate adapter binding)

Event without attention causes RunTurn: NO

Room reconnect resets Harness task sessions: NO

Harness process death behavior: process death invalidates all ACP conversations owned by that process. Existing Runtime failure handling remains truthful; each scope receives a new bootstrap/session when next needed.

Runtime restart behavior: rejoin the Room, recreate logical scopes lazily as needed, and pull bounded current source context through existing source-owned paths. Old private Harness memory is not claimed to survive.

Local persistence required: NO

SQLite required: NO

Full Room messages persisted locally: NO

Existing #223 semantics preserved: YES — Room delta push remains distinct from bounded history pull, Harness-owned private memory remains private, and delivery acknowledgement occurs only after successful Harness turn.

Existing ordinary Room @Agent behavior: PASS

Real Harness smoke: not run; deterministic fake ACP smoke passes with one process, three session/new conversations, distinct session ids, and T/U/T/U prompt routing.

Files changed: `agent/internal/types/types.go`, `agent/internal/runtime/{runtime.go,helpers.go,media.go,live_transcript.go}`, `agent/internal/runtime/{runtime_test.go,scoped_sessions_test.go}`, `agent/internal/harness/{acp.go,acp_test.go}`, and the fake ACP test Harness.

New generalized abstractions: none. The optional adapter seam and task-local state are Runtime-specific and not exposed as a Thread/Session service.

Smallest Runtime-specific seam: optional scoped Harness adapter methods plus a per-scope delivery state map; existing Room fields and APIs remain the default path.

What should NOT be promoted to core: Thread, generic task UI, Counter/Domain bridge, Surface renderer, Extension registry, global event log/sequence, SQLite message mirror, ContextStore, RAG/vector DB, workflow engine, A2A, AG-UI/A2UI, or one process per source.

## Validation

- `gofmt -l .` clean
- `go vet ./...` passed
- `go test ./... -count=1 -timeout 300s` passed
- `go build ./cmd/free4chat-agent` passed
- distribution cleanup, installer, and bootstrap contract checks passed
- focused Runtime scope tests and fake ACP multi-session trace test passed

This PR is intentionally unmerged and gated for review.