### PR TITLE
chore: activate Agent Runtime 0.5.25 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -310,7 +310,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.24` (release tag `agent-v0.5.24`).
+`0.5.25` (release tag `agent-v0.5.25`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -371,7 +371,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.24"
+expected_version="0.5.25"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1819,7 +1819,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.24` (release tag `agent-v0.5.24`).
+`0.5.25` (release tag `agent-v0.5.25`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1880,7 +1880,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.24"
+expected_version="0.5.25"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

- activate the already-published and verified `agent-v0.5.25` native Runtime
- update the live bootstrap version/tag in `app/public/agent.md`
- regenerate the matching `app/public/llms-full.txt`

## Release evidence

- source-version PR #307 merged at `2c2b7af3cad9f21ef15d9aa3b4d2fc120e3ee6c8`
- native Release: https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.25
- all four assets and `SHA256SUMS` verified
- darwin/arm64 `doctor --json` reports `0.5.25`

## Verification

- bootstrap contract
- docs check
- Vitest 660/660
- type-check
- ESLint
- Prettier
- Cloudflare/OpenNext build

Bootstrap activation is intentionally separate from the native Runtime source-version PR.