### PR TITLE
feat: add scoped Room task interaction views

### DIFF
--- a/agent/internal/daemon/daemon_test.go
+++ b/agent/internal/daemon/daemon_test.go
@@ -305,6 +305,9 @@ func (c *recordingClient) SendText(_ string, text string, _ []string) (types.Sen
 	c.mu.Unlock()
 	return types.SendTextResult{Sequence: int64(len(c.sent))}, nil
 }
+func (c *recordingClient) SendTextForTask(handle, text string, targets []string, _ string) (types.SendTextResult, error) {
+	return c.SendText(handle, text, targets)
+}
 func (*recordingClient) ReadAttachment(string, string) (types.AttachmentRead, error) {
 	return types.AttachmentRead{}, errors.New("not used")
 }

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.25"
+var Version = "0.5.26"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -943,12 +943,26 @@ func parseLiveTranscriptContextWindow(result map[string]any) (types.LiveTranscri
 // carries explicit addressing (#165); when empty the tool payload is
 // byte-identical to the pre-#165 ordinary unaddressed send.
 func (c *Client) SendText(participantHandle, text string, targetParticipantIDs []string) (types.SendTextResult, error) {
+	return c.sendText(participantHandle, text, targetParticipantIDs, "")
+}
+
+// SendTextForTask preserves the canonical Room collaboration request on
+// ordinary Agent output so the browser can project it into the same Task view
+// and the Room can route the follow-up back to the same task scope.
+func (c *Client) SendTextForTask(participantHandle, text string, targetParticipantIDs []string, taskRequestID string) (types.SendTextResult, error) {
+	return c.sendText(participantHandle, text, targetParticipantIDs, taskRequestID)
+}
+
+func (c *Client) sendText(participantHandle, text string, targetParticipantIDs []string, taskRequestID string) (types.SendTextResult, error) {
 	args := map[string]any{
 		"participantHandle": participantHandle,
 		"text":              text,
 	}
 	if len(targetParticipantIDs) > 0 {
 		args["targetParticipantIds"] = targetParticipantIDs
+	}
+	if taskRequestID != "" {
+		args["taskRequestId"] = taskRequestID
 	}
 	result, err := c.callTool("send_text", args)
 	if err != nil {

--- a/agent/internal/free4chat/client_test.go
+++ b/agent/internal/free4chat/client_test.go
@@ -494,6 +494,31 @@ func TestSendTextCarriesExplicitTargets(t *testing.T) {
 	}
 }
 
+func TestSendTextForTaskCarriesExistingRequestCorrelation(t *testing.T) {
+	var seenArgs map[string]any
+	client, _ := newTestClient(t, func(w http.ResponseWriter, body map[string]any) {
+		switch toolNameOf(body) {
+		case "":
+			respondToolsList(w)
+		case "send_text":
+			seenArgs = toolArgs(body)
+			writeJSON(w, callResult(map[string]any{"sequence": float64(1)}))
+		default:
+			writeJSON(w, callResult(map[string]any{"sequence": float64(1)}))
+		}
+	})
+
+	if _, err := client.SendTextForTask("h", "task output", nil, "request-T"); err != nil {
+		t.Fatalf("task send failed: %v", err)
+	}
+	if seenArgs["taskRequestId"] != "request-T" {
+		t.Fatalf("task request correlation missing: %#v", seenArgs)
+	}
+	if _, present := seenArgs["targetParticipantIds"]; present {
+		t.Fatalf("task send unexpectedly invented targets: %#v", seenArgs)
+	}
+}
+
 func TestHTTPStatusClassification(t *testing.T) {
 	for _, tc := range []struct {
 		status   int

--- a/agent/internal/media/controller_test.go
+++ b/agent/internal/media/controller_test.go
@@ -85,6 +85,9 @@ func (*fakeRoomClient) WaitForEvents(string, int64, int) (types.WaitResult, erro
 func (*fakeRoomClient) SendText(string, string, []string) (types.SendTextResult, error) {
 	return types.SendTextResult{}, nil
 }
+func (*fakeRoomClient) SendTextForTask(string, string, []string, string) (types.SendTextResult, error) {
+	return types.SendTextResult{}, nil
+}
 func (*fakeRoomClient) ReadAttachment(string, string) (types.AttachmentRead, error) {
 	return types.AttachmentRead{}, errors.New("not used")
 }

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -28,6 +28,8 @@ const (
 
 const roomScope = "room"
 
+var errTaskTextUnsupported = errors.New("task-scoped text transport is unavailable")
+
 // logicalSessionState is Runtime-local cognition state for one logical
 // scope. Room transport, participant credentials, roster, and the bounded
 // source event buffer remain ResidentRuntime-level state.
@@ -1168,7 +1170,7 @@ func (r *ResidentRuntime) drainTurns() {
 			r.log("turn_failed", nil)
 			return
 		}
-		sent, err := r.options.Client.SendText(handle, text, result.TargetParticipantIDs)
+		sent, err := r.sendHarnessText(scope, handle, text, result.TargetParticipantIDs)
 		if err != nil {
 			r.mu.Lock()
 			r.lastError = err.Error()
@@ -1195,6 +1197,25 @@ func (r *ResidentRuntime) drainTurns() {
 			voiceOutput.Speak(text)
 		}
 	}
+}
+
+func taskRequestIDForScope(scope string) string {
+	scope = normalizeScope(scope)
+	if strings.HasPrefix(scope, "task:") {
+		return strings.TrimPrefix(scope, "task:")
+	}
+	return ""
+}
+
+func (r *ResidentRuntime) sendHarnessText(scope, handle, text string, targets []string) (types.SendTextResult, error) {
+	if requestID := taskRequestIDForScope(scope); requestID != "" {
+		client, ok := r.options.Client.(types.TaskTextClient)
+		if !ok {
+			return types.SendTextResult{}, errTaskTextUnsupported
+		}
+		return client.SendTextForTask(handle, text, targets, requestID)
+	}
+	return r.options.Client.SendText(handle, text, targets)
 }
 
 // enrichAttachments applies the shared enrichment pass with the negotiated

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -992,6 +992,12 @@ func (a *fakeAdapter) scopedSessionNewSnapshot(scope string) []bool {
 	return append([]bool(nil), a.scopedSessionNews[scope]...)
 }
 
+func (a *fakeAdapter) scopedGenerationSnapshot(scope string) int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.scopedGenerations[scope]
+}
+
 func (a *fakeAdapter) sessionsInt() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -116,7 +116,8 @@ type fakeClient struct {
 	sent  []string
 	// sentTargets mirrors sent: the explicit targets (#165) each reply
 	// carried, nil for ordinary unaddressed sends.
-	sentTargets [][]string
+	sentTargets        [][]string
+	sentTaskRequestIDs []string
 	// hostsSeen records the #176 Runtime Host projection each join carried
 	// (nil = legacy caller); hostUpdates records hot-reload pushes.
 	hostsSeen   []*types.RuntimeHostProjection
@@ -447,6 +448,13 @@ func (c *fakeClient) SendText(_ string, text string, targets []string) (types.Se
 		c.sendHook(text)
 	}
 	return types.SendTextResult{Sequence: int64(len(c.sent))}, nil
+}
+
+func (c *fakeClient) SendTextForTask(handle, text string, targets []string, taskRequestID string) (types.SendTextResult, error) {
+	c.mu.Lock()
+	c.sentTaskRequestIDs = append(c.sentTaskRequestIDs, taskRequestID)
+	c.mu.Unlock()
+	return c.SendText(handle, text, targets)
 }
 
 func (*fakeClient) ReadAttachment(_, _ string) (types.AttachmentRead, error) {
@@ -1079,6 +1087,12 @@ func (c *fakeClient) snapshotSentTargets() [][]string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([][]string(nil), c.sentTargets...)
+}
+
+func (c *fakeClient) snapshotSentTaskRequestIDs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.sentTaskRequestIDs...)
 }
 
 // snapshotHosts mirrors snapshotSent with the #176 Runtime Host projection

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -125,6 +125,33 @@ func TestLogicalScopesReuseIsolatedHarnessSessions(t *testing.T) {
 	}
 }
 
+func TestTaskScopedHarnessOutputPreservesRequestCorrelation(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	client := &fakeClient{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "scoped-output-test",
+		RoomID:     "room-scoped-output",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	rt.acceptEvent(scopedEvent(1, "task:T", "T prompt"))
+	rt.acceptEvent(scopedEvent(2, "task:U", "U prompt"))
+	rt.drainTurns()
+
+	if got := client.snapshotSentTaskRequestIDs(); !reflect.DeepEqual(got, []string{"T", "U"}) {
+		t.Fatalf("task output lost Room request correlation: %v", got)
+	}
+}
+
 func TestLegacyAdapterFailsClosedForTaskScope(t *testing.T) {
 	adapter := &legacyOnlyAdapter{}
 	rt := NewResidentRuntime(Options{

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -236,8 +236,13 @@ func TestScopedSessionGenerationAndRoomReconnectAreTruthful(t *testing.T) {
 	rt.drainTurns()
 	rt.acceptEvent(scopedEvent(2, "task:T", "T2"))
 	rt.drainTurns()
-	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false}) {
+	rt.acceptEvent(scopedEvent(3, "task:T", "T3"))
+	rt.drainTurns()
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false}) {
 		t.Fatalf("same scope did not reuse its retained conversation: %v", got)
+	}
+	if got := adapter.scopedGenerationSnapshot("task:T"); got != 1 {
+		t.Fatalf("same task follow-ups changed ACP generation: %d", got)
 	}
 
 	// A Room reconnect replaces transport credentials but does not create a
@@ -248,20 +253,26 @@ func TestScopedSessionGenerationAndRoomReconnectAreTruthful(t *testing.T) {
 		Cursor:            10,
 		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
 	})
-	rt.acceptEvent(scopedEvent(3, "task:T", "T3"))
+	rt.acceptEvent(scopedEvent(4, "task:T", "T4"))
 	rt.drainTurns()
-	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false}) {
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false, false}) {
 		t.Fatalf("Room reconnect reset task Harness session: %v", got)
+	}
+	if got := adapter.scopedGenerationSnapshot("task:T"); got != 1 {
+		t.Fatalf("Room reconnect changed ACP generation: %d", got)
 	}
 
 	adapter.recreateScopedSession("task:T")
-	rt.acceptEvent(scopedEvent(4, "task:T", "T4"))
+	rt.acceptEvent(scopedEvent(5, "task:T", "T5"))
 	rt.drainTurns()
-	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false, true}) {
+	if got := adapter.scopedSessionNewSnapshot("task:T"); !reflect.DeepEqual(got, []bool{true, false, false, false, true}) {
 		t.Fatalf("scoped Harness replacement did not request bootstrap: %v", got)
 	}
+	if got := adapter.scopedGenerationSnapshot("task:T"); got != 2 {
+		t.Fatalf("replacement did not advance ACP generation: %d", got)
+	}
 	_, details := adapter.scopedRunSnapshot()
-	if !reflect.DeepEqual(details["task:T"], []string{"T1", "T2", "T3", "T4"}) {
+	if !reflect.DeepEqual(details["task:T"], []string{"T1", "T2", "T3", "T4", "T5"}) {
 		t.Fatalf("new session replayed unrelated private context: %#v", details)
 	}
 }

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -724,6 +724,14 @@ type Free4ChatClient interface {
 	Close() error
 }
 
+// TaskTextClient is the optional narrow transport extension for preserving an
+// existing Room collaboration request on ordinary task text. Legacy clients
+// remain valid for ordinary Room text; a Runtime must not silently use that
+// legacy path for a non-Room scope.
+type TaskTextClient interface {
+	SendTextForTask(participantHandle, text string, targetParticipantIDs []string, taskRequestID string) (SendTextResult, error)
+}
+
 // RoomContextClient is an optional narrow historical-observation extension.
 // The Runtime keeps the participant handle private while mediating every call.
 type RoomContextClient interface {

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -59,14 +59,19 @@ The seventeen tools are:
 - `wait_for_events(participantHandle, cursor, timeoutSeconds)` - wait for text,
   action, image, and collaboration events. The response also carries a compact
   participant/capability projection.
-- `send_text(participantHandle, text, targetParticipantIds?)` - send ordinary
+- `send_text(participantHandle, text, targetParticipantIds?, taskRequestId?)` - send ordinary
   Room text. Optional targets are at most 8 public `participantId` values
   discovered through Room metadata, never participant names; a target may be
   any current participant (Human or Agent). Everyone can observe the message
   as Room context, but only the targeted current participants receive it as an
   addressed turn — a targeted Agent's resident Runtime wakes, while targeting a
   Human is attention only and never creates a Human task/workflow concept.
-  Visible `@Name` text never creates routing.
+  Visible `@Name` text never creates routing. When replying inside an existing
+  collaboration task, pass the exact canonical `requestId` received in the
+  task-scoped event as `taskRequestId`; the Room validates it and keeps the
+  message in that task interaction. Do not invent a scope id. Task-scoped
+  text cannot also provide explicit targets; the Room derives the canonical
+  Agent endpoint.
 - `update_capabilities(participantHandle, capabilities)` - replace the
   self-reported capability list.
 - `update_runtime_host(participantHandle, runtimeHost)` - publish the local
@@ -310,7 +315,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.25` (release tag `agent-v0.5.25`).
+`0.5.26` (release tag `agent-v0.5.26`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -371,7 +376,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.25"
+expected_version="0.5.26"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -69,9 +69,10 @@ The seventeen tools are:
   Visible `@Name` text never creates routing. When replying inside an existing
   collaboration task, pass the exact canonical `requestId` received in the
   task-scoped event as `taskRequestId`; the Room validates it and keeps the
-  message in that task interaction. Do not invent a scope id. Task-scoped
-  text cannot also provide explicit targets; the Room derives the canonical
-  Agent endpoint.
+  message in that task interaction. Do not invent a scope id. Agent
+  `send_text` may still include explicit `targetParticipantIds`; those targets
+  retain the normal validated addressing semantics. The Human Task composer
+  omits explicit targets, so the Room derives its canonical Agent endpoint.
 - `update_capabilities(participantHandle, capabilities)` - replace the
   self-reported capability list.
 - `update_runtime_host(participantHandle, runtimeHost)` - publish the local
@@ -315,7 +316,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.26` (release tag `agent-v0.5.26`).
+`0.5.25` (release tag `agent-v0.5.25`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -376,7 +377,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.26"
+expected_version="0.5.25"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1578,9 +1578,10 @@ The seventeen tools are:
   Visible `@Name` text never creates routing. When replying inside an existing
   collaboration task, pass the exact canonical `requestId` received in the
   task-scoped event as `taskRequestId`; the Room validates it and keeps the
-  message in that task interaction. Do not invent a scope id. Task-scoped
-  text cannot also provide explicit targets; the Room derives the canonical
-  Agent endpoint.
+  message in that task interaction. Do not invent a scope id. Agent
+  `send_text` may still include explicit `targetParticipantIds`; those targets
+  retain the normal validated addressing semantics. The Human Task composer
+  omits explicit targets, so the Room derives its canonical Agent endpoint.
 - `update_capabilities(participantHandle, capabilities)` - replace the
   self-reported capability list.
 - `update_runtime_host(participantHandle, runtimeHost)` - publish the local
@@ -1824,7 +1825,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.26` (release tag `agent-v0.5.26`).
+`0.5.25` (release tag `agent-v0.5.25`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1885,7 +1886,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.26"
+expected_version="0.5.25"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1568,14 +1568,19 @@ The seventeen tools are:
 - `wait_for_events(participantHandle, cursor, timeoutSeconds)` - wait for text,
   action, image, and collaboration events. The response also carries a compact
   participant/capability projection.
-- `send_text(participantHandle, text, targetParticipantIds?)` - send ordinary
+- `send_text(participantHandle, text, targetParticipantIds?, taskRequestId?)` - send ordinary
   Room text. Optional targets are at most 8 public `participantId` values
   discovered through Room metadata, never participant names; a target may be
   any current participant (Human or Agent). Everyone can observe the message
   as Room context, but only the targeted current participants receive it as an
   addressed turn — a targeted Agent's resident Runtime wakes, while targeting a
   Human is attention only and never creates a Human task/workflow concept.
-  Visible `@Name` text never creates routing.
+  Visible `@Name` text never creates routing. When replying inside an existing
+  collaboration task, pass the exact canonical `requestId` received in the
+  task-scoped event as `taskRequestId`; the Room validates it and keeps the
+  message in that task interaction. Do not invent a scope id. Task-scoped
+  text cannot also provide explicit targets; the Room derives the canonical
+  Agent endpoint.
 - `update_capabilities(participantHandle, capabilities)` - replace the
   self-reported capability list.
 - `update_runtime_host(participantHandle, runtimeHost)` - publish the local
@@ -1819,7 +1824,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.25` (release tag `agent-v0.5.25`).
+`0.5.26` (release tag `agent-v0.5.26`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1880,7 +1885,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.25"
+expected_version="0.5.26"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/src/common/taskViews.test.ts
+++ b/app/src/common/taskViews.test.ts
@@ -105,4 +105,18 @@ describe("task interaction projections (#309)", () => {
     }
     expect(buildTaskProjections([task, terminal])[0]?.status).toBe("Completed")
   })
+
+  it("keeps scoped messages in Room when their canonical request was evicted", () => {
+    const orphan: Message = {
+      peerId: "agent-x",
+      name: "Agent",
+      kind: "agent",
+      type: "text",
+      text: "orphaned task output",
+      taskRequestId: "evicted-request",
+    }
+
+    expect(buildTaskProjections([orphan])).toEqual([])
+    expect(roomMessagesForView([orphan])).toEqual([orphan])
+  })
 })

--- a/app/src/common/taskViews.test.ts
+++ b/app/src/common/taskViews.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest"
+
+import { buildTaskProjections, roomMessagesForView } from "./taskViews"
+import type { Message } from "./types"
+
+const request = (requestId: string, summary: string): Message => ({
+  peerId: "human",
+  name: "Human",
+  kind: "human",
+  type: "action",
+  actionType: "collab",
+  collab: {
+    requestId,
+    kind: "request",
+    fromParticipantId: "human",
+    targetParticipantId: "agent-x",
+    summary,
+  },
+})
+
+describe("task interaction projections (#309)", () => {
+  it("derives Room, T, and U views from canonical messages without a task store", () => {
+    const taskT = request("T", "Migration plan")
+    const taskU = request("U", "U marker")
+    const messages: Message[] = [
+      { peerId: "human", name: "Human", type: "text", text: "ROOM" },
+      taskT,
+      {
+        peerId: "agent-x",
+        name: "Agent",
+        kind: "agent",
+        type: "action",
+        actionType: "collab",
+        collab: {
+          requestId: "T",
+          kind: "accepted",
+          fromParticipantId: "agent-x",
+          targetParticipantId: "human",
+          summary: "working",
+        },
+      },
+      {
+        peerId: "agent-x",
+        name: "Agent",
+        kind: "agent",
+        type: "text",
+        text: "T output",
+        taskRequestId: "T",
+      },
+      taskU,
+      {
+        peerId: "human",
+        name: "Human",
+        kind: "human",
+        type: "text",
+        text: "T follow-up",
+        taskRequestId: "T",
+      },
+      {
+        peerId: "agent-x",
+        name: "Agent",
+        kind: "agent",
+        type: "text",
+        text: "U output",
+        taskRequestId: "U",
+      },
+    ]
+
+    expect(
+      roomMessagesForView(messages).map((message) => message.text)
+    ).toEqual(["ROOM"])
+    const projections = buildTaskProjections(messages)
+    expect(
+      projections.map(({ requestId, title, status }) => ({
+        requestId,
+        title,
+        status,
+      }))
+    ).toEqual([
+      { requestId: "T", title: "Migration plan", status: "Working" },
+      { requestId: "U", title: "U marker", status: "Starting" },
+    ])
+    expect(projections[0]?.messages.map((message) => message.text)).toEqual([
+      undefined,
+      undefined,
+      "T output",
+      "T follow-up",
+    ])
+    expect(projections[1]?.messages.map((message) => message.text)).toEqual([
+      undefined,
+      "U output",
+    ])
+  })
+
+  it("projects terminal lifecycle states without adding new status vocabulary", () => {
+    const task = request("T", "Task")
+    const terminal: Message = {
+      ...task,
+      collab: {
+        ...task.collab!,
+        kind: "completed",
+        fromParticipantId: "agent-x",
+        targetParticipantId: "human",
+      },
+    }
+    expect(buildTaskProjections([task, terminal])[0]?.status).toBe("Completed")
+  })
+})

--- a/app/src/common/taskViews.ts
+++ b/app/src/common/taskViews.ts
@@ -67,5 +67,13 @@ export function buildTaskProjections(messages: Message[]): TaskProjection[] {
 }
 
 export function roomMessagesForView(messages: Message[]): Message[] {
-  return messages.filter((message) => !isTaskCorrelatedMessage(message))
+  const retainedRequestIds = new Set(
+    messages
+      .filter((message) => message.collab?.kind === "request")
+      .map((message) => message.collab!.requestId)
+  )
+  return messages.filter((message) => {
+    const requestId = message.taskRequestId ?? message.collab?.requestId
+    return !requestId || !retainedRequestIds.has(requestId)
+  })
 }

--- a/app/src/common/taskViews.ts
+++ b/app/src/common/taskViews.ts
@@ -1,0 +1,71 @@
+import type { Message } from "./types"
+
+export type TaskStatus = "Starting" | "Working" | "Completed" | "Failed"
+
+export interface TaskProjection {
+  requestId: string
+  title: string
+  createdByParticipantId: string
+  targetParticipantId: string
+  status: TaskStatus
+  messages: Message[]
+}
+
+export function isTaskCorrelatedMessage(message: Message): boolean {
+  return Boolean(message.taskRequestId || message.collab?.requestId)
+}
+
+function applyTaskLifecycle(
+  current: TaskStatus,
+  kind: NonNullable<Message["collab"]>["kind"]
+): TaskStatus {
+  switch (kind) {
+    case "accepted":
+      return "Working"
+    case "completed":
+      return "Completed"
+    case "declined":
+    case "failed":
+      return "Failed"
+    default:
+      return current
+  }
+}
+
+/**
+ * Derives bounded Task views from the canonical retained Room message log.
+ * This is presentation only: the Room collaboration request remains the
+ * identity and authority, and no browser task history is created.
+ */
+export function buildTaskProjections(messages: Message[]): TaskProjection[] {
+  const projections = new Map<string, TaskProjection>()
+
+  for (const message of messages) {
+    const collab = message.collab
+    if (collab?.kind === "request") {
+      projections.set(collab.requestId, {
+        requestId: collab.requestId,
+        title: collab.summary ?? "Untitled task",
+        createdByParticipantId: collab.fromParticipantId,
+        targetParticipantId: collab.targetParticipantId,
+        status: "Starting",
+        messages: [message],
+      })
+      continue
+    }
+
+    const requestId = message.taskRequestId ?? collab?.requestId
+    if (!requestId) continue
+    const projection = projections.get(requestId)
+    if (!projection) continue
+    projection.messages.push(message)
+    if (collab)
+      projection.status = applyTaskLifecycle(projection.status, collab.kind)
+  }
+
+  return [...projections.values()]
+}
+
+export function roomMessagesForView(messages: Message[]): Message[] {
+  return messages.filter((message) => !isTaskCorrelatedMessage(message))
+}

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -53,6 +53,7 @@ export interface Message {
   actionPayload?: Record<string, string>
   collab?: CollabEvent
   permission?: PermissionEvent
+  taskRequestId?: string
   // #165: structured addressing targets (participant IDs) the sender
   // explicitly chose. Pure routing metadata for the recipient cue — the
   // canonical source of truth for wakeup, never a capability grant.

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../hooks/useSfuChatRoom", () => ({
   useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
 }))
 
+import type { Message } from "@common/types"
 import { trackAnalyticsEvent } from "@common/utils"
 
 import RoomContent from "./RoomContent"
@@ -169,6 +170,82 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(mock.render).toHaveBeenCalledTimes(1)
     expect(mock.remove).toHaveBeenCalledTimes(1)
     expect(container.querySelector('[id^="cf-chl-widget"]')).toBeNull()
+  })
+
+  it("switches between Room, T, and U without mirroring task text into Room", () => {
+    const taskRequest = (
+      requestId: string,
+      summary: string,
+      sequence: number
+    ): Message => ({
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "action",
+      actionType: "collab",
+      sequence,
+      collab: {
+        requestId,
+        kind: "request",
+        fromParticipantId: "human-local",
+        targetParticipantId: "agent-x",
+        summary,
+      },
+    })
+    const message = (
+      taskRequestId: string,
+      text: string,
+      sequence: number
+    ): Message => ({
+      peerId: "agent-x",
+      name: "Agent X",
+      kind: "agent",
+      type: "text",
+      sequence,
+      text,
+      taskRequestId,
+    })
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [
+        {
+          peerId: "human-local",
+          name: "Hannah",
+          kind: "human",
+          type: "text",
+          sequence: 1,
+          text: "ROOM marker",
+        },
+        taskRequest("T", "Migration plan", 2),
+        message("T", "T output", 3),
+        taskRequest("U", "U marker", 4),
+        message("U", "U output", 5),
+      ],
+      localParticipantId: "human-local",
+      getLocalRoomAuth: vi.fn(() => ({ participantId: "human-local" })),
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    expect(screen.getByText("ROOM marker")).toBeInTheDocument()
+    expect(screen.queryByText("T output")).not.toBeInTheDocument()
+    expect(screen.queryByText("U output")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    expect(screen.getByText("T output")).toBeInTheDocument()
+    expect(screen.queryByText("ROOM marker")).not.toBeInTheDocument()
+    expect(screen.queryByText("U output")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-U"))
+    expect(screen.getByText("U output")).toBeInTheDocument()
+    expect(screen.queryByText("T output")).not.toBeInTheDocument()
   })
 
   it("copies the ordinary Agent invite only through the popover action, without a provider claim", async () => {

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -238,14 +238,77 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(screen.queryByText("T output")).not.toBeInTheDocument()
     expect(screen.queryByText("U output")).not.toBeInTheDocument()
 
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, "Room draft must not follow a task")
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+
     fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
     expect(screen.getByText("T output")).toBeInTheDocument()
     expect(screen.queryByText("ROOM marker")).not.toBeInTheDocument()
     expect(screen.queryByText("U output")).not.toBeInTheDocument()
+    expect(
+      (
+        screen.getByLabelText(
+          "Message the room or @ an Agent"
+        ) as HTMLTextAreaElement
+      ).value
+    ).toBe("")
 
     fireEvent.click(screen.getByTestId("interaction-tab-task-U"))
     expect(screen.getByText("U output")).toBeInTheDocument()
     expect(screen.queryByText("T output")).not.toBeInTheDocument()
+  })
+
+  it("auto-opens an incoming task only once so Room can be selected again", async () => {
+    const incomingTask: Message = {
+      peerId: "agent-x",
+      name: "Agent X",
+      kind: "agent",
+      type: "action",
+      actionType: "collab",
+      sequence: 1,
+      collab: {
+        requestId: "incoming-task",
+        kind: "request",
+        fromParticipantId: "agent-x",
+        targetParticipantId: "human-local",
+        summary: "Incoming task",
+      },
+    }
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [incomingTask],
+      localParticipantId: "human-local",
+      getLocalRoomAuth: vi.fn(() => ({ participantId: "human-local" })),
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("interaction-tab-task-incoming-task")
+      ).toHaveAttribute("aria-selected", "true")
+    )
+    fireEvent.click(screen.getByTestId("interaction-tab-room"))
+    expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    )
   })
 
   it("copies the ordinary Agent invite only through the popover action, without a provider claim", async () => {

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react"
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react"
 
 import { useRouter } from "next/router"
 
@@ -11,6 +11,7 @@ import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
+import { buildTaskProjections, roomMessagesForView } from "../common/taskViews"
 import {
   umamiEvent,
   trackAnalyticsEvent,
@@ -97,6 +98,8 @@ export default function RoomContent({
   const [taskAgent, setTaskAgent] = useState<TaskAgent | null>(null)
   const [taskInstruction, setTaskInstruction] = useState("")
   const [taskError, setTaskError] = useState("")
+  const [activeInteraction, setActiveInteraction] = useState("room")
+  const pendingLocalTaskSummaries = useRef<string[]>([])
   // #236 follow-up: shared popover state so the Live Transcript setup copy
   // can cross-open the Invite Agent popover (no routing machinery).
   const [agentInviteOpen, setAgentInviteOpen] = useState(false)
@@ -163,6 +166,53 @@ export default function RoomContent({
     getTurnstileToken: requestToken,
   })
 
+  const taskProjections = useMemo(
+    () => buildTaskProjections(messages),
+    [messages]
+  )
+  const effectiveLocalParticipantId =
+    localParticipantId ?? getLocalRoomAuth()?.participantId
+  const activeTask = taskProjections.find(
+    (task) => task.requestId === activeInteraction
+  )
+  const interactionMessages = activeTask
+    ? activeTask.messages
+    : roomMessagesForView(messages)
+
+  useEffect(() => {
+    const pending = pendingLocalTaskSummaries.current
+    const created =
+      effectiveLocalParticipantId && pending.length > 0
+        ? taskProjections.find(
+            (task) =>
+              task.createdByParticipantId === effectiveLocalParticipantId &&
+              pending.includes(task.title)
+          )
+        : undefined
+    if (created) {
+      pending.splice(pending.indexOf(created.title), 1)
+      setActiveInteraction(created.requestId)
+      return
+    }
+
+    // Preserve the existing Human-facing collaboration controls: an incoming
+    // request addressed to this Human opens its task view so Accept/Decline
+    // remains visible, while unrelated task views stay behind the switcher.
+    if (activeInteraction !== "room" || !effectiveLocalParticipantId) return
+    const incoming = taskProjections.find(
+      (task) => task.targetParticipantId === effectiveLocalParticipantId
+    )
+    if (incoming) setActiveInteraction(incoming.requestId)
+  }, [activeInteraction, effectiveLocalParticipantId, taskProjections])
+
+  useEffect(() => {
+    if (
+      activeInteraction !== "room" &&
+      !taskProjections.some((task) => task.requestId === activeInteraction)
+    )
+      setActiveInteraction("room")
+  }, [activeInteraction, taskProjections])
+
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
   const handleStartTask = useCallback(
@@ -193,6 +243,7 @@ export default function RoomContent({
         setTaskError("Could not start the task. Check your connection.")
         return
       }
+      pendingLocalTaskSummaries.current.push(taskInstruction.trim())
       closeTaskComposer()
     },
     [closeTaskComposer, sendCollabRequest, taskAgent, taskInstruction]
@@ -345,7 +396,7 @@ export default function RoomContent({
 
   const hasSentTextRef = useRef(false)
   const wrappedSendText = useCallback(
-    (text: string, targets: string[] = []) => {
+    (text: string, targets: string[] = [], taskRequestId?: string) => {
       if (!hasSentTextRef.current) {
         hasSentTextRef.current = true
         umamiEvent("ChatActivity", {
@@ -353,7 +404,7 @@ export default function RoomContent({
           roomHash: hashRoom(roomName),
         })
       }
-      sendTextMessage(text, targets)
+      sendTextMessage(text, targets, taskRequestId)
     },
     [roomName, sendTextMessage]
   )
@@ -609,7 +660,7 @@ export default function RoomContent({
               liveTranscript={liveTranscript}
               runtimeHosts={runtimeHosts}
               runtimeHostProviders={runtimeHostProviders}
-              localParticipantId={localParticipantId}
+              localParticipantId={effectiveLocalParticipantId}
               participants={participants}
               mediaAvailable={liveTranscriptMediaAvailable}
               onStart={handleStartLiveTranscript}
@@ -805,22 +856,72 @@ export default function RoomContent({
         />
 
         <div className="room-panel room-chat-panel flex flex-1 flex-col overflow-hidden">
-          <TextChatCard
-            room={roomName}
-            nickName={nickName}
-            messages={messages}
-            attachments={attachments}
-            participants={participants}
-            pendingFiles={pendingFiles}
-            onSendText={wrappedSendText}
-            onSendFile={wrappedSendFile}
-            onSendAction={sendActionMessage}
-            localParticipantId={getLocalRoomAuth()?.participantId}
-            onCollabRespond={handleCollabRespond}
-            onReadArtifact={handleReadArtifact}
-            onCollabResult={handleCollabResult}
-            onPermissionRespond={handlePermissionResponse}
-          />
+          <div
+            role="tablist"
+            aria-label="Room interactions"
+            className="scrollbar-thin flex flex-none gap-1 overflow-x-auto border-b border-gray-800 bg-gray-950/60 px-3 py-2"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeInteraction === "room"}
+              data-testid="interaction-tab-room"
+              onClick={() => setActiveInteraction("room")}
+              className={`shrink-0 rounded-md px-3 py-1.5 text-xs transition ${
+                activeInteraction === "room"
+                  ? "bg-blue-600 text-white"
+                  : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+              }`}
+            >
+              Room
+            </button>
+            {taskProjections.map((task) => (
+              <button
+                key={task.requestId}
+                type="button"
+                role="tab"
+                aria-selected={activeInteraction === task.requestId}
+                data-testid={`interaction-tab-task-${task.requestId}`}
+                onClick={() => setActiveInteraction(task.requestId)}
+                className={`flex max-w-52 shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition ${
+                  activeInteraction === task.requestId
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                }`}
+              >
+                <span className="truncate">{task.title}</span>
+                <span
+                  aria-label={`Status ${task.status}`}
+                  className="text-[10px] opacity-70"
+                >
+                  {task.status === "Completed"
+                    ? "✓"
+                    : task.status === "Failed"
+                    ? "×"
+                    : "●"}
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="min-h-0 flex-1">
+            <TextChatCard
+              room={roomName}
+              nickName={nickName}
+              messages={interactionMessages}
+              attachments={activeTask ? [] : attachments}
+              participants={participants}
+              pendingFiles={activeTask ? [] : pendingFiles}
+              onSendText={wrappedSendText}
+              onSendFile={wrappedSendFile}
+              onSendAction={sendActionMessage}
+              localParticipantId={effectiveLocalParticipantId}
+              onCollabRespond={handleCollabRespond}
+              onReadArtifact={handleReadArtifact}
+              onCollabResult={handleCollabResult}
+              onPermissionRespond={handlePermissionResponse}
+              taskRequestId={activeTask?.requestId}
+            />
+          </div>
         </div>
       </div>
       {taskAgent && (

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -100,6 +100,7 @@ export default function RoomContent({
   const [taskError, setTaskError] = useState("")
   const [activeInteraction, setActiveInteraction] = useState("room")
   const pendingLocalTaskSummaries = useRef<string[]>([])
+  const autoOpenedTaskIds = useRef<Set<string>>(new Set())
   // #236 follow-up: shared popover state so the Live Transcript setup copy
   // can cross-open the Invite Agent popover (no routing machinery).
   const [agentInviteOpen, setAgentInviteOpen] = useState(false)
@@ -191,6 +192,7 @@ export default function RoomContent({
         : undefined
     if (created) {
       pending.splice(pending.indexOf(created.title), 1)
+      autoOpenedTaskIds.current.add(created.requestId)
       setActiveInteraction(created.requestId)
       return
     }
@@ -200,9 +202,14 @@ export default function RoomContent({
     // remains visible, while unrelated task views stay behind the switcher.
     if (activeInteraction !== "room" || !effectiveLocalParticipantId) return
     const incoming = taskProjections.find(
-      (task) => task.targetParticipantId === effectiveLocalParticipantId
+      (task) =>
+        task.targetParticipantId === effectiveLocalParticipantId &&
+        !autoOpenedTaskIds.current.has(task.requestId)
     )
-    if (incoming) setActiveInteraction(incoming.requestId)
+    if (incoming) {
+      autoOpenedTaskIds.current.add(incoming.requestId)
+      setActiveInteraction(incoming.requestId)
+    }
   }, [activeInteraction, effectiveLocalParticipantId, taskProjections])
 
   useEffect(() => {
@@ -905,6 +912,7 @@ export default function RoomContent({
           </div>
           <div className="min-h-0 flex-1">
             <TextChatCard
+              key={activeInteraction}
               room={roomName}
               nickName={nickName}
               messages={interactionMessages}

--- a/app/src/components/TextChatCard.composer.test.tsx
+++ b/app/src/components/TextChatCard.composer.test.tsx
@@ -144,6 +144,16 @@ describe("composer keyboard semantics", () => {
     )
   })
 
+  it("sends task text with the existing task correlation and no ad hoc picker target", () => {
+    const { composer, onSendText } = renderCard({
+      taskRequestId: "task-123",
+    })
+    typeMessage(composer, "continue the task")
+    fireEvent.keyDown(composer, { key: "Enter" })
+    expect(onSendText).toHaveBeenCalledWith("continue the task", [], "task-123")
+    expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument()
+  })
+
   it("dismisses the mention picker with Escape so Enter sends normally", () => {
     const { composer, onSendText } = renderCard()
     typeMessage(composer, "@Age")

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -54,7 +54,7 @@ interface TextChatCardProps {
   attachments?: RoomAttachmentProjection[]
   participants: UserInfo[]
   pendingFiles?: PendingFile[]
-  onSendText: (text: string, targets?: string[]) => void
+  onSendText: (text: string, targets?: string[], taskRequestId?: string) => void
   onSendFile: (file: File) => void
   onSendAction: (
     actionType: ActionType,
@@ -80,6 +80,9 @@ interface TextChatCardProps {
   /** #286: submit one exact native permission option through the
    * authenticated Human Room WebSocket action. */
   onPermissionRespond?: (requestId: string, selectedOptionId: string) => void
+  /** #309: when set, this composer sends ordinary text into one existing
+   * canonical task and targets its primary Agent only. */
+  taskRequestId?: string
 }
 
 const GAMES = [
@@ -1479,7 +1482,9 @@ const TextChatCard = memo(function TextChatCard({
   onReadArtifact,
   onCollabResult,
   onPermissionRespond,
+  taskRequestId,
 }: TextChatCardProps) {
+  const taskScoped = Boolean(taskRequestId)
   const [message, setMessage] = useState<string>("")
   const [submenu, setSubmenu] = useState<"more" | "games" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
@@ -1546,10 +1551,11 @@ const TextChatCard = memo(function TextChatCard({
 
   const sendCurrentMessage = () => {
     if (message.trim() === "") return
-    onSendText(
-      message.trim(),
-      resolveAgentTargetIds(message.trim(), connectedAgents, selectedAgents)
-    )
+    const targets = taskScoped
+      ? []
+      : resolveAgentTargetIds(message.trim(), connectedAgents, selectedAgents)
+    if (taskRequestId) onSendText(message.trim(), targets, taskRequestId)
+    else onSendText(message.trim(), targets)
     setMessage("")
     setSelectedAgents([])
   }
@@ -1690,7 +1696,8 @@ const TextChatCard = memo(function TextChatCard({
       : connectedAgents.filter((agent) =>
           agent.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
         )
-  const showAgentPicker = !pickerDismissed && mentionAgents.length > 0
+  const showAgentPicker =
+    !taskScoped && !pickerDismissed && mentionAgents.length > 0
 
   const selectAgent = (agent: UserInfo) => {
     if (!agent) return
@@ -1772,7 +1779,7 @@ const TextChatCard = memo(function TextChatCard({
           onPermissionRespond={onPermissionRespond}
         />
 
-        {showPollCreator && (
+        {showPollCreator && !taskScoped && (
           <PollCreator
             onSend={handlePollSend}
             onCancel={() => setShowPollCreator(false)}
@@ -1823,87 +1830,91 @@ const TextChatCard = memo(function TextChatCard({
               )}
             </div>
           )}
-          <div ref={moreBtnRef} className="relative">
-            <button
-              type="button"
-              onClick={() => setSubmenu((v) => (v === "more" ? null : "more"))}
-              className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white"
-              title="More actions"
-              aria-label="More actions"
-              aria-expanded={submenu === "more" || submenu === "games"}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-                className="h-4 w-4"
+          {!taskScoped && (
+            <div ref={moreBtnRef} className="relative">
+              <button
+                type="button"
+                onClick={() =>
+                  setSubmenu((v) => (v === "more" ? null : "more"))
+                }
+                className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white"
+                title="More actions"
+                aria-label="More actions"
+                aria-expanded={submenu === "more" || submenu === "games"}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 4.5v15m7.5-7.5h-15"
-                />
-              </svg>
-            </button>
-            {submenu === "more" && (
-              <>
-                <div
-                  className="fixed inset-0 z-20 md:hidden"
-                  onClick={closeMenu}
-                />
-                <div
-                  ref={moreMenuRef}
-                  className="fixed bottom-0 left-0 right-0 z-30 rounded-t-xl border-t border-gray-600 bg-gray-800 py-1 shadow-xl md:absolute md:bottom-full md:left-0 md:right-auto md:mb-1 md:w-48 md:rounded-lg md:border md:border-gray-600"
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  className="h-4 w-4"
                 >
-                  <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
-                    Room actions
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      // Close before opening the native picker so the menu
-                      // (mobile bottom sheet) is gone when the picker returns.
-                      closeMenu()
-                      fileInputRef.current?.click()
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 4.5v15m7.5-7.5h-15"
+                  />
+                </svg>
+              </button>
+              {submenu === "more" && (
+                <>
+                  <div
+                    className="fixed inset-0 z-20 md:hidden"
+                    onClick={closeMenu}
+                  />
+                  <div
+                    ref={moreMenuRef}
+                    className="fixed bottom-0 left-0 right-0 z-30 rounded-t-xl border-t border-gray-600 bg-gray-800 py-1 shadow-xl md:absolute md:bottom-full md:left-0 md:right-auto md:mb-1 md:w-48 md:rounded-lg md:border md:border-gray-600"
                   >
-                    <span>📎</span> Attach file
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleWhiteboard}
-                    className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                  >
-                    <span>🎨</span> Whiteboard
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handlePoll}
-                    className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                  >
-                    <span>📊</span> Poll
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setSubmenu("games")}
-                    className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                  >
-                    <span>🎮</span> Games
-                  </button>
-                </div>
-              </>
-            )}
-            {submenu === "games" && (
-              <GamesMenu
-                onSelect={handleGameSelect}
-                onBack={() => setSubmenu(null)}
-                menuRef={gamesMenuRef}
-              />
-            )}
-          </div>
+                    <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
+                      Room actions
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        // Close before opening the native picker so the menu
+                        // (mobile bottom sheet) is gone when the picker returns.
+                        closeMenu()
+                        fileInputRef.current?.click()
+                      }}
+                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                    >
+                      <span>📎</span> Attach file
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleWhiteboard}
+                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                    >
+                      <span>🎨</span> Whiteboard
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handlePoll}
+                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                    >
+                      <span>📊</span> Poll
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSubmenu("games")}
+                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                    >
+                      <span>🎮</span> Games
+                    </button>
+                  </div>
+                </>
+              )}
+              {submenu === "games" && (
+                <GamesMenu
+                  onSelect={handleGameSelect}
+                  onBack={() => setSubmenu(null)}
+                  menuRef={gamesMenuRef}
+                />
+              )}
+            </div>
+          )}
           <textarea
             ref={textRef}
             rows={1}

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -430,6 +430,9 @@ type ControlRequest =
       participantId: string
       token: string
       text: string
+      // #309: optional task correlation. The DO validates this against an
+      // existing canonical collaboration request before persisting text.
+      taskRequestId?: unknown
       // #165/#234: optional explicit addressing carried by the same Room
       // primitive the Human chat path uses. Participant IDs only — the DO
       // normalizes, drops malformed/stale/self targets, and persists at most
@@ -584,7 +587,13 @@ type ControlRequest =
     }
 
 type ClientMessage =
-  | { type: "chat"; text: string; targets?: string[] }
+  | {
+      type: "chat"
+      text: string
+      targets?: string[]
+      // #309: only an existing canonical collaboration request may be used.
+      taskRequestId?: string
+    }
   | {
       type: "action"
       actionType: string
@@ -694,6 +703,33 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       }))
     this.collabRegistry.rebuild(entries)
     this.collabRebuilt = true
+  }
+
+  // #309: task text is allowed only when its correlation resolves to a
+  // retained canonical collaboration request whose primary target is still
+  // the connected Agent. This keeps stale/arbitrary client scope labels from
+  // becoming Room state or Runtime routing hints.
+  private taskRequestFor(
+    room: RoomRecord,
+    rawRequestId: unknown
+  ):
+    | { ok: true; requestId: string; targetParticipantId: string }
+    | { ok: false; error: string } {
+    if (typeof rawRequestId !== "string")
+      return { ok: false, error: "invalid_task_request" }
+    const requestId = rawRequestId.trim()
+    if (!requestId) return { ok: false, error: "invalid_task_request" }
+    this.warmCollabRegistry(room)
+    const record = this.collabRegistry.find(requestId)
+    if (!record) return { ok: false, error: "unknown_task_request" }
+    const target = room.participants[record.targetParticipantId]
+    if (!target || target.kind !== "agent" || !target.connected)
+      return { ok: false, error: "task_target_not_in_room" }
+    return {
+      ok: true,
+      requestId,
+      targetParticipantId: record.targetParticipantId,
+    }
   }
 
   private async loadRoom(): Promise<RoomRecord | null> {
@@ -1748,9 +1784,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     // instead of storing a second scope field in Room state. Only the target
     // Agent receives this task scope; ordinary text and non-target context
     // remain in the default Room conversation.
+    const taskRequest = message.taskRequestId
+      ? this.collabRegistry.find(message.taskRequestId)
+      : undefined
     const scopeId =
-      message.collab?.targetParticipantId === participantId &&
-      message.collab.requestId
+      taskRequest?.targetParticipantId === participantId
+        ? `task:${message.taskRequestId}`
+        : message.collab?.targetParticipantId === participantId &&
+          message.collab.requestId
         ? `task:${message.collab.requestId}`
         : undefined
     return {
@@ -1808,6 +1849,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     expiresAt: number
     truncated?: boolean
   } {
+    this.warmCollabRegistry(room)
     const serverCursor = room.nextMessageSequence
     const clampedCursor = Math.min(Math.max(cursor, 0), serverCursor)
     const events = [
@@ -1852,6 +1894,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     room: RoomRecord,
     participantId: string
   ): AgentEvent[] {
+    this.warmCollabRegistry(room)
     return [
       ...room.messages
         .filter((message) =>
@@ -2923,6 +2966,18 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         return this.json({ error: "agent_only" }, 403)
       const text = request.text.trim()
       if (!text) return this.json({ error: "text_required" }, 400)
+      const taskRequest =
+        request.taskRequestId === undefined
+          ? undefined
+          : this.taskRequestFor(room, request.taskRequestId)
+      if (taskRequest && taskRequest.ok === false)
+        return this.json({ error: taskRequest.error }, 409)
+      if (
+        taskRequest &&
+        taskRequest.ok === true &&
+        taskRequest.targetParticipantId !== participant.id
+      )
+        return this.json({ error: "task_target_mismatch" }, 403)
       participant.lastSeenAt = Date.now()
       const roomMessage = this.appendMessage(room, {
         id: crypto.randomUUID(),
@@ -2931,6 +2986,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         kind: participant.kind,
         type: "text",
         text: text.slice(0, 4000),
+        ...(taskRequest && taskRequest.ok === true
+          ? { taskRequestId: taskRequest.requestId }
+          : {}),
         // #165/#234: Agent-originated explicit addressing reuses the exact
         // Room target semantics of the Human chat path (dedupe, current
         // participant filter, MAX_TARGETS). Self-targets are dropped so an
@@ -4978,6 +5036,20 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
 
     if (message.type === "chat" && message.text.trim()) {
+      const taskRequest =
+        message.taskRequestId === undefined
+          ? undefined
+          : this.taskRequestFor(room, message.taskRequestId)
+      if (taskRequest && taskRequest.ok === false) {
+        socket.send(JSON.stringify({ type: "error", error: taskRequest.error }))
+        return
+      }
+      if (taskRequest && message.targets?.length) {
+        socket.send(
+          JSON.stringify({ type: "error", error: "task_targets_forbidden" })
+        )
+        return
+      }
       const roomMessage = this.appendMessage(room, {
         id: crypto.randomUUID(),
         peerId: participant.id,
@@ -4985,10 +5057,15 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         kind: participant.kind,
         type: "text",
         text: message.text.trim().slice(0, 4000),
-        ...(() => {
-          const targets = normalizeChatTargets(room, message.targets)
-          return targets.length ? { targets } : {}
-        })(),
+        ...(taskRequest && taskRequest.ok === true
+          ? {
+              taskRequestId: taskRequest.requestId,
+              targets: [taskRequest.targetParticipantId],
+            }
+          : (() => {
+              const targets = normalizeChatTargets(room, message.targets)
+              return targets.length ? { targets } : {}
+            })()),
         createdAt: Date.now(),
       })
       await this.saveRoom(room)

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -706,14 +706,20 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   }
 
   // #309: task text is allowed only when its correlation resolves to a
-  // retained canonical collaboration request whose primary target is still
-  // the connected Agent. This keeps stale/arbitrary client scope labels from
-  // becoming Room state or Runtime routing hints.
+  // retained canonical collaboration request with a connected Agent
+  // endpoint. A request can be Agent→Human or Agent→Agent, so the requester
+  // and target are both considered endpoints rather than assuming the target
+  // is always the sole Agent.
   private taskRequestFor(
     room: RoomRecord,
     rawRequestId: unknown
   ):
-    | { ok: true; requestId: string; targetParticipantId: string }
+    | {
+        ok: true
+        requestId: string
+        primaryAgentParticipantId: string
+        agentParticipantIds: string[]
+      }
     | { ok: false; error: string } {
     if (typeof rawRequestId !== "string")
       return { ok: false, error: "invalid_task_request" }
@@ -722,13 +728,28 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     this.warmCollabRegistry(room)
     const record = this.collabRegistry.find(requestId)
     if (!record) return { ok: false, error: "unknown_task_request" }
+    const from = room.participants[record.fromParticipantId]
     const target = room.participants[record.targetParticipantId]
-    if (!target || target.kind !== "agent" || !target.connected)
+    const agentParticipantIds = [from, target]
+      .filter(
+        (participant): participant is NonNullable<typeof participant> =>
+          participant?.kind === "agent" && participant.connected
+      )
+      .map((participant) => participant.id)
+      .filter((id, index, ids) => ids.indexOf(id) === index)
+    if (agentParticipantIds.length === 0)
       return { ok: false, error: "task_target_not_in_room" }
+    const primaryAgentParticipantId =
+      target?.kind === "agent" && target.connected
+        ? target.id
+        : from?.kind === "agent" && from.connected
+        ? from.id
+        : agentParticipantIds[0]
     return {
       ok: true,
       requestId,
-      targetParticipantId: record.targetParticipantId,
+      primaryAgentParticipantId,
+      agentParticipantIds,
     }
   }
 
@@ -1781,13 +1802,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participantId: string
   ): AgentEvent {
     // #303: reuse the already validated structured collaboration correlation
-    // instead of storing a second scope field in Room state. Only the target
-    // Agent receives this task scope; ordinary text and non-target context
-    // remain in the default Room conversation.
+    // instead of storing a second scope field in Room state. Either Agent
+    // endpoint may continue an Agent→Human or Agent→Agent request; ordinary
+    // text and non-endpoint context remain in the default Room conversation.
     const taskRequest = message.taskRequestId
       ? this.collabRegistry.find(message.taskRequestId)
       : undefined
     const scopeId =
+      taskRequest?.fromParticipantId === participantId ||
       taskRequest?.targetParticipantId === participantId
         ? `task:${message.taskRequestId}`
         : message.collab?.targetParticipantId === participantId &&
@@ -2975,7 +2997,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (
         taskRequest &&
         taskRequest.ok === true &&
-        taskRequest.targetParticipantId !== participant.id
+        !taskRequest.agentParticipantIds.includes(participant.id)
       )
         return this.json({ error: "task_target_mismatch" }, 403)
       participant.lastSeenAt = Date.now()
@@ -5060,7 +5082,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         ...(taskRequest && taskRequest.ok === true
           ? {
               taskRequestId: taskRequest.requestId,
-              targets: [taskRequest.targetParticipantId],
+              targets: [taskRequest.primaryAgentParticipantId],
             }
           : (() => {
               const targets = normalizeChatTargets(room, message.targets)

--- a/app/src/do/roomSessionAgentSendText.test.ts
+++ b/app/src/do/roomSessionAgentSendText.test.ts
@@ -6,7 +6,10 @@ const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
 
 // #165 fixture: one Human plus N Agents so addressed persistence and the
 // per-agent addressed projection can be exercised against the real DO path.
-function buildStoredRoom(agentIds = ["agent-a", "agent-b", "agent-c"]) {
+function buildStoredRoom(
+  agentIds = ["agent-a", "agent-b", "agent-c"],
+  messages: Array<Record<string, unknown>> = []
+) {
   return {
     createdAt: Date.now(),
     expiresAt: FAR_FUTURE,
@@ -35,8 +38,8 @@ function buildStoredRoom(agentIds = ["agent-a", "agent-b", "agent-c"]) {
         ])
       ),
     },
-    messages: [],
-    nextMessageSequence: 1,
+    messages,
+    nextMessageSequence: messages.length + 1,
     meetingNotes: { active: false },
     voiceReply: { active: false },
     pendingMediaCleanup: [],
@@ -74,7 +77,8 @@ function makeRoomSession(stored: ReturnType<typeof buildStoredRoom>) {
   const sendText = async (
     participantId: string,
     text: string,
-    targetParticipantIds?: unknown
+    targetParticipantIds?: unknown,
+    taskRequestId?: string
   ) =>
     control({
       action: "agent-send-text",
@@ -82,6 +86,7 @@ function makeRoomSession(stored: ReturnType<typeof buildStoredRoom>) {
       token: `tok-${participantId}`,
       text,
       ...(targetParticipantIds === undefined ? {} : { targetParticipantIds }),
+      ...(taskRequestId === undefined ? {} : { taskRequestId }),
     })
   const agentWait = async (participantId: string, cursor = 0) =>
     control({
@@ -93,7 +98,32 @@ function makeRoomSession(stored: ReturnType<typeof buildStoredRoom>) {
     })
   const storedMessages = () =>
     (store.get("room") as { messages: Array<Record<string, unknown>> }).messages
-  return { control, sendText, agentWait, storedMessages }
+  return { session: rs, control, sendText, agentWait, storedMessages }
+}
+
+function taskRequest(
+  requestId: string,
+  fromParticipantId: string,
+  targetParticipantId: string
+): Record<string, unknown> {
+  return {
+    id: `message-${requestId}`,
+    peerId: fromParticipantId,
+    name: fromParticipantId,
+    kind: "agent",
+    type: "action",
+    actionType: "collab",
+    sequence: 1,
+    createdAt: 1,
+    targets: [targetParticipantId],
+    collab: {
+      requestId,
+      kind: "request",
+      fromParticipantId,
+      targetParticipantId,
+      summary: `Task ${requestId}`,
+    },
+  }
 }
 
 describe("RoomSession agent-send-text structured addressing (#165)", () => {
@@ -184,6 +214,75 @@ describe("RoomSession agent-send-text structured addressing (#165)", () => {
 
     await room.sendText("agent-a", "for the Human", ["human-1"])
     expect(room.storedMessages()[0].targets).toEqual(["human-1"])
+  })
+
+  it("allows every connected Agent endpoint to continue Agent-originated tasks", async () => {
+    const agentToHuman = makeRoomSession(
+      buildStoredRoom(
+        ["agent-a", "agent-b"],
+        [taskRequest("agent-human", "agent-a", "human-1")]
+      )
+    )
+    const requesterReply = await agentToHuman.sendText(
+      "agent-a",
+      "requester task output",
+      undefined,
+      "agent-human"
+    )
+    expect(requesterReply.status).toBe(200)
+    expect(agentToHuman.storedMessages()[1]).toMatchObject({
+      taskRequestId: "agent-human",
+    })
+    expect(
+      (
+        agentToHuman.session as unknown as {
+          toAgentEvent: (
+            message: unknown,
+            participantId: string
+          ) => {
+            scopeId?: string
+          }
+        }
+      ).toAgentEvent(agentToHuman.storedMessages()[1], "agent-a").scopeId
+    ).toBe("task:agent-human")
+
+    const agentToAgent = makeRoomSession(
+      buildStoredRoom(
+        ["agent-a", "agent-b"],
+        [taskRequest("agent-agent", "agent-a", "agent-b")]
+      )
+    )
+    expect(
+      (
+        await agentToAgent.sendText(
+          "agent-a",
+          "requester output",
+          undefined,
+          "agent-agent"
+        )
+      ).status
+    ).toBe(200)
+    expect(
+      (
+        await agentToAgent.sendText(
+          "agent-b",
+          "target output",
+          undefined,
+          "agent-agent"
+        )
+      ).status
+    ).toBe(200)
+    expect(
+      agentToAgent
+        .storedMessages()
+        .slice(1)
+        .map((m) => m.taskRequestId)
+    ).toEqual(["agent-agent", "agent-agent"])
+    const targetEvents = (await agentToAgent.agentWait("agent-b")).json
+      .events as Array<{ text?: string; scopeId?: string }>
+    expect(
+      targetEvents.find((event) => event.text === "requester output")?.scopeId
+    ).toBe("task:agent-agent")
   })
 
   it("projects addressed=true only to targeted Agents; others see context with addressed=false", async () => {

--- a/app/src/do/roomSessionHumanTaskRequest.test.ts
+++ b/app/src/do/roomSessionHumanTaskRequest.test.ts
@@ -94,6 +94,18 @@ function harness() {
     session,
     socket,
     sendHuman,
+    control: async (body: Record<string, unknown>) => {
+      const response = await session.fetch(
+        new Request("https://room/control", {
+          method: "POST",
+          body: JSON.stringify(body),
+        })
+      )
+      return {
+        status: response.status,
+        json: (await response.json()) as Record<string, unknown>,
+      }
+    },
     stored: () => store.get("room") as RoomRecord,
   }
 }
@@ -209,6 +221,71 @@ describe("RoomSession Human task entry (#305)", () => {
       type: "error",
       error: "target_not_in_room",
     })
+    expect(test.stored().messages).toHaveLength(0)
+  })
+
+  it("keeps Agent output and Human follow-up in the existing task interaction", async () => {
+    const test = harness()
+
+    await test.sendHuman({
+      type: "collab-request",
+      targetParticipantId: "agent-a",
+      summary: "Investigate the task marker",
+    })
+    const requestId = test.stored().messages[0].collab?.requestId
+    expect(requestId).toEqual(expect.any(String))
+
+    const agentReply = await test.control({
+      action: "agent-send-text",
+      participantId: "agent-a",
+      token: "agent-a-token",
+      text: "task agent output",
+      taskRequestId: requestId,
+    })
+    expect(agentReply.status).toBe(200)
+    expect(test.stored().messages[1]).toMatchObject({
+      text: "task agent output",
+      taskRequestId: requestId,
+    })
+
+    await test.sendHuman({
+      type: "chat",
+      text: "task human follow-up",
+      taskRequestId: requestId,
+    })
+    expect(test.stored().messages[2]).toMatchObject({
+      peerId: "human-1",
+      text: "task human follow-up",
+      taskRequestId: requestId,
+      targets: ["agent-a"],
+    })
+
+    const agentEvent = (
+      test.session as unknown as {
+        toAgentEvent: (
+          message: unknown,
+          participantId: string
+        ) => { scopeId?: string; addressed: boolean }
+      }
+    ).toAgentEvent(test.stored().messages[2], "agent-a")
+    expect(agentEvent).toMatchObject({
+      scopeId: `task:${requestId}`,
+      addressed: true,
+    })
+  })
+
+  it("rejects arbitrary task correlation instead of creating a task view", async () => {
+    const test = harness()
+
+    await test.sendHuman({
+      type: "chat",
+      text: "forged task text",
+      taskRequestId: "not-a-canonical-request",
+    })
+
+    expect(test.socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "error", error: "unknown_task_request" })
+    )
     expect(test.stored().messages).toHaveLength(0)
   })
 })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -440,6 +440,7 @@ const roomMessageToMessage = (
     actionPayload: message.actionPayload,
     collab: message.collab,
     permission: message.permission,
+    taskRequestId: message.taskRequestId,
     targets: message.targets,
   }
 }
@@ -2990,8 +2991,13 @@ export function useSfuChatRoom(
   ])
 
   const sendTextMessage = useCallback(
-    (text: string, targets: string[] = []) => {
-      sendSocketMessage({ type: "chat", text, targets })
+    (text: string, targets: string[] = [], taskRequestId?: string) => {
+      sendSocketMessage({
+        type: "chat",
+        text,
+        targets,
+        ...(taskRequestId ? { taskRequestId } : {}),
+      })
     },
     [sendSocketMessage]
   )

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -514,7 +514,7 @@ function createMcpServer(context: McpRequestContext) {
     "send_text",
     {
       description:
-        "Send one text message to the room as the joined Agent. Optionally pass explicit target participant IDs (from room_info/wait_for_events roster metadata) to address the message: every participant still sees it as room context, but only the targeted current participants receive it as a new addressed turn — targets may be Humans or Agents. Targeting decides attention only — never authorization. Plain text without targets stays an ordinary unaddressed message.",
+        "Send one text message to the room as the joined Agent. Optionally pass explicit target participant IDs (from room_info/wait_for_events roster metadata) to address the message: every participant still sees it as room context, but only the targeted current participants receive it as a new addressed turn — targets may be Humans or Agents. A taskRequestId keeps the text in that existing task interaction and is validated by the Room. Targeting decides attention only — never authorization. Plain text without targets stays an ordinary unaddressed message.",
       inputSchema: {
         participantHandle: z.string().min(1),
         text: z.string().trim().min(1).max(MAX_TEXT_LENGTH),
@@ -522,9 +522,15 @@ function createMcpServer(context: McpRequestContext) {
           .array(z.string().trim().min(1).max(MAX_TARGET_ID_LENGTH))
           .max(MAX_TARGETS)
           .optional(),
+        taskRequestId: z.string().trim().min(1).max(64).optional(),
       },
     },
-    async ({ participantHandle, text, targetParticipantIds }) => {
+    async ({
+      participantHandle,
+      text,
+      targetParticipantIds,
+      taskRequestId,
+    }) => {
       const handle = decodeHandle(participantHandle)
       if (!handle) return toolError("invalid_participant_handle")
       const result = await roomControl(env, handle.room, {
@@ -533,6 +539,7 @@ function createMcpServer(context: McpRequestContext) {
         token: handle.participantToken,
         text,
         ...(targetParticipantIds?.length ? { targetParticipantIds } : {}),
+        ...(taskRequestId ? { taskRequestId } : {}),
       })
       return result.ok
         ? toolResult(result.data)

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -232,6 +232,9 @@ export interface RoomMessage {
   // request/resolution lifecycle. Agent delivery is filtered by the DO to
   // the exact agentParticipantId in this envelope.
   permission?: PermissionEvent
+  // #309: validated correlation to an existing canonical collaboration
+  // request. This is not a client-selected generic scope id.
+  taskRequestId?: string
   targets?: string[]
   createdAt: number
   sequence: number


### PR DESCRIPTION
## Summary

Implements the scoped Room task interaction slice without introducing Thread, a task store, or a new event protocol.

- Preserve canonical CollabEvent.requestId as task identity.
- Carry validated taskRequestId on ordinary Agent/Human text.
- Resolve task-capable Agent endpoints from both sides of a collaboration request.
- Route Runtime task output through the narrow task text transport so task T stays correlated.
- Derive bounded Room/T/U interaction views from retained Room messages.
- Keep ordinary Room chat and existing Human collaboration controls intact.

## Review fixes

- Agent→Human and Agent→Agent task text remains correlated for every connected Agent endpoint; Human follow-up targets the canonical primary Agent.
- Incoming Human-targeted tasks auto-open once per browser requestId, so Room can be selected again.
- Orphaned scoped messages fall back to Room after request eviction.
- Composer drafts reset when switching Room/T/U.
- The canonical Agent contract documents taskRequestId and the actual Agent target behavior.

## Runtime release staging

The source Runtime is 0.5.26, but the live bootstrap pin intentionally remains 0.5.25 because agent-v0.5.26 has not been published yet.

Runtime release flow:
1. Merge this PR.
2. Publish and verify native agent-v0.5.26 assets and SHA256SUMS.
3. Open the separate small activation PR changing agent.md 0.5.25 to 0.5.26 and regenerate llms-full.txt.
4. Merge/deploy the activation PR, then dogfood.

This avoids deploying a bootstrap contract that points at a release asset that does not yet exist.

## Verification

- App Vitest: 74 files / 669 tests passed
- Typecheck, ESLint, Prettier, docs:check passed
- Docs tests: 19 passed
- Go test ./... -count=1 passed
- gofmt, go vet, and Go build passed
- Distribution cleanup/install/bootstrap contracts passed, including staged source/live versions
- Cloudflare/OpenNext build passed
- Real Chromium Room E2E: 1 passed

Keep this PR open and unmerged for review.