### PR TITLE
chore: bump Agent Runtime to 0.5.25

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.24"
+var Version = "0.5.25"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary

- bump `agent/internal/doctor/doctor.go` from `0.5.24` to `0.5.25`
- keep live bootstrap on `0.5.24` until the native `agent-v0.5.25` Release is published and verified

## Verification

- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`
- `go build ./cmd/free4chat-agent`
- `gofmt -l .`
- installer and bootstrap contract scripts
- `doctor version --json` reports `0.5.25`

This PR is the source-version phase only; bootstrap activation follows after the native Release is verified.