### PR TITLE
feat(agent): expose ACP session mapping in status

### DIFF
--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -799,6 +799,44 @@ func TestStatusPayloadShowsResidentAfterDaemonAutoStart(t *testing.T) {
 	}
 }
 
+func TestStatusCLIPrintsHarnessSessionDiagnostics(t *testing.T) {
+	fixture := newFakeDaemon(t, func(request daemon.IpcRequest) daemon.IpcResponse {
+		if request.Op != "status" {
+			return daemon.IpcResponse{OK: false, Error: "unexpected fake daemon operation"}
+		}
+		return daemon.IpcResponse{OK: true, Result: []any{
+			map[string]any{
+				"instanceId": "resident-status",
+				"harnessSessions": []map[string]any{
+					{"scope": "room", "sessionId": "room-session", "generation": 1},
+					{"scope": "task:T", "sessionId": "task-session", "generation": 1},
+				},
+			},
+		}}
+	})
+
+	output, code := runCliWithFakeDaemon(t, fixture, "status")
+	if code != 0 {
+		t.Fatalf("status exited %d: %q", code, output)
+	}
+	var residents []struct {
+		HarnessSessions []struct {
+			Scope      string `json:"scope"`
+			SessionID  string `json:"sessionId"`
+			Generation int64  `json:"generation"`
+		} `json:"harnessSessions"`
+	}
+	if err := json.Unmarshal([]byte(output), &residents); err != nil {
+		t.Fatalf("status output was not JSON: %v (%q)", err, output)
+	}
+	if len(residents) != 1 || len(residents[0].HarnessSessions) != 2 ||
+		residents[0].HarnessSessions[0].Scope != "room" ||
+		residents[0].HarnessSessions[0].SessionID != "room-session" ||
+		residents[0].HarnessSessions[1].Scope != "task:T" {
+		t.Fatalf("status CLI altered or omitted Harness session diagnostics: %q", output)
+	}
+}
+
 func TestRunViaDaemonRejectsStaleResidentBeforeJoin(t *testing.T) {
 	dir, err := os.MkdirTemp("", "fcagent-")
 	if err != nil {

--- a/agent/internal/daemon/daemon_test.go
+++ b/agent/internal/daemon/daemon_test.go
@@ -366,6 +366,15 @@ func (*stubAdapter) OnFailure(types.AdapterFailureHandler) {}
 func (*stubAdapter) CancelTurn() error                     { return nil }
 func (*stubAdapter) Close() error                          { return nil }
 
+type diagnosticStubAdapter struct {
+	*stubAdapter
+	diagnostics []types.HarnessSessionDiagnostic
+}
+
+func (a *diagnosticStubAdapter) SessionDiagnostics() []types.HarnessSessionDiagnostic {
+	return append([]types.HarnessSessionDiagnostic(nil), a.diagnostics...)
+}
+
 type stubBundle struct {
 	client     *recordingClient
 	runtimeRef *runtime.ResidentRuntime
@@ -548,6 +557,48 @@ func TestDaemonStatusPreservesDistinctHarnessIdentities(t *testing.T) {
 	}
 	if seen["resident-hermes"] != "hermes" || seen["resident-codex"] != "codex" {
 		t.Fatalf("status substituted or obscured resident Harness identity: %#v", seen)
+	}
+}
+
+func TestDaemonStatusIPCProjectsHarnessSessionDiagnostics(t *testing.T) {
+	d, _ := startDaemon(t)
+	rt := runtime.NewResidentRuntime(runtime.Options{
+		InstanceID: "resident-status",
+		RoomID:     "status-room",
+		Name:       "Status Agent",
+		Client:     &recordingClient{},
+		Adapter: &diagnosticStubAdapter{
+			stubAdapter: &stubAdapter{name: "codex"},
+			diagnostics: []types.HarnessSessionDiagnostic{
+				{Scope: "room", SessionID: "room-session", Generation: 1},
+				{Scope: "task:T", SessionID: "task-session", Generation: 1},
+			},
+		},
+	})
+	t.Cleanup(rt.Stop)
+	d.register(&residentInstance{
+		instanceID: "resident-status",
+		roomID:     "status-room",
+		runtime:    rt,
+		workspace:  t.TempDir(),
+	})
+
+	result, err := SendIPC(&IpcRequest{Op: "status"})
+	if err != nil {
+		t.Fatalf("status IPC failed: %v", err)
+	}
+	var views []struct {
+		HarnessSessions []types.HarnessSessionDiagnostic `json:"harnessSessions"`
+	}
+	if err := json.Unmarshal(result, &views); err != nil {
+		t.Fatalf("decode status IPC result: %v (%s)", err, result)
+	}
+	if len(views) != 1 || len(views[0].HarnessSessions) != 2 ||
+		views[0].HarnessSessions[0].Scope != "room" ||
+		views[0].HarnessSessions[0].SessionID != "room-session" ||
+		views[0].HarnessSessions[1].Scope != "task:T" ||
+		views[0].HarnessSessions[1].SessionID != "task-session" {
+		t.Fatalf("status IPC omitted or altered Harness session diagnostics: %s", result)
 	}
 }
 

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -452,6 +452,40 @@ func (a *ACPAdapter) SessionGenerationFor(scope string) int64 {
 	return 0
 }
 
+// SessionDiagnostics returns the currently retained ACP conversation mapping
+// for local daemon/CLI status only. The snapshot contains no prompt/context
+// data and is sorted by logical scope so map iteration cannot affect output.
+func (a *ACPAdapter) SessionDiagnostics() []types.HarnessSessionDiagnostic {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	diagnostics := make([]types.HarnessSessionDiagnostic, 0, 1+len(a.sessions))
+	if a.sessionID != "" && a.sessionGeneration > 0 {
+		diagnostics = append(diagnostics, types.HarnessSessionDiagnostic{
+			Scope:      "room",
+			SessionID:  a.sessionID,
+			Generation: a.sessionGeneration,
+		})
+	}
+
+	scopes := make([]string, 0, len(a.sessions))
+	for scope, session := range a.sessions {
+		if session != nil && session.sessionID != "" && session.generation > 0 {
+			scopes = append(scopes, scope)
+		}
+	}
+	sort.Strings(scopes)
+	for _, scope := range scopes {
+		session := a.sessions[scope]
+		diagnostics = append(diagnostics, types.HarnessSessionDiagnostic{
+			Scope:      scope,
+			SessionID:  session.sessionID,
+			Generation: session.generation,
+		})
+	}
+	return diagnostics
+}
+
 // OnFailure registers the handler invoked on unexpected process death.
 func (a *ACPAdapter) OnFailure(handler types.AdapterFailureHandler) {
 	a.mu.Lock()

--- a/agent/internal/harness/acp_test.go
+++ b/agent/internal/harness/acp_test.go
@@ -257,6 +257,85 @@ func TestACPScopesRetainMultipleConversationsInOneProcess(t *testing.T) {
 	}
 }
 
+func TestACPSessionDiagnosticsTrackScopesAndClearOnProcessReplacement(t *testing.T) {
+	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{
+		"FAKE_UNIQUE_SESSION_IDS": "1",
+	}), AdapterOptions{})
+	defer adapter.Close()
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure Room session failed: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:U"); err != nil {
+		t.Fatalf("ensure U session failed: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:T"); err != nil {
+		t.Fatalf("ensure T session failed: %v", err)
+	}
+	wantScopes := []string{"room", "task:T", "task:U"}
+	wantGenerations := []int64{1, 2, 1}
+	got := adapter.SessionDiagnostics()
+	if len(got) != len(wantScopes) {
+		t.Fatalf("unexpected ACP session diagnostic count: got=%+v", got)
+	}
+	for index, diagnostic := range got {
+		if diagnostic.Scope != wantScopes[index] || diagnostic.SessionID == "" || diagnostic.Generation != wantGenerations[index] {
+			t.Fatalf("unexpected deterministic ACP session diagnostics: got=%+v", got)
+		}
+	}
+	if err := adapter.EnsureSessionFor("task:T"); err != nil {
+		t.Fatalf("reusing T session failed: %v", err)
+	}
+	if repeated := adapter.SessionDiagnostics(); !reflect.DeepEqual(repeated, got) {
+		t.Fatalf("reusing a scope changed its diagnostic mapping: got=%+v want=%+v", repeated, got)
+	}
+
+	old := append([]types.HarnessSessionDiagnostic(nil), got...)
+	adapter.mu.Lock()
+	process := adapter.proc
+	adapter.mu.Unlock()
+	if process == nil || process.cmd.Process == nil {
+		t.Fatal("ACP process disappeared before replacement")
+	}
+	if err := process.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill ACP process: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(adapter.SessionDiagnostics()) == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := adapter.SessionDiagnostics(); len(got) != 0 {
+		t.Fatalf("process replacement retained stale diagnostics: %+v", got)
+	}
+
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure replacement Room session failed: %v", err)
+	}
+	if err := adapter.EnsureSessionFor("task:T"); err != nil {
+		t.Fatalf("ensure replacement T session failed: %v", err)
+	}
+	recreated := adapter.SessionDiagnostics()
+	if len(recreated) != 2 || recreated[0].Scope != "room" || recreated[1].Scope != "task:T" {
+		t.Fatalf("replacement diagnostics lost expected scopes: %+v", recreated)
+	}
+	for _, diagnostic := range recreated {
+		for _, previous := range old {
+			if diagnostic.Scope == previous.Scope && diagnostic.SessionID == previous.SessionID {
+				t.Fatalf("replacement reused stale ACP session id for %s: %q", diagnostic.Scope, diagnostic.SessionID)
+			}
+			if diagnostic.Scope == previous.Scope && diagnostic.Generation <= previous.Generation {
+				t.Fatalf("replacement did not advance ACP session generation for %s: old=%d new=%d", diagnostic.Scope, previous.Generation, diagnostic.Generation)
+			}
+		}
+		if diagnostic.Generation <= 0 {
+			t.Fatalf("replacement diagnostic has invalid generation: %+v", diagnostic)
+		}
+	}
+}
+
 func TestACPScopesAreBoundedAndExistingConversationRemainsReusable(t *testing.T) {
 	tracePath := filepath.Join(t.TempDir(), "acp-bound-trace.log")
 	adapter, _ := newTestAdapter(t, scriptLauncher("normal", map[string]string{

--- a/agent/internal/harness/testdata/fakeagent/main.go
+++ b/agent/internal/harness/testdata/fakeagent/main.go
@@ -16,7 +16,8 @@
 //
 // Markers/env: FAKE_EXIT_MARKER, FAKE_STATE_MARKER, FAKE_CANCEL_MARKER,
 // FAKE_IMAGE_CAP ("1" advertises image support), FAKE_REPLY_TEXT,
-// FAKE_POLICY_CAP ("1" advertises native modes/config options).
+// FAKE_POLICY_CAP ("1" advertises native modes/config options),
+// FAKE_UNIQUE_SESSION_IDS ("1" makes session ids process-unique for tests).
 package main
 
 import (
@@ -192,6 +193,9 @@ func main() {
 		case message.Method == "session/new":
 			a.nextSessionID++
 			sessionID := "session-" + strconv.Itoa(a.nextSessionID)
+			if os.Getenv("FAKE_UNIQUE_SESSION_IDS") == "1" {
+				sessionID = fmt.Sprintf("session-%d-%d", os.Getpid(), a.nextSessionID)
+			}
 			response := map[string]any{"sessionId": sessionID}
 			if os.Getenv("FAKE_POLICY_CAP") == "1" {
 				response["modes"] = map[string]any{

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -54,6 +54,10 @@ type Status struct {
 	State         State  `json:"state"`
 	ParticipantID string `json:"participantId,omitempty"`
 	LastError     string `json:"lastError,omitempty"`
+	// HarnessSessions is optional local ACP observability. It contains only
+	// logical scope, opaque session identity, and generation; it is never
+	// copied into Room/MCP state or Harness prompts.
+	HarnessSessions []types.HarnessSessionDiagnostic `json:"harnessSessions,omitempty"`
 	// ParticipatingSince is the epoch-ms timestamp of the resident's first
 	// successful join/create for the CURRENT lifecycle (#228). Preserved
 	// across transient retries/reconnects; a new resident lifecycle starts
@@ -412,6 +416,10 @@ func (r *ResidentRuntime) ConnectProviderClaim(providerClaim string) error {
 
 // Status snapshots the lifecycle state. It never contains the handle.
 func (r *ResidentRuntime) Status() Status {
+	var harnessSessions []types.HarnessSessionDiagnostic
+	if adapter, ok := r.options.Adapter.(types.HarnessSessionDiagnostics); ok {
+		harnessSessions = append(harnessSessions, adapter.SessionDiagnostics()...)
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return Status{
@@ -422,6 +430,7 @@ func (r *ResidentRuntime) Status() Status {
 		State:              r.state,
 		ParticipantID:      r.participantID,
 		LastError:          r.lastError,
+		HarnessSessions:    harnessSessions,
 		ParticipatingSince: r.participatingSince,
 	}
 }

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -79,6 +79,46 @@ func (a *legacyOnlyAdapter) OnFailure(types.AdapterFailureHandler) {}
 func (a *legacyOnlyAdapter) CancelTurn() error                     { return nil }
 func (a *legacyOnlyAdapter) Close() error                          { return nil }
 
+type diagnosticFakeAdapter struct {
+	*fakeAdapter
+	diagnostics []types.HarnessSessionDiagnostic
+}
+
+func (a *diagnosticFakeAdapter) SessionDiagnostics() []types.HarnessSessionDiagnostic {
+	return append([]types.HarnessSessionDiagnostic(nil), a.diagnostics...)
+}
+
+func TestStatusProjectsOptionalHarnessSessionDiagnostics(t *testing.T) {
+	want := []types.HarnessSessionDiagnostic{
+		{Scope: "room", SessionID: "room-session", Generation: 1},
+		{Scope: "task:T", SessionID: "task-session", Generation: 1},
+	}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "status-test",
+		RoomID:     "room-status",
+		Name:       "Agent",
+		Client:     &fakeClient{},
+		Adapter: &diagnosticFakeAdapter{
+			fakeAdapter: &fakeAdapter{name: "pi"},
+			diagnostics: want,
+		},
+	})
+	defer rt.Stop()
+
+	status := rt.Status()
+	if !reflect.DeepEqual(status.HarnessSessions, want) {
+		t.Fatalf("Runtime status lost optional Harness session diagnostics: got=%+v want=%+v", status.HarnessSessions, want)
+	}
+	encoded, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal status: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"harnessSessions"`) ||
+		!strings.Contains(string(encoded), `"sessionId":"room-session"`) {
+		t.Fatalf("status JSON omitted Harness session diagnostics: %s", encoded)
+	}
+}
+
 func TestLogicalScopesReuseIsolatedHarnessSessions(t *testing.T) {
 	adapter := &fakeAdapter{name: "pi"}
 	rt := newScopedRuntimeFixture(t, adapter)
@@ -157,6 +197,9 @@ func TestLegacyAdapterFailsClosedForTaskScope(t *testing.T) {
 	}
 	if status := rt.Status(); status.LastError != errScopedHarnessUnsupported.Error() {
 		t.Fatalf("unsupported task scope was not reported explicitly: %+v", status)
+	}
+	if status := rt.Status(); len(status.HarnessSessions) != 0 {
+		t.Fatalf("legacy adapter unexpectedly exposed Harness session diagnostics: %+v", status.HarnessSessions)
 	}
 
 	if err := rt.ensureHarnessSession("task:T"); !errors.Is(err, errScopedHarnessUnsupported) {

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -94,6 +94,23 @@ type HarnessCapabilities struct {
 	Resume bool
 }
 
+// HarnessSessionDiagnostic is bounded local diagnostic information for one
+// retained Harness conversation. ACP session ids are opaque adapter-local
+// identities: this type is used only at the daemon/CLI status boundary and
+// must never enter Room state, prompts, telemetry, or public responses.
+type HarnessSessionDiagnostic struct {
+	Scope      string `json:"scope"`
+	SessionID  string `json:"sessionId"`
+	Generation int64  `json:"generation"`
+}
+
+// HarnessSessionDiagnostics is an optional adapter capability for local
+// status observability. It deliberately does not broaden HarnessAdapter, so
+// legacy/custom adapters remain compatible and simply omit diagnostics.
+type HarnessSessionDiagnostics interface {
+	SessionDiagnostics() []HarnessSessionDiagnostic
+}
+
 // RuntimeHostProjection is the complete, secret-free capability projection a
 // Runtime Host shares about itself (#176 Phase A). runtimeHostId is a stable
 // opaque grouping key for one local Runtime installation/root; the speech


### PR DESCRIPTION
## Summary

Fixes #310.

Expose the retained local ACP session mapping through `free4chat-agent status`:

- add an optional `HarnessSessionDiagnostics` adapter seam without changing the core `HarnessAdapter` contract;
- report `room` plus bounded task scopes as `{scope, sessionId, generation}`;
- sort task scopes deterministically and keep ACP session ids local/opaque;
- clear stale mappings on Harness process death and report fresh mappings after recreation;
- preserve legacy/custom adapter compatibility by omitting the optional field when unsupported.

The existing scope bound and #309 session lifecycle are reused. No Task manager,
Room/MCP, prompt, credential, participant-handle, telemetry, or web surface was
added.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go build -o /private/tmp/free4chat-agent-310 ./cmd/free4chat-agent`
- focused `-race` tests for ACP, Runtime status, daemon IPC, and CLI status

The full `go test -race ./... -count=1` run is currently blocked by existing
unrelated races in free4chat client envelope use, daemon executable replacement,
Runtime media/cleanup tests, and voice test fixtures. The new and directly
affected race tests pass.
