### PR TITLE
chore: activate Agent Runtime 0.5.26 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -316,7 +316,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.25` (release tag `agent-v0.5.25`).
+`0.5.26` (release tag `agent-v0.5.26`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -377,7 +377,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.25"
+expected_version="0.5.26"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1825,7 +1825,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.25` (release tag `agent-v0.5.25`).
+`0.5.26` (release tag `agent-v0.5.26`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1886,7 +1886,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.25"
+expected_version="0.5.26"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

Activate the already published Free4Chat Agent Runtime 0.5.26 in the live bootstrap contract.

- Update app/public/agent.md from 0.5.25 / agent-v0.5.25 to 0.5.26 / agent-v0.5.26.
- Regenerate app/public/llms-full.txt.
- No Runtime source or application behavior changes.

## Release evidence

- Source-version merge commit: 597dc8ee9cbbcb9b32c4dc8d8e33c51e45a02a6c
- Published release: agent-v0.5.26
- Four native assets and SHA256SUMS verified.
- Current darwin-arm64 asset doctor --json reports version 0.5.26.
- Release workflow completed successfully.

## Verification

- bootstrap contract passed with source/live versions aligned
- app Vitest: 74 files / 669 tests passed
- docs:check, type-check, ESLint passed
- Cloudflare/OpenNext build passed

Merge this activation PR only after CI is green, then verify the deployed /agent.md before production dogfood.