### PR TITLE
[codex] perf(cost): remove resident media polling

### DIFF
--- a/agent/internal/free4chat/resident_events.go
+++ b/agent/internal/free4chat/resident_events.go
@@ -36,6 +36,7 @@ type residentEventEnvelope struct {
 	ExpiresAt    int64                      `json:"expiresAt"`
 	Participants []json.RawMessage          `json:"participants"`
 	RuntimeHosts map[string]json.RawMessage `json:"runtimeHosts"`
+	MediaState   *types.ResidentMediaState  `json:"mediaState,omitempty"`
 	Expired      bool                       `json:"expired,omitempty"`
 	Truncated    bool                       `json:"truncated,omitempty"`
 }
@@ -135,9 +136,10 @@ func (s *residentEventStream) Receive(ctx context.Context) (types.WaitResult, er
 		return types.WaitResult{}, &Error{Message: "resident event stream returned an invalid envelope", Code: CodeToolError}
 	}
 	wait := types.WaitResult{
-		Events:    envelope.Events,
-		Cursor:    envelope.Cursor,
-		ExpiresAt: envelope.ExpiresAt,
+		Events:     envelope.Events,
+		Cursor:     envelope.Cursor,
+		ExpiresAt:  envelope.ExpiresAt,
+		MediaState: envelope.MediaState,
 	}
 	if envelope.Participants != nil {
 		raw := make([]any, 0, len(envelope.Participants))

--- a/agent/internal/free4chat/resident_events_test.go
+++ b/agent/internal/free4chat/resident_events_test.go
@@ -58,6 +58,14 @@ func TestResidentEventStreamUsesHeadersAndDecodesEnvelope(t *testing.T) {
 					"speech":        map[string]any{"stt": true, "tts": false},
 				},
 			},
+			"mediaState": map[string]any{
+				"meetingNotes":        map[string]any{"active": true, "startedAt": 11},
+				"agentVoiceEnabledAt": float64(22),
+				"mediaAvailable":      true,
+				"liveTranscript": map[string]any{
+					"active": true, "producerRuntimeHostId": "host-a", "epoch": float64(7),
+				},
+			},
 		})
 		_ = conn.Write(context.Background(), websocket.MessageText, payload)
 	}))
@@ -84,6 +92,13 @@ func TestResidentEventStreamUsesHeadersAndDecodesEnvelope(t *testing.T) {
 	host := wait.RuntimeHosts["11111111-2222-3333-4444-555555555555"]
 	if !host.Speech.STT || host.Speech.TTS {
 		t.Fatalf("runtime host envelope mismatch: %+v", wait.RuntimeHosts)
+	}
+	if wait.MediaState == nil || !wait.MediaState.MediaAvailable ||
+		!wait.MediaState.MeetingNotes.Active || wait.MediaState.AgentVoiceEnabledAt != 22 ||
+		!wait.MediaState.LiveTranscript.Active ||
+		wait.MediaState.LiveTranscript.ProducerRuntimeHostID != "host-a" ||
+		wait.MediaState.LiveTranscript.Epoch != 7 {
+		t.Fatalf("media state envelope mismatch: %+v", wait.MediaState)
 	}
 	if strings.Contains(requestURL, token) || requestURL != "/api/room/agent-events" {
 		t.Fatalf("capability leaked into resident URL: %q", requestURL)

--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -14,11 +14,20 @@ import (
 
 // ControllerOptions wires the media grant controller into the runtime.
 type ControllerOptions struct {
-	Client        types.Free4ChatClient // RoomInfo (sanitized room state)
+	Client        types.Free4ChatClient // RoomInfo fallback (sanitized room state)
 	RoomID        string
 	ParticipantID string
 	SiteOrigin    string
 	Handle        DecodedHandle
+	// UsePushedMediaState is true for the resident Runtime, whose existing
+	// hibernatable event stream carries the current self-targeted media state.
+	// The compatibility path keeps one startup RoomInfo observation for clients
+	// that do not implement that stream, but never starts a recurring ticker.
+	UsePushedMediaState bool
+	// PollIntervalMs is retained for source compatibility with older injected
+	// callers. Controller no longer starts a RoomInfo ticker, so this value is
+	// ignored; BridgeOptions owns the independent SFU track-discovery cadence.
+	PollIntervalMs int
 	// RuntimeHostID is the room-scoped public host identity of this local
 	// Runtime. Live Transcript must match it exactly.
 	RuntimeHostID string
@@ -31,8 +40,6 @@ type ControllerOptions struct {
 	// CanProduceLiveTranscript proves this daemon still holds the private
 	// provider association for RuntimeHostID. Nil/false fails closed.
 	CanProduceLiveTranscript func() bool
-	// PollIntervalMs defaults to 5s.
-	PollIntervalMs int
 	// OnAudioFrame receives attributed SFU audio frames (wire to the
 	// transcriber).
 	OnAudioFrame func(source speech.AudioSource, frame speech.AudioFrame)
@@ -42,7 +49,7 @@ type ControllerOptions struct {
 	// OnGrantActivated fires on each grant activation EDGE (#171): a grant
 	// newly targeting this participant, or a fresh epoch of it. The runtime
 	// uses it to evaluate that grant's own speech prerequisite once — never
-	// per poll.
+	// for an unchanged state observation.
 	OnGrantActivated func(kind GrantKind)
 	// OnLiveTranscriptState tells the runtime whether this resident owns the
 	// active local producer lease. It is a state edge, never a Harness wakeup.
@@ -88,15 +95,19 @@ const (
 	GrantVoiceReply = GrantAgentVoice
 )
 
-// Controller owns the Runtime-side half of the media lifecycle: it polls
-// room_info for the Meeting Notes and Agent Voice grants and starts/stops the
-// ONE shared Bridge accordingly. This is the ONLY thing that decides when
-// this process may hold an active media session — authorization always comes
-// from the room-visible grant, never from a local decision.
+// Controller owns the Runtime-side half of the media lifecycle: it reconciles
+// the Meeting Notes, Agent Voice, and Live Transcript grants and starts/stops
+// the ONE shared Bridge accordingly. Resident Runtimes receive this state from
+// the authenticated event stream; RoomInfo remains only as a one-shot
+// compatibility bootstrap for non-resident clients. This is the ONLY thing
+// that decides when this process may hold an active media session —
+// authorization always comes from the room-visible grant, never from a local
+// decision.
 type Controller struct {
 	options ControllerOptions
 	log     func(event string, details map[string]string)
 
+	reconcileMu        sync.Mutex
 	mu                 sync.Mutex
 	state              string // idle | starting | running
 	generation         int
@@ -113,20 +124,23 @@ type Controller struct {
 	liveProducing     bool
 	// #171 grant-announcement state: the last grant instance (kind + epoch)
 	// whose activation edge was already reported, so an unchanged grant
-	// never re-fires while polls continue. Re-armed when the grant stops
+	// never re-fires while observations continue. Re-armed when the grant stops
 	// targeting this participant.
-	mnAnnounced      bool
-	mnAnnouncedEpoch *int64
-	vrAnnounced      bool
-	vrAnnouncedEpoch *int64
-	bridge           *Bridge
-	speaker          *voice.Speaker
-	voiceStarting    bool
-	stopped          bool
-	cancel           context.CancelFunc
-	ctx              context.Context
-	bridgeCancel     context.CancelFunc
-	now              func() time.Time
+	mnAnnounced             bool
+	mnAnnouncedEpoch        *int64
+	vrAnnounced             bool
+	vrAnnouncedEpoch        *int64
+	bridge                  *Bridge
+	speaker                 *voice.Speaker
+	voiceStarting           bool
+	stopped                 bool
+	mediaStateObserved      bool
+	lastMediaState          types.ResidentMediaState
+	lastMediaStateConfirmed bool
+	cancel                  context.CancelFunc
+	ctx                     context.Context
+	bridgeCancel            context.CancelFunc
+	now                     func() time.Time
 }
 
 // NewController builds an idle controller.
@@ -149,8 +163,9 @@ func NewController(options ControllerOptions) *Controller {
 	}
 }
 
-// Start runs the first poll synchronously, then arms the ticker — a caller
-// awaiting Start sees the first authorization check settle deterministically.
+// Start performs one compatibility bootstrap unless the Runtime is receiving
+// its initial state from the resident event stream. It never arms a recurring
+// RoomInfo ticker: subsequent transitions are pushed over that stream.
 func (c *Controller) Start(parent context.Context) {
 	if parent == nil {
 		parent = context.Background()
@@ -163,27 +178,16 @@ func (c *Controller) Start(parent context.Context) {
 		return
 	}
 	c.stopped = false
+	c.mediaStateObserved = false
+	c.lastMediaState = types.ResidentMediaState{}
+	c.lastMediaStateConfirmed = false
 	c.cancel = cancel
 	c.ctx = ctx
 	c.mu.Unlock()
 
-	c.poll()
-	interval := c.options.PollIntervalMs
-	if interval <= 0 {
-		interval = DefaultPollIntervalMs
+	if !c.options.UsePushedMediaState {
+		c.poll()
 	}
-	go func() {
-		ticker := time.NewTicker(time.Duration(interval) * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				c.poll()
-			}
-		}
-	}()
 }
 
 // Stop tears everything down (bridge + speaker), bounded.
@@ -194,6 +198,9 @@ func (c *Controller) Stop() {
 		return
 	}
 	c.stopped = true
+	c.mediaStateObserved = false
+	c.lastMediaState = types.ResidentMediaState{}
+	c.lastMediaStateConfirmed = false
 	cancel := c.cancel
 	c.cancel = nil
 	c.ctx = nil
@@ -232,7 +239,8 @@ func (c *Controller) HasVoiceOutput() bool {
 	return c.speaker != nil
 }
 
-// poll samples room_info and reconciles grants (fail-closed on error).
+// poll is a one-shot compatibility/helper path. Resident Runtimes use
+// ObserveMediaState instead, so an idle resident never sends room_info.
 func (c *Controller) poll() {
 	c.mu.Lock()
 	stopped := c.stopped
@@ -240,72 +248,134 @@ func (c *Controller) poll() {
 	if stopped {
 		return
 	}
-
-	authorized := false
-	var epoch *int64
-	vrAuthorized := false
-	var vrEpoch *int64
-	liveAuthorized := false
-	var liveInfo types.LiveTranscriptInfo
-	// #175 review fix: only a SUCCESSFUL RoomInfo observation may re-arm the
-	// announcement state. A transient failure leaves the grants unknown —
-	// the last announced epoch must survive it, so a recovery that observes
-	// the SAME grant epoch never re-announces the prerequisite.
-	roomInfoObserved := false
-
 	info, err := c.options.Client.RoomInfo(c.options.RoomID)
 	if err != nil {
-		// A transient room_info failure fails closed for BOTH grants.
-		authorized = false
-		vrAuthorized = false
+		// A transient RoomInfo failure fails closed for both grants but does not
+		// count as a confirmed inactive Room observation. This preserves the
+		// activation-edge behavior of the old polling controller.
 		c.log("voice_reply_room_info_failed", map[string]string{"code": safeDiagnosticCode(err)})
-	} else {
-		roomInfoObserved = true
-		liveInfo = info.LiveTranscript
-		if c.options.Voice != nil {
-			grant, vrTargetsSelf := info.AgentVoice[c.options.ParticipantID]
-			vrAuthorized = info.AgentVoiceMediaAvailable && vrTargetsSelf && grant.EnabledAt > 0
-			if grant.EnabledAt > 0 {
-				value := grant.EnabledAt
-				vrEpoch = &value
-			}
-			c.mu.Lock()
-			epochChanged := c.voiceObservedInit && !int64Equal(c.voiceObservedEpoch, vrEpoch)
-			c.voiceObservedEpoch = vrEpoch
-			c.voiceObservedInit = true
-			c.mu.Unlock()
-			c.log("voice_reply_state", map[string]string{
-				"agent_voice_media_available":     bool01(info.AgentVoiceMediaAvailable),
-				"agent_voice_enabled":             bool01(vrAuthorized),
-				"voice_reply_targets_self":        bool01(vrTargetsSelf),
-				"voice_reply_grant_epoch_present": bool01(vrEpoch != nil),
-				"voice_reply_grant_epoch_changed": bool01(epochChanged),
-			})
-		}
-		authorized = info.MeetingNotesMediaAvailable &&
-			info.MeetingNotes.Active &&
-			info.MeetingNotes.AgentParticipantID == c.options.ParticipantID
-		if info.MeetingNotes.StartedAt > 0 {
-			value := info.MeetingNotes.StartedAt
-			epoch = &value
-		}
-		liveAuthorized = c.acquireLiveTranscriptLease(info.LiveTranscript)
+		c.observeMediaState(types.ResidentMediaState{}, false)
+		return
 	}
+	c.observeMediaState(residentMediaStateFromRoomInfo(info, c.options.ParticipantID), true)
+}
+
+// ObserveMediaState reconciles one self-targeted state envelope from the
+// resident event stream. Identical envelopes are ignored so ordinary event
+// traffic does not restart media or emit repeated diagnostics.
+func (c *Controller) ObserveMediaState(state types.ResidentMediaState) {
+	c.observeMediaState(state, true)
+}
+
+// FailClosedMediaState stops local media after the resident event stream loses
+// its authenticated state source. It deliberately is not a confirmed Room
+// revocation, so a reconnect observing the same grant does not re-announce the
+// grant prerequisite.
+func (c *Controller) FailClosedMediaState() {
+	c.observeMediaState(types.ResidentMediaState{}, false)
+}
+
+func (c *Controller) observeMediaState(
+	state types.ResidentMediaState,
+	confirmed bool,
+) {
+	c.reconcileMu.Lock()
+	defer c.reconcileMu.Unlock()
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	if c.mediaStateObserved && c.lastMediaState == state &&
+		(!confirmed || c.lastMediaStateConfirmed) {
+		c.mu.Unlock()
+		return
+	}
+	c.mediaStateObserved = true
+	c.lastMediaState = state
+	c.lastMediaStateConfirmed = confirmed
+	c.mu.Unlock()
+	c.reconcileMediaState(state, confirmed)
+}
+
+func residentMediaStateFromRoomInfo(
+	info types.RoomInfo,
+	participantID string,
+) types.ResidentMediaState {
+	state := types.ResidentMediaState{
+		MediaAvailable: info.MeetingNotesMediaAvailable || info.AgentVoiceMediaAvailable,
+		LiveTranscript: types.ResidentLiveTranscriptState{
+			Active:                info.LiveTranscript.Active,
+			ProducerRuntimeHostID: info.LiveTranscript.ProducerRuntimeHostID,
+			Epoch:                 info.LiveTranscript.Epoch,
+		},
+		MeetingNotes: types.ResidentMeetingNotesState{
+			Active: info.MeetingNotesMediaAvailable &&
+				info.MeetingNotes.Active &&
+				info.MeetingNotes.AgentParticipantID == participantID,
+			StartedAt: info.MeetingNotes.StartedAt,
+		},
+	}
+	if grant, ok := info.AgentVoice[participantID]; ok &&
+		info.AgentVoiceMediaAvailable && grant.EnabledAt > 0 {
+		state.AgentVoiceEnabledAt = grant.EnabledAt
+	}
+	return state
+}
+
+func (c *Controller) reconcileMediaState(
+	mediaState types.ResidentMediaState,
+	roomInfoObserved bool,
+) {
+	authorized := mediaState.MediaAvailable && mediaState.MeetingNotes.Active
+	var epoch *int64
+	if mediaState.MeetingNotes.StartedAt > 0 {
+		value := mediaState.MeetingNotes.StartedAt
+		epoch = &value
+	}
+	vrAuthorized := c.options.Voice != nil &&
+		mediaState.MediaAvailable && mediaState.AgentVoiceEnabledAt > 0
+	var vrEpoch *int64
+	if mediaState.AgentVoiceEnabledAt > 0 {
+		value := mediaState.AgentVoiceEnabledAt
+		vrEpoch = &value
+	}
+	liveInfo := types.LiveTranscriptInfo{
+		Active:                mediaState.LiveTranscript.Active,
+		ProducerRuntimeHostID: mediaState.LiveTranscript.ProducerRuntimeHostID,
+		Epoch:                 mediaState.LiveTranscript.Epoch,
+	}
+	liveAuthorized := mediaState.MediaAvailable && c.acquireLiveTranscriptLease(liveInfo)
 	if !liveAuthorized {
 		c.releaseLiveTranscriptLease()
 	}
 	c.notifyLiveTranscriptState(liveInfo, liveAuthorized)
 
+	if c.options.Voice != nil {
+		c.mu.Lock()
+		epochChanged := c.voiceObservedInit && !int64Equal(c.voiceObservedEpoch, vrEpoch)
+		c.voiceObservedEpoch = vrEpoch
+		c.voiceObservedInit = true
+		c.mu.Unlock()
+		c.log("voice_reply_state", map[string]string{
+			"agent_voice_media_available":     bool01(mediaState.MediaAvailable),
+			"agent_voice_enabled":             bool01(vrAuthorized),
+			"voice_reply_targets_self":        bool01(vrEpoch != nil),
+			"voice_reply_grant_epoch_present": bool01(vrEpoch != nil),
+			"voice_reply_grant_epoch_changed": bool01(epochChanged),
+		})
+	}
+
 	// #171: per-grant activation edges. Each grant announces ONCE per grant
-	// instance (kind + epoch): a grant that stays active across polls never
-	// re-fires; a stop/start (new epoch) or a reassignment to this
+	// instance (kind + epoch): a grant that stays active across observations
+	// never re-fires; a stop/start (new epoch) or a reassignment to this
 	// participant produces a fresh edge. Edges fire even while the shared
 	// bridge is already running, so a second grant added later still gets
 	// its own prerequisite evaluation without splitting the bridge.
 	c.mu.Lock()
-	stopped = c.stopped
-	// A missing epoch (malformed/partial room_info) never participates in
-	// edge comparison: an already-announced grant cannot re-fire from it.
+	stopped := c.stopped
+	// A missing epoch (malformed/partial state) never participates in edge
+	// comparison: an already-announced grant cannot re-fire from it.
 	mnEdge := authorized &&
 		(!c.mnAnnounced || (epoch != nil && !int64Equal(c.mnAnnouncedEpoch, epoch)))
 	vrEdge := vrAuthorized &&
@@ -353,21 +423,18 @@ func (c *Controller) poll() {
 		return
 	}
 
-	// Epoch changes between polls mean the server already closed the old
-	// grant's tracks. Meeting Notes and Voice Reply need a whole-session
-	// rebuild. Live Transcript needs only its remote subscriptions cleared
-	// when another independent grant keeps the shared bridge alive; retaining
-	// those old local reservations would suppress tracks/new in the new epoch.
+	// Epoch changes mean the server already closed the old grant's tracks.
+	// Meeting Notes and Voice Reply need a whole-session rebuild. Live
+	// Transcript needs only its remote subscriptions cleared when another
+	// independent grant keeps the shared bridge alive.
 	c.mu.Lock()
 	mnStale := authorized && c.state != "idle" && !int64Equal(c.grantEpoch, epoch)
 	vrStale := vrAuthorized && c.state != "idle" && !int64Equal(c.voiceEpoch, vrEpoch)
 	liveWasBound := c.liveEpoch != nil
 	liveStarted := liveAuthorized && !liveWasBound
 	liveStale := liveAuthorized && liveWasBound && !int64Equal(c.liveEpoch, &liveInfo.Epoch)
-	// A successful room_info observation of Live Transcript Off means the
-	// server is revoking its remote subscriptions. A transport failure is
-	// deliberately excluded: it fails local processing closed but does not
-	// invent a server-side revocation.
+	// A confirmed inactive Live Transcript state means the server is revoking
+	// its remote subscriptions. A transport failure is deliberately excluded.
 	liveStopped := roomInfoObserved && !liveAuthorized && liveWasBound
 	rebuildBridge := mnStale || vrStale || (liveStale && !authorized && !vrAuthorized)
 	if liveStopped {
@@ -471,7 +538,7 @@ func (c *Controller) acquireLiveTranscriptLease(state types.LiveTranscriptInfo) 
 }
 
 // releaseLiveTranscriptLease only releases the exact epoch this resident
-// acquired. It is safe to call on every failed poll and during shutdown.
+// acquired. It is safe to call on every failed observation and during shutdown.
 func (c *Controller) releaseLiveTranscriptLease() {
 	if c.options.LiveTranscriptCoordinator == nil || c.options.RuntimeHostID == "" || c.options.RuntimeInstanceID == "" {
 		return

--- a/agent/internal/media/controller_test.go
+++ b/agent/internal/media/controller_test.go
@@ -266,12 +266,15 @@ func waitController(t *testing.T, timeout time.Duration, condition func() bool, 
 	t.Fatalf("timeout waiting for %s", message)
 }
 
-func TestControllerResidentMediaStateIsPushDriven(t *testing.T) {
+func TestControllerPushedMediaStateAtStartupBoundaryAndNoPolling(t *testing.T) {
 	client := &fakeRoomClient{}
 	controller, harness := newControllerHarness(t, client, nil)
 	controller.options.UsePushedMediaState = true
 	defer controller.Stop()
 
+	// This is the resident startup ordering: the Runtime starts the pushed
+	// controller synchronously, then the event stream delivers its first
+	// authorization projection.
 	controller.Start(t.Context())
 	time.Sleep(50 * time.Millisecond)
 	if got := client.roomInfoCallCount(); got != 0 {
@@ -296,7 +299,10 @@ func TestControllerResidentMediaStateIsPushDriven(t *testing.T) {
 }
 
 func TestControllerLiveTranscriptElectsOneVerifiedSameHostProducer(t *testing.T) {
-	client := &fakeRoomClient{live: types.LiveTranscriptInfo{
+	// Production projects the same AGENT_MEDIA_ENABLED master switch into
+	// both compatibility availability fields. Keep the fixture on that
+	// contract so Live Transcript is tested with media enabled as well.
+	client := &fakeRoomClient{mnAvail: true, vrAvail: true, live: types.LiveTranscriptInfo{
 		Active: true, ProducerRuntimeHostID: "host-a", StartedByHumanParticipantID: "human", Epoch: 7, StartedAt: 9,
 	}}
 	coordinator := &testLiveTranscriptCoordinator{}

--- a/agent/internal/media/controller_test.go
+++ b/agent/internal/media/controller_test.go
@@ -14,17 +14,18 @@ import (
 
 // fakeRoomClient scripts RoomInfo responses.
 type fakeRoomClient struct {
-	mu        sync.Mutex
-	mnActive  bool
-	mnAvail   bool
-	mnAgent   string
-	mnStarted int64
-	vrActive  bool
-	vrAvail   bool
-	vrAgent   string
-	vrStarted int64
-	live      types.LiveTranscriptInfo
-	err       error
+	mu            sync.Mutex
+	mnActive      bool
+	mnAvail       bool
+	mnAgent       string
+	mnStarted     int64
+	vrActive      bool
+	vrAvail       bool
+	vrAgent       string
+	vrStarted     int64
+	live          types.LiveTranscriptInfo
+	err           error
+	roomInfoCalls int
 }
 
 func (f *fakeRoomClient) setRoom(mnActive, mnAvail, mnAgent string, mnStarted int64,
@@ -45,6 +46,7 @@ func (f *fakeRoomClient) setRoom(mnActive, mnAvail, mnAgent string, mnStarted in
 func (f *fakeRoomClient) RoomInfo(string) (types.RoomInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.roomInfoCalls++
 	if f.err != nil {
 		return types.RoomInfo{}, f.err
 	}
@@ -65,6 +67,12 @@ func (f *fakeRoomClient) RoomInfo(string) (types.RoomInfo, error) {
 		AgentVoiceMediaAvailable: f.vrAvail,
 		LiveTranscript:           f.live,
 	}, nil
+}
+
+func (f *fakeRoomClient) roomInfoCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.roomInfoCalls
 }
 
 func (*fakeRoomClient) Connect() error               { return nil }
@@ -256,6 +264,35 @@ func waitController(t *testing.T, timeout time.Duration, condition func() bool, 
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timeout waiting for %s", message)
+}
+
+func TestControllerResidentMediaStateIsPushDriven(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, harness := newControllerHarness(t, client, nil)
+	controller.options.UsePushedMediaState = true
+	defer controller.Stop()
+
+	controller.Start(t.Context())
+	time.Sleep(50 * time.Millisecond)
+	if got := client.roomInfoCallCount(); got != 0 {
+		t.Fatalf("resident controller RoomInfo calls before state push = %d, want 0", got)
+	}
+
+	controller.ObserveMediaState(types.ResidentMediaState{
+		MeetingNotes:   types.ResidentMeetingNotesState{Active: true, StartedAt: 111},
+		MediaAvailable: true,
+	})
+	waitController(t, time.Second, func() bool { return harness.bridgeCount() == 1 }, "pushed Meeting Notes grant")
+	time.Sleep(50 * time.Millisecond)
+	if got := client.roomInfoCallCount(); got != 0 {
+		t.Fatalf("resident controller RoomInfo calls after state push = %d, want 0", got)
+	}
+
+	controller.ObserveMediaState(types.ResidentMediaState{})
+	waitController(t, time.Second, func() bool {
+		engine := harness.engineAt(0)
+		return engine != nil && engine.closeCalls == 1
+	}, "pushed media revocation")
 }
 
 func TestControllerLiveTranscriptElectsOneVerifiedSameHostProducer(t *testing.T) {

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -35,6 +35,7 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 	}
 	client := r.options.Client
 	siteOrigin := r.options.SiteOrigin
+	_, usePushedMediaState := client.(types.ResidentEventClient)
 	r.mu.Unlock()
 
 	previous := r.mediaController
@@ -95,6 +96,7 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 		ParticipantID:             handle.ParticipantID,
 		SiteOrigin:                siteOrigin,
 		Handle:                    handle,
+		UsePushedMediaState:       usePushedMediaState,
 		RuntimeHostID:             runtimeHostID,
 		RuntimeInstanceID:         r.options.InstanceID,
 		LiveTranscriptCoordinator: r.options.TranscriptProducers,
@@ -142,6 +144,35 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 	// Non-blocking like the frozen Node reference: the first grant poll must
 	// never gate join()/create() on a room_info round trip.
 	go controller.Start(context.Background())
+}
+
+// observeResidentMediaState forwards only the bounded media projection to the
+// current controller. It never enters the event buffer or pending-turn queue,
+// so media transitions cannot wake a Harness turn.
+func (r *ResidentRuntime) observeResidentMediaState(
+	state *types.ResidentMediaState,
+) {
+	if state == nil {
+		return
+	}
+	r.mediaMu.Lock()
+	controller := r.mediaController
+	r.mediaMu.Unlock()
+	if controller != nil {
+		controller.ObserveMediaState(*state)
+	}
+}
+
+// failClosedResidentMediaState revokes local media whenever the authenticated
+// resident state source is unavailable. The next reconnect must re-authorize
+// from a fresh server envelope before media can run again.
+func (r *ResidentRuntime) failClosedResidentMediaState() {
+	r.mediaMu.Lock()
+	controller := r.mediaController
+	r.mediaMu.Unlock()
+	if controller != nil {
+		controller.FailClosedMediaState()
+	}
 }
 
 func (r *ResidentRuntime) withCurrentMediaGeneration(

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -18,7 +18,10 @@ import (
 // decoded token discarded first. A failure here is logged and never fails
 // the join itself — media is strictly additive to text/ACP.
 func (r *ResidentRuntime) restartMediaController(participantHandle string) {
-	// Lock ordering is always mediaMu -> mu here and in releaseResources.
+	r.residentMediaStateApplyMu.Lock()
+	defer r.residentMediaStateApplyMu.Unlock()
+	// Lock ordering is always residentMediaStateApplyMu -> mediaMu -> mu here
+	// and in releaseResources.
 	// Stop sets stopped under mu before it waits for mediaMu, so a reload that
 	// begins after shutdown cannot create a controller against a closed client.
 	r.mediaMu.Lock()
@@ -162,6 +165,8 @@ func (r *ResidentRuntime) observeResidentMediaState(
 	if state == nil {
 		return
 	}
+	r.residentMediaStateApplyMu.Lock()
+	defer r.residentMediaStateApplyMu.Unlock()
 	r.mediaMu.Lock()
 	r.residentMediaStateMu.Lock()
 	r.residentMediaState = *state
@@ -179,6 +184,18 @@ func (r *ResidentRuntime) observeResidentMediaState(
 // It must run outside mediaMu because reconciliation may perform SFU I/O and
 // invoke callbacks that briefly inspect the Runtime's media generation.
 func (r *ResidentRuntime) replayResidentMediaState() {
+	r.replayResidentMediaStateWithBarrier(nil)
+}
+
+// replayResidentMediaStateWithBarrier contains the serialized replay path.
+// The barrier is nil in production; tests use it to pause exactly after the
+// cached snapshot is taken and prove revocations/new observations cannot pass
+// an in-flight replay.
+func (r *ResidentRuntime) replayResidentMediaStateWithBarrier(
+	barrier func(),
+) {
+	r.residentMediaStateApplyMu.Lock()
+	defer r.residentMediaStateApplyMu.Unlock()
 	r.mediaMu.Lock()
 	controller := r.mediaController
 	r.residentMediaStateMu.Lock()
@@ -186,6 +203,9 @@ func (r *ResidentRuntime) replayResidentMediaState() {
 	valid := r.residentMediaStateValid
 	r.residentMediaStateMu.Unlock()
 	r.mediaMu.Unlock()
+	if barrier != nil {
+		barrier()
+	}
 	if controller != nil && valid {
 		controller.ObserveMediaState(state)
 	}
@@ -195,6 +215,8 @@ func (r *ResidentRuntime) replayResidentMediaState() {
 // resident state source is unavailable. The next reconnect must re-authorize
 // from a fresh server envelope before media can run again.
 func (r *ResidentRuntime) failClosedResidentMediaState() {
+	r.residentMediaStateApplyMu.Lock()
+	defer r.residentMediaStateApplyMu.Unlock()
 	r.mediaMu.Lock()
 	r.residentMediaStateMu.Lock()
 	r.residentMediaStateValid = false

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -141,9 +141,16 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 	})
 	r.mediaController = controller
 	r.voiceSrc = controller
-	// Non-blocking like the frozen Node reference: the first grant poll must
-	// never gate join()/create() on a room_info round trip.
-	go controller.Start(context.Background())
+	// Pushed-state residents must be started before StartLoop opens the event
+	// stream. Start is local in this mode, so doing it synchronously closes the
+	// assignment -> initial mediaState scheduling gap. Compatibility clients
+	// retain the old non-blocking RoomInfo bootstrap so join/create is never
+	// gated on that network round trip.
+	if usePushedMediaState {
+		controller.Start(context.Background())
+	} else {
+		go controller.Start(context.Background())
+	}
 }
 
 // observeResidentMediaState forwards only the bounded media projection to the
@@ -156,10 +163,31 @@ func (r *ResidentRuntime) observeResidentMediaState(
 		return
 	}
 	r.mediaMu.Lock()
+	r.residentMediaStateMu.Lock()
+	r.residentMediaState = *state
+	r.residentMediaStateValid = true
+	r.residentMediaStateMu.Unlock()
 	controller := r.mediaController
 	r.mediaMu.Unlock()
 	if controller != nil {
 		controller.ObserveMediaState(*state)
+	}
+}
+
+// replayResidentMediaState reapplies the last authenticated projection after
+// a live resident Controller rebuild, without using RoomInfo as a fallback.
+// It must run outside mediaMu because reconciliation may perform SFU I/O and
+// invoke callbacks that briefly inspect the Runtime's media generation.
+func (r *ResidentRuntime) replayResidentMediaState() {
+	r.mediaMu.Lock()
+	controller := r.mediaController
+	r.residentMediaStateMu.Lock()
+	state := r.residentMediaState
+	valid := r.residentMediaStateValid
+	r.residentMediaStateMu.Unlock()
+	r.mediaMu.Unlock()
+	if controller != nil && valid {
+		controller.ObserveMediaState(state)
 	}
 }
 
@@ -168,6 +196,10 @@ func (r *ResidentRuntime) observeResidentMediaState(
 // from a fresh server envelope before media can run again.
 func (r *ResidentRuntime) failClosedResidentMediaState() {
 	r.mediaMu.Lock()
+	r.residentMediaStateMu.Lock()
+	r.residentMediaStateValid = false
+	r.residentMediaState = types.ResidentMediaState{}
+	r.residentMediaStateMu.Unlock()
 	controller := r.mediaController
 	r.mediaMu.Unlock()
 	if controller != nil {

--- a/agent/internal/runtime/resident_events_test.go
+++ b/agent/internal/runtime/resident_events_test.go
@@ -139,6 +139,17 @@ func TestResidentRuntimeUsesEventStreamAndSparseLeaseHeartbeat(t *testing.T) {
 		return open == 1
 	}, "resident event stream open")
 	stream.results <- types.WaitResult{
+		MediaState: &types.ResidentMediaState{
+			MediaAvailable: true,
+			MeetingNotes:   types.ResidentMeetingNotesState{Active: true, StartedAt: 7},
+		},
+		Cursor: 0, ExpiresAt: time.Now().Add(time.Hour).UnixMilli(),
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := adapter.sessionsInt(); got != 0 {
+		t.Fatalf("media-only resident state must not wake Harness, turns=%d", got)
+	}
+	stream.results <- types.WaitResult{
 		Events: []types.RoomEvent{roomEvent(1, true)},
 		Cursor: 1, ExpiresAt: time.Now().Add(time.Hour).UnixMilli(),
 	}

--- a/agent/internal/runtime/resident_events_test.go
+++ b/agent/internal/runtime/resident_events_test.go
@@ -229,6 +229,89 @@ func TestResidentRuntimeRetriesHumanTaskAcceptanceOnHeartbeat(t *testing.T) {
 	}
 }
 
+func TestResidentMediaReplaySerializesWithTransportFailClosed(t *testing.T) {
+	rt := NewResidentRuntime(Options{})
+	rt.observeResidentMediaState(&types.ResidentMediaState{
+		MediaAvailable: true,
+		MeetingNotes:   types.ResidentMeetingNotesState{Active: true, StartedAt: 7},
+	})
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	replayDone := make(chan struct{})
+	go func() {
+		rt.replayResidentMediaStateWithBarrier(func() {
+			close(entered)
+			<-release
+		})
+		close(replayDone)
+	}()
+	<-entered
+
+	failClosedDone := make(chan struct{})
+	go func() {
+		rt.failClosedResidentMediaState()
+		close(failClosedDone)
+	}()
+	select {
+	case <-failClosedDone:
+		t.Fatal("fail-closed must wait for an in-flight replay application")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	<-replayDone
+	<-failClosedDone
+
+	rt.residentMediaStateMu.Lock()
+	valid := rt.residentMediaStateValid
+	rt.residentMediaStateMu.Unlock()
+	if valid {
+		t.Fatal("transport fail-closed must invalidate the replay cache")
+	}
+}
+
+func TestResidentMediaReplaySerializesWithNewInactiveState(t *testing.T) {
+	rt := NewResidentRuntime(Options{})
+	rt.observeResidentMediaState(&types.ResidentMediaState{
+		MediaAvailable: true,
+		MeetingNotes:   types.ResidentMeetingNotesState{Active: true, StartedAt: 7},
+	})
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	replayDone := make(chan struct{})
+	go func() {
+		rt.replayResidentMediaStateWithBarrier(func() {
+			close(entered)
+			<-release
+		})
+		close(replayDone)
+	}()
+	<-entered
+
+	inactiveDone := make(chan struct{})
+	go func() {
+		rt.observeResidentMediaState(&types.ResidentMediaState{})
+		close(inactiveDone)
+	}()
+	select {
+	case <-inactiveDone:
+		t.Fatal("new inactive state must wait for an in-flight replay application")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	<-replayDone
+	<-inactiveDone
+
+	rt.residentMediaStateMu.Lock()
+	state := rt.residentMediaState
+	valid := rt.residentMediaStateValid
+	rt.residentMediaStateMu.Unlock()
+	if !valid || state.MediaAvailable || state.MeetingNotes.Active {
+		t.Fatalf("new inactive state lost after replay: valid=%v state=%+v", valid, state)
+	}
+}
+
 func TestResidentRuntimeUsesLeaseParsedFromMCPJoin(t *testing.T) {
 	const leaseMs = 30
 	handlePayload, err := json.Marshal(map[string]string{

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -627,8 +627,8 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 	}
 	r.mu.Unlock()
 	// Media controller (re)build happens OUTSIDE the runtime lock: it may
-	// stop the previous bridge, create a transcriber, and poll room_info —
-	// none of that may hold the runtime mutex.
+	// stop the previous bridge, create a transcriber, and perform a compatibility
+	// RoomInfo bootstrap — none of that may hold the runtime mutex.
 	r.restartMediaController(joined.ParticipantHandle)
 }
 
@@ -738,6 +738,12 @@ func (r *ResidentRuntime) residentWaitLoop(client types.ResidentEventClient) {
 			_ = stream.Close()
 		}
 
+		// Media authorization is fail-closed at the transport boundary. A
+		// reconnect must receive a fresh current media projection before any
+		// local bridge can run again.
+		if !r.isStopped() {
+			r.failClosedResidentMediaState()
+		}
 		if r.isStopped() {
 			return
 		}
@@ -861,8 +867,16 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 				}
 				return received.err
 			}
+			if received.result.MediaState == nil {
+				// A resident envelope without the mandatory media projection is
+				// not an authorization observation. Keep event delivery alive,
+				// but revoke local media until a complete envelope arrives.
+				r.failClosedResidentMediaState()
+			}
 			r.advanceFromWait(received.result)
-			if len(r.pendingScopes()) > 0 && !r.isStopped() {
+			// A media-only envelope is observation, not an activation event. Do
+			// not use it as a Harness wakeup/retry boundary for pre-existing work.
+			if len(received.result.Events) > 0 && len(r.pendingScopes()) > 0 && !r.isStopped() {
 				r.drainTurns()
 			}
 			receiveNext()
@@ -942,6 +956,11 @@ func (r *ResidentRuntime) advanceFromWait(result types.WaitResult) {
 		r.roster = append([]types.ParticipantRosterEntry(nil), result.Participants...)
 	}
 	r.mu.Unlock()
+
+	// Media state is observation-only runtime input. It is deliberately
+	// processed outside the Runtime event queue so a grant transition never
+	// wakes or creates a Harness turn.
+	r.observeResidentMediaState(result.MediaState)
 
 	// Deduplicate within the envelope as well as against the prior transport
 	// receipt boundary. This map is intentionally envelope-local: the monotonic

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -202,6 +202,12 @@ type ResidentRuntime struct {
 
 	mediaController *media.Controller
 	mediaMu         sync.Mutex
+	// residentMediaState is the last authenticated media projection. It is
+	// replayed only when a live resident controller is rebuilt (for example by
+	// speech hot reload); transport loss invalidates it before reconnect.
+	residentMediaStateMu    sync.Mutex
+	residentMediaState      types.ResidentMediaState
+	residentMediaStateValid bool
 	// mediaGeneration invalidates callbacks from a stopped/replaced bridge.
 	// Bridge teardown reports TrackEnded asynchronously so it cannot re-enter
 	// mediaMu; without this generation fence, a late old callback could end a
@@ -237,6 +243,7 @@ func (r *ResidentRuntime) ReloadSpeech(config speech.Config) {
 	r.mu.Unlock()
 	if !stopped && handle != "" {
 		r.restartMediaController(handle)
+		r.replayResidentMediaState()
 		r.projectRuntimeHost(handle)
 	}
 }
@@ -630,6 +637,7 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 	// stop the previous bridge, create a transcriber, and perform a compatibility
 	// RoomInfo bootstrap — none of that may hold the runtime mutex.
 	r.restartMediaController(joined.ParticipantHandle)
+	r.replayResidentMediaState()
 }
 
 // requireHandle returns the live capability or fails closed.
@@ -1585,6 +1593,10 @@ func (r *ResidentRuntime) beginStop(lastError string) bool {
 func (r *ResidentRuntime) releaseResources() {
 	r.mediaMu.Lock()
 	defer r.mediaMu.Unlock()
+	r.residentMediaStateMu.Lock()
+	r.residentMediaStateValid = false
+	r.residentMediaState = types.ResidentMediaState{}
+	r.residentMediaStateMu.Unlock()
 	// Invalidate every callback before Controller.Stop tears the bridge down.
 	// Its active-subscription TrackEnded notifications are intentionally
 	// asynchronous to keep this lifecycle mutex non-reentrant.

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -202,6 +202,10 @@ type ResidentRuntime struct {
 
 	mediaController *media.Controller
 	mediaMu         sync.Mutex
+	// residentMediaStateApplyMu serializes cache changes with their Controller
+	// application. It is held across the apply call so a replay cannot take a
+	// stale snapshot, yield to revocation, and then re-enable media afterward.
+	residentMediaStateApplyMu sync.Mutex
 	// residentMediaState is the last authenticated media projection. It is
 	// replayed only when a live resident controller is rebuilt (for example by
 	// speech hot reload); transport loss invalidates it before reconnect.
@@ -1591,6 +1595,8 @@ func (r *ResidentRuntime) beginStop(lastError string) bool {
 // releaseResources mirrors the Node cleanupResources ordering: media first
 // (bounded teardown), then the lease, then Harness/client.
 func (r *ResidentRuntime) releaseResources() {
+	r.residentMediaStateApplyMu.Lock()
+	defer r.residentMediaStateApplyMu.Unlock()
 	r.mediaMu.Lock()
 	defer r.mediaMu.Unlock()
 	r.residentMediaStateMu.Lock()

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -445,13 +445,15 @@ func (c *fakeClient) SendText(_ string, text string, targets []string) (types.Se
 		c.mu.Unlock()
 		return types.SendTextResult{}, errors.New("send failed")
 	}
-	c.mu.Unlock()
 	c.sent = append(c.sent, text)
 	c.sentTargets = append(c.sentTargets, append([]string(nil), targets...))
-	if c.sendHook != nil {
-		c.sendHook(text)
+	sequence := len(c.sent)
+	hook := c.sendHook
+	c.mu.Unlock()
+	if hook != nil {
+		hook(text)
 	}
-	return types.SendTextResult{Sequence: int64(len(c.sent))}, nil
+	return types.SendTextResult{Sequence: int64(sequence)}, nil
 }
 
 func (c *fakeClient) SendTextForTask(handle, text string, targets []string, taskRequestID string) (types.SendTextResult, error) {

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -419,6 +419,27 @@ type LiveTranscriptInfo struct {
 	StartedAt                   int64  `json:"startedAt,omitempty"`
 }
 
+// ResidentMediaState is the self-targeted media projection delivered on the
+// private resident event stream. It contains authorization epochs only; it
+// never carries media/session identifiers or another Agent's grants.
+type ResidentMediaState struct {
+	MeetingNotes        ResidentMeetingNotesState   `json:"meetingNotes"`
+	AgentVoiceEnabledAt int64                       `json:"agentVoiceEnabledAt,omitempty"`
+	MediaAvailable      bool                        `json:"mediaAvailable"`
+	LiveTranscript      ResidentLiveTranscriptState `json:"liveTranscript"`
+}
+
+type ResidentMeetingNotesState struct {
+	Active    bool  `json:"active"`
+	StartedAt int64 `json:"startedAt,omitempty"`
+}
+
+type ResidentLiveTranscriptState struct {
+	Active                bool   `json:"active"`
+	ProducerRuntimeHostID string `json:"producerRuntimeHostId,omitempty"`
+	Epoch                 int64  `json:"epoch,omitempty"`
+}
+
 // LiveTranscriptSegment is one committed Room-shared utterance. It is
 // bounded by the Room Durable Object and intentionally has no audio or media
 // identifiers.
@@ -574,8 +595,9 @@ type RoomInfo struct {
 	Exists       bool                     `json:"exists"`
 	Participants []ParticipantRosterEntry `json:"participants,omitempty"`
 	MeetingNotes MeetingNotesInfo         `json:"meetingNotes"`
-	// Fail closed: only explicit true counts. Media is PR 2 scope in the Go
-	// runtime; these fields remain part of the transport contract.
+	// Fail closed: only explicit true counts. The resident event stream carries
+	// the equivalent bounded self-targeted projection; these fields remain part
+	// of the compatibility transport contract.
 	MeetingNotesMediaAvailable bool                       `json:"meetingNotesMediaAvailable"`
 	AgentVoice                 map[string]AgentVoiceGrant `json:"agentVoice"`
 	AgentVoiceMediaAvailable   bool                       `json:"agentVoiceMediaAvailable"`
@@ -636,6 +658,9 @@ type WaitResult struct {
 	// RuntimeHosts (#176 Phase A): one coarse readiness projection per
 	// Runtime Host id present in the Room, shared by all same-host Agents.
 	RuntimeHosts map[string]RuntimeHostProjection
+	// MediaState is populated only by the private resident event stream. The
+	// public wait_for_events contract remains text/roster-only.
+	MediaState *ResidentMediaState `json:"mediaState,omitempty"`
 }
 
 // CollabRequestArgs are the arguments for send_collab_request.

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -58,6 +58,7 @@ import {
   stageAgentMediaRevocation,
   type AgentMediaRevocationDirection,
 } from "./realtimeMedia"
+import { projectResidentMediaState } from "./residentMediaState"
 import {
   buildAgentJoinedEvent,
   buildCollabOutcomeEvent,
@@ -2054,6 +2055,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         ...result,
         participants: rosterProjection(room.participants),
         runtimeHosts: projectRuntimeHosts(room.runtimeHosts),
+        mediaState: projectResidentMediaState({
+          participantId: attachment.participantId,
+          meetingNotes: room.meetingNotes,
+          agentVoice: room.agentVoice,
+          liveTranscript: room.liveTranscript,
+          mediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+        }),
       })
       if (
         new TextEncoder().encode(encoded).byteLength > RESIDENT_EVENT_MAX_BYTES

--- a/app/src/do/residentMediaState.test.ts
+++ b/app/src/do/residentMediaState.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { projectResidentMediaState } from "./residentMediaState"
+
+describe("projectResidentMediaState", () => {
+  it("projects only the named resident's media authorization", () => {
+    const state = projectResidentMediaState({
+      participantId: "agent-a",
+      meetingNotes: {
+        active: true,
+        agentParticipantId: "agent-a",
+        startedAt: 11,
+      },
+      agentVoice: {
+        "agent-a": { enabled: true, enabledAt: 22 },
+        "agent-b": { enabled: true, enabledAt: 33 },
+      },
+      liveTranscript: {
+        active: true,
+        producerRuntimeHostId: "host-a",
+        startedByHumanParticipantId: "human-a",
+        epoch: 7,
+        startedAt: 8,
+      },
+      mediaAvailable: true,
+    })
+
+    expect(state).toEqual({
+      meetingNotes: { active: true, startedAt: 11 },
+      agentVoiceEnabledAt: 22,
+      mediaAvailable: true,
+      liveTranscript: {
+        active: true,
+        producerRuntimeHostId: "host-a",
+        epoch: 7,
+      },
+    })
+    expect(state).not.toHaveProperty("startedByHumanParticipantId")
+  })
+
+  it("does not leak another Agent's grant to a different resident", () => {
+    const state = projectResidentMediaState({
+      participantId: "agent-b",
+      meetingNotes: {
+        active: true,
+        agentParticipantId: "agent-a",
+        startedAt: 11,
+      },
+      agentVoice: {
+        "agent-a": { enabled: true, enabledAt: 22 },
+      },
+      liveTranscript: { active: false },
+      mediaAvailable: false,
+    })
+
+    expect(state).toEqual({
+      meetingNotes: { active: false },
+      mediaAvailable: false,
+      liveTranscript: { active: false },
+    })
+  })
+})

--- a/app/src/do/residentMediaState.ts
+++ b/app/src/do/residentMediaState.ts
@@ -1,0 +1,58 @@
+import type {
+  AgentVoiceState,
+  LiveTranscriptState,
+  MeetingNotesState,
+  ResidentMediaState,
+} from "../room/types"
+
+interface ResidentMediaStateInput {
+  participantId: string
+  meetingNotes: MeetingNotesState
+  agentVoice: AgentVoiceState
+  liveTranscript: LiveTranscriptState
+  mediaAvailable: boolean
+}
+
+// Projects only the media state that the named resident needs to reconcile its
+// own controller. In particular, do not expose another Agent's grant or the
+// Human that started Live Transcript through this private event envelope.
+export function projectResidentMediaState({
+  participantId,
+  meetingNotes,
+  agentVoice,
+  liveTranscript,
+  mediaAvailable,
+}: ResidentMediaStateInput): ResidentMediaState {
+  const meetingNotesForSelf =
+    meetingNotes.active && meetingNotes.agentParticipantId === participantId
+  const meetingNotesState = meetingNotesForSelf
+    ? {
+        active: true as const,
+        ...(meetingNotes.startedAt !== undefined
+          ? { startedAt: meetingNotes.startedAt }
+          : {}),
+      }
+    : { active: false as const }
+
+  const voiceGrant = agentVoice[participantId]
+  const agentVoiceEnabledAt =
+    voiceGrant?.enabled && voiceGrant.enabledAt > 0
+      ? voiceGrant.enabledAt
+      : undefined
+
+  const liveTranscriptState: ResidentMediaState["liveTranscript"] =
+    liveTranscript.active
+      ? {
+          active: true,
+          producerRuntimeHostId: liveTranscript.producerRuntimeHostId,
+          epoch: liveTranscript.epoch,
+        }
+      : { active: false }
+
+  return {
+    meetingNotes: meetingNotesState,
+    ...(agentVoiceEnabledAt === undefined ? {} : { agentVoiceEnabledAt }),
+    mediaAvailable,
+    liveTranscript: liveTranscriptState,
+  }
+}

--- a/app/src/do/roomSessionLifecycle.test.ts
+++ b/app/src/do/roomSessionLifecycle.test.ts
@@ -474,7 +474,37 @@ describe("RoomSession expiry cleanup", () => {
     }
     vi.stubGlobal("Response", UpgradeResponse)
 
-    const store = new Map<string, unknown>([["room", agentEventRoom()]])
+    const room = agentEventRoom()
+    room.meetingNotes = {
+      active: true,
+      agentParticipantId: "agent",
+      startedAt: 11,
+    }
+    room.agentVoice = { agent: { enabled: true, enabledAt: 22 } }
+    const runtimeHostId = "11111111-2222-3333-4444-555555555555"
+    room.participants.agent.runtimeHostId = runtimeHostId
+    room.runtimeHosts = {
+      [runtimeHostId]: {
+        runtimeHostId,
+        speech: { stt: true, tts: true },
+      },
+    }
+    room.runtimeHostProviders = {
+      [runtimeHostId]: {
+        humanParticipantId: "human",
+        claimedAt: 1,
+        providerHandleHash: "A".repeat(43),
+        verifiedParticipantIds: ["agent"],
+      },
+    }
+    room.liveTranscript = {
+      active: true,
+      producerRuntimeHostId: runtimeHostId,
+      startedByHumanParticipantId: "human",
+      epoch: 7,
+      startedAt: 8,
+    }
+    const store = new Map<string, unknown>([["room", room]])
     const sockets: TestAgentEventSocket[] = []
     const tags = new Map<TestAgentEventSocket, string[]>()
     const ctx = {
@@ -502,7 +532,10 @@ describe("RoomSession expiry cleanup", () => {
         }
       ),
     }
-    const session = new RoomSession(ctx as never, { SFU_ROOM: {} } as never)
+    const session = new RoomSession(
+      ctx as never,
+      { SFU_ROOM: {}, AGENT_MEDIA_ENABLED: "true" } as never
+    )
     const first = {
       0: new TestAgentEventSocket(),
       1: new TestAgentEventSocket(),
@@ -511,9 +544,17 @@ describe("RoomSession expiry cleanup", () => {
       0: new TestAgentEventSocket(),
       1: new TestAgentEventSocket(),
     }
+    const third = {
+      0: new TestAgentEventSocket(),
+      1: new TestAgentEventSocket(),
+    }
     vi.stubGlobal(
       "WebSocketPair",
-      vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second)
+      vi
+        .fn()
+        .mockReturnValueOnce(first)
+        .mockReturnValueOnce(second)
+        .mockReturnValueOnce(third)
     )
     const request = () =>
       new Request("https://room/agent-events", {
@@ -540,6 +581,16 @@ describe("RoomSession expiry cleanup", () => {
     expect(JSON.parse(first[1].sent[0])).toMatchObject({
       type: "events",
       cursor: 0,
+      mediaState: {
+        meetingNotes: { active: true, startedAt: 11 },
+        agentVoiceEnabledAt: 22,
+        mediaAvailable: true,
+        liveTranscript: {
+          active: true,
+          producerRuntimeHostId: runtimeHostId,
+          epoch: 7,
+        },
+      },
     })
 
     const secondResponse = await (
@@ -549,6 +600,9 @@ describe("RoomSession expiry cleanup", () => {
     ).handleAgentEventConnection(request())
     expect(secondResponse.status).toBe(101)
     expect(first[1].closed).toContainEqual({ code: 4000, reason: "Replaced" })
+    expect(JSON.parse(second[1].sent[0]).mediaState).toEqual(
+      JSON.parse(first[1].sent[0]).mediaState
+    )
 
     // A delayed close from the replaced socket cannot revoke the new nonce.
     await session.webSocketClose(first[1] as never, 4000, "Replaced", true)
@@ -562,6 +616,25 @@ describe("RoomSession expiry cleanup", () => {
     current = store.get("room") as RoomRecord
     expect(current.participants.agent.connected).toBe(true)
     expect(current.nextMessageSequence).toBe(0)
+
+    current.meetingNotes = { active: false }
+    current.agentVoice = {}
+    current.liveTranscript = { active: false }
+    await (
+      session as unknown as {
+        saveRoom: (room: RoomRecord) => Promise<void>
+      }
+    ).saveRoom(current)
+    await (
+      session as unknown as {
+        broadcastState: (room: RoomRecord) => Promise<void>
+      }
+    ).broadcastState(current)
+    expect(JSON.parse(second[1].sent.at(-1) ?? "{}").mediaState).toEqual({
+      meetingNotes: { active: false },
+      mediaAvailable: true,
+      liveTranscript: { active: false },
+    })
 
     current.messages.push({
       id: "message-1",
@@ -586,7 +659,24 @@ describe("RoomSession expiry cleanup", () => {
       text: "hello",
     })
 
-    await session.webSocketClose(second[1] as never, 1000, "closed", true)
+    await (
+      session as unknown as {
+        saveRoom: (room: RoomRecord) => Promise<void>
+      }
+    ).saveRoom(current)
+    const thirdResponse = await (
+      session as unknown as {
+        handleAgentEventConnection: (request: Request) => Promise<Response>
+      }
+    ).handleAgentEventConnection(request())
+    expect(thirdResponse.status).toBe(101)
+    expect(JSON.parse(third[1].sent[0]).mediaState).toEqual({
+      meetingNotes: { active: false },
+      mediaAvailable: true,
+      liveTranscript: { active: false },
+    })
+
+    await session.webSocketClose(third[1] as never, 1000, "closed", true)
     current = store.get("room") as RoomRecord
     expect(current.participants.agent.connected).toBe(false)
   })

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -334,6 +334,29 @@ export type LiveTranscriptState =
       startedAt: number
     }
 
+// Private resident event-stream projection. It is self-targeted and contains
+// only the grant epochs needed to reconcile one local media controller; it is
+// not part of browser RoomState or the public room_info projection.
+export interface ResidentMeetingNotesState {
+  active: boolean
+  startedAt?: number
+}
+
+export type ResidentLiveTranscriptState =
+  | { active: false }
+  | {
+      active: true
+      producerRuntimeHostId: string
+      epoch: number
+    }
+
+export interface ResidentMediaState {
+  meetingNotes: ResidentMeetingNotesState
+  agentVoiceEnabledAt?: number
+  mediaAvailable: boolean
+  liveTranscript: ResidentLiveTranscriptState
+}
+
 // A committed, Room-scoped STT result. Sequence and createdAt are assigned by
 // RoomSession; speaker is derived from the current Human participant rather
 // than trusted from a Runtime callback.


### PR DESCRIPTION
## Summary

- Refs #317.
- Remove the resident Agent Runtime's recurring `room_info` polling for media authorization.
- Reuse the existing hibernatable resident event WebSocket to deliver a bounded, self-targeted media projection.

## Root cause / cost path

The resident media Controller previously polled `room_info` every 5 seconds. Each poll is a `POST /room/control` request that wakes the Room Durable Object and performs a storage-backed observation. With three resident runtimes, this accounts for roughly 2,100 DO control requests per hour before normal room traffic. The separate SFU track-discovery cadence is unchanged by this PR.

## What changed

- Add a minimal resident-only `mediaState` projection to the existing Agent event stream.
- Push the current state on initial connection, reconnect, grant transitions, and environment media-gate changes.
- Reconcile Meeting Notes, Agent Voice, and Live Transcript state from the pushed projection.
- Fail closed when the authenticated event stream fails or an envelope lacks the required projection; require a fresh state after reconnect before media can run.
- Keep media-only envelopes outside the Runtime event queue so they never wake the Harness.
- Retain one-shot `RoomInfo` bootstrap compatibility for non-resident/injected clients, but remove the recurring Controller ticker.

## Invariants

- The projection is self-targeted and does not expose another Agent's grant, Human identifiers, handles, tokens, or media/session identifiers.
- The public `wait_for_events` contract is unchanged.
- Existing SFU subscription polling remains separate and unchanged.
- PR B (heartbeat/persistence write amplification) is intentionally not included.

## Verification

- `yarn test` — 75 files, 671 tests passed.
- `yarn type-check` passed.
- `yarn docs:check` passed.
- `yarn eslint src --no-fix` passed.
- `yarn prettier --check .` passed.
- `yarn cf-build` completed successfully; OpenNext emitted existing non-fatal copy warnings.
- `go test ./...` passed.
- `go vet ./...` and `go build ./cmd/free4chat` passed.
- Focused resident event-stream race test passed.
- CI-equivalent `go test ./... -count=1` passed after the follow-up fix.

## Follow-up fix

- Start pushed-state Controllers synchronously before opening the resident event stream, closing the initial projection scheduling gap.
- Retain the last authenticated projection only in Runtime memory for live Controller rebuilds such as speech hot reload; clear it on transport loss before reconnect.
- Align the Live Transcript compatibility test fixture with the production `AGENT_MEDIA_ENABLED` projection contract.

After deployment, production DO request/write metrics should be rechecked to confirm the expected reduction and to size the separate PR B follow-up.
