### PR TITLE
Fix task-scoped Agent context isolation and participation

### DIFF
--- a/agent/internal/runtime/helpers.go
+++ b/agent/internal/runtime/helpers.go
@@ -160,6 +160,23 @@ func scopeForRoomEvent(event types.RoomEvent) string {
 	return roomScope
 }
 
+// humanTaskRequestFor returns the Human-originated Task request that admitted
+// this Runtime's first scoped turn. Agent-originated collaboration requests
+// keep their explicit accepted/declined semantics and are deliberately
+// excluded here.
+func humanTaskRequestFor(events []types.RoomEvent, participantID string) *types.WireCollabEvent {
+	for _, event := range events {
+		if !event.Addressed || event.Participant.Kind != types.KindHuman || event.Collab == nil ||
+			event.Collab.Kind != types.CollabRequest || event.Collab.TargetParticipantID != participantID ||
+			taskRequestIDForScope(scopeForRoomEvent(event)) == "" {
+			continue
+		}
+		request := *event.Collab
+		return &request
+	}
+	return nil
+}
+
 func containsSequence(items []int64, sequence int64) bool {
 	for _, item := range items {
 		if item == sequence {

--- a/agent/internal/runtime/resident_events_test.go
+++ b/agent/internal/runtime/resident_events_test.go
@@ -161,6 +161,63 @@ func TestResidentRuntimeUsesEventStreamAndSparseLeaseHeartbeat(t *testing.T) {
 	}
 }
 
+func TestResidentRuntimeRetriesHumanTaskAcceptanceOnHeartbeat(t *testing.T) {
+	stream := newResidentTestStream()
+	client := &residentTestClient{
+		fakeClient: &fakeClient{
+			collabResponseErrors: []error{errors.New("temporary acceptance failure"), nil},
+		},
+		streams: make(chan *residentTestStream, 1),
+	}
+	client.streams <- stream
+	adapter := &fakeAdapter{name: "pi"}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "resident-human-task-retry",
+		RoomID:     "room-human-task-retry",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	if err := rt.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer rt.Stop()
+	waitFor(t, time.Second, func() bool {
+		open, _, _ := client.residentOpenSnapshot()
+		return open == 1
+	}, "resident event stream open")
+
+	event := scopedEvent(1, "task:T", "Investigate this")
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human",
+		TargetParticipantID: "agent-1",
+	}
+	// There is intentionally exactly one Room envelope. The second accepted
+	// call must be caused by the resident lease heartbeat, not another event.
+	stream.results <- types.WaitResult{
+		Events:    []types.RoomEvent{event},
+		Cursor:    1,
+		ExpiresAt: time.Now().Add(time.Hour).UnixMilli(),
+	}
+
+	waitFor(t, time.Second, func() bool {
+		responses := client.snapshotCollabResponses()
+		runs, _ := adapter.scopedRunSnapshot()
+		return len(responses) == 2 && len(runs) == 1 && len(rt.pendingAddressedSnapshotFor("task:T")) == 0
+	}, "heartbeat acceptance retry and single Harness turn")
+	if len(stream.heartbeats) == 0 {
+		t.Fatal("accepted retry completed without a resident heartbeat")
+	}
+	status := rt.Status()
+	if status.LastError != "" || status.State != StateWaiting {
+		t.Fatalf("successful acceptance retry left stale Runtime state: %+v", status)
+	}
+}
+
 func TestResidentRuntimeUsesLeaseParsedFromMCPJoin(t *testing.T) {
 	const leaseMs = 30
 	handlePayload, err := json.Marshal(map[string]string{

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -796,6 +796,21 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	heartbeatErrors := make(chan error, 1)
+	retrySignals := make(chan struct{}, 1)
+	type receiveResult struct {
+		result types.WaitResult
+		err    error
+	}
+	receiveResults := make(chan receiveResult, 1)
+	receiveNext := func() {
+		go func() {
+			result, err := stream.Receive(ctx)
+			select {
+			case receiveResults <- receiveResult{result: result, err: err}:
+			case <-ctx.Done():
+			}
+		}()
+	}
 	interval := r.residentHeartbeatInterval()
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -812,28 +827,45 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 					_ = stream.Close()
 					return
 				}
+				// Heartbeats are also the narrow retry clock for a Human Task
+				// whose canonical accepted response failed. Keep the signal
+				// bounded; drainTurns remains the sole serial admission path.
+				select {
+				case retrySignals <- struct{}{}:
+				default:
+				}
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
 
+	receiveNext()
 	for {
-		result, err := stream.Receive(ctx)
-		if err != nil {
-			select {
-			case heartbeatErr := <-heartbeatErrors:
-				return heartbeatErr
-			default:
+		select {
+		case heartbeatErr := <-heartbeatErrors:
+			return heartbeatErr
+		case <-retrySignals:
+			if r.shouldRetryHumanTaskAcceptance() && !r.isStopped() {
+				r.drainTurns()
 			}
-			if r.isStopped() {
-				return nil
+		case received := <-receiveResults:
+			if received.err != nil {
+				select {
+				case heartbeatErr := <-heartbeatErrors:
+					return heartbeatErr
+				default:
+				}
+				if r.isStopped() {
+					return nil
+				}
+				return received.err
 			}
-			return err
-		}
-		r.advanceFromWait(result)
-		if len(r.pendingScopes()) > 0 && !r.isStopped() {
-			r.drainTurns()
+			r.advanceFromWait(received.result)
+			if len(r.pendingScopes()) > 0 && !r.isStopped() {
+				r.drainTurns()
+			}
+			receiveNext()
 		}
 	}
 }
@@ -1140,6 +1172,15 @@ func (r *ResidentRuntime) drainTurns() {
 				r.log("collab_accept_failed", nil)
 				return
 			}
+			r.mu.Lock()
+			// A successful canonical acceptance resolves the send-origin
+			// admission failure before cognition starts. Do not let the stale
+			// reconnect state survive into the healthy Harness turn.
+			if r.lastErrorSource == "send" {
+				r.lastError = ""
+				r.lastErrorSource = ""
+			}
+			r.mu.Unlock()
 		}
 
 		// A newly addressed turn wins the speaker: stale audio from the
@@ -1225,6 +1266,41 @@ func (r *ResidentRuntime) drainTurns() {
 			voiceOutput.Speak(text)
 		}
 	}
+}
+
+// shouldRetryHumanTaskAcceptance is deliberately narrower than a generic
+// retry scheduler. A heartbeat may retry only the admission boundary that can
+// otherwise remain pinned after transport receipt: a Human-originated Task
+// whose canonical accepted response failed. Generic Agent collaboration keeps
+// its existing explicit response semantics and is still driven by its normal
+// event path.
+func (r *ResidentRuntime) shouldRetryHumanTaskAcceptance() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastErrorSource != "send" || r.participantID == "" {
+		return false
+	}
+	hasPendingRequest := func(ref *logicalSessionRef) bool {
+		if ref == nil || ref.pendingAddressed == nil || ref.pendingContexts == nil {
+			return false
+		}
+		for _, target := range *ref.pendingAddressed {
+			pending, ok := (*ref.pendingContexts)[target]
+			if ok && humanTaskRequestFor(pending.events, r.participantID) != nil {
+				return true
+			}
+		}
+		return false
+	}
+	if hasPendingRequest(r.sessionRefLocked(roomScope)) {
+		return true
+	}
+	for _, scope := range r.scopeOrder {
+		if hasPendingRequest(r.sessionRefLocked(scope)) {
+			return true
+		}
+	}
+	return false
 }
 
 func taskRequestIDForScope(scope string) string {

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -1038,7 +1038,7 @@ func (r *ResidentRuntime) drainTurns() {
 		r.mu.Lock()
 		r.turnRunning = false
 		if !r.stopped {
-			if r.harnessFailed {
+			if r.harnessFailed || r.lastErrorSource == "send" {
 				r.state = StateReconnecting
 			} else {
 				r.state = StateWaiting
@@ -1122,6 +1122,25 @@ func (r *ResidentRuntime) drainTurns() {
 		r.enrichAttachments(input)
 		meetingThrough := r.attachTranscriptFor(scope, input)
 		liveThrough := r.attachLiveTranscriptFor(scope, input)
+
+		// A Human-originated Task becomes Working only after its scoped session
+		// is available and immediately before the first real cognition turn.
+		// Agent-originated collaboration keeps its explicit response semantics.
+		if request := humanTaskRequestFor(events, r.currentParticipantID()); request != nil {
+			if _, err := r.CollabResponse(types.CollabResponseArgs{
+				RequestID: request.RequestID,
+				Decision:  "accepted",
+				Summary:   "Agent started working.",
+			}); err != nil {
+				r.mu.Lock()
+				r.lastError = err.Error()
+				r.lastErrorSource = "send"
+				r.state = StateReconnecting
+				r.mu.Unlock()
+				r.log("collab_accept_failed", nil)
+				return
+			}
+		}
 
 		// A newly addressed turn wins the speaker: stale audio from the
 		// previous response must never keep playing over the new one.

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -141,6 +141,7 @@ type fakeClient struct {
 	collabResults         []types.CollabResultArgs
 	collabResponses       []types.CollabResponseArgs
 	collabResponseHook    func(types.CollabResponseArgs)
+	collabResponseErrors  []error
 	collabResponseErr     error
 }
 
@@ -770,12 +771,17 @@ func (c *fakeClient) SendCollabResponse(_ string, args types.CollabResponseArgs)
 	c.mu.Lock()
 	c.collabResponses = append(c.collabResponses, args)
 	hook := c.collabResponseHook
+	responseErr := c.collabResponseErr
+	if len(c.collabResponseErrors) > 0 {
+		responseErr = c.collabResponseErrors[0]
+		c.collabResponseErrors = c.collabResponseErrors[1:]
+	}
 	c.mu.Unlock()
 	if hook != nil {
 		hook(args)
 	}
-	if c.collabResponseErr != nil {
-		return types.SendTextResult{}, c.collabResponseErr
+	if responseErr != nil {
+		return types.SendTextResult{}, responseErr
 	}
 	return types.SendTextResult{Sequence: 1}, nil
 }

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -139,6 +139,9 @@ type fakeClient struct {
 	contextCalls          int
 	contextOptions        []types.RoomContextReadOptions
 	collabResults         []types.CollabResultArgs
+	collabResponses       []types.CollabResponseArgs
+	collabResponseHook    func(types.CollabResponseArgs)
+	collabResponseErr     error
 }
 
 type transcriptClient struct {
@@ -763,7 +766,17 @@ func (*fakeClient) SendCollabRequest(string, types.CollabRequestArgs) (types.Col
 	return types.CollabRequestOutcome{RequestID: "req-1", Sequence: 1}, nil
 }
 
-func (*fakeClient) SendCollabResponse(string, types.CollabResponseArgs) (types.SendTextResult, error) {
+func (c *fakeClient) SendCollabResponse(_ string, args types.CollabResponseArgs) (types.SendTextResult, error) {
+	c.mu.Lock()
+	c.collabResponses = append(c.collabResponses, args)
+	hook := c.collabResponseHook
+	c.mu.Unlock()
+	if hook != nil {
+		hook(args)
+	}
+	if c.collabResponseErr != nil {
+		return types.SendTextResult{}, c.collabResponseErr
+	}
 	return types.SendTextResult{Sequence: 1}, nil
 }
 
@@ -831,6 +844,7 @@ type fakeAdapter struct {
 	scopedRuns        []string
 	scopedTurnDetails map[string][]string
 	scopedSessionNews map[string][]bool
+	scopedRunHook     func(string)
 }
 
 // adapterRunTurnHook lets individual tests observe the exact enriched turn
@@ -957,6 +971,12 @@ func (a *fakeAdapter) RunTurnFor(scope string, input types.HarnessTurnInput, exp
 	a.scopedRuns = append(a.scopedRuns, scope)
 	a.scopedTurnDetails[scope] = append(a.scopedTurnDetails[scope], combined)
 	a.scopedSessionNews[scope] = append(a.scopedSessionNews[scope], input.Session != nil && input.Session.New)
+	hook := a.scopedRunHook
+	a.mu.Unlock()
+	if hook != nil {
+		hook(scope)
+	}
+	a.mu.Lock()
 	if a.turnErr != nil {
 		err := a.turnErr
 		a.mu.Unlock()
@@ -1099,6 +1119,12 @@ func (c *fakeClient) snapshotSentTaskRequestIDs() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]string(nil), c.sentTaskRequestIDs...)
+}
+
+func (c *fakeClient) snapshotCollabResponses() []types.CollabResponseArgs {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]types.CollabResponseArgs(nil), c.collabResponses...)
 }
 
 // snapshotHosts mirrors snapshotSent with the #176 Runtime Host projection

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -281,6 +281,59 @@ func TestHumanTaskAcceptanceFailureDoesNotStartHarnessTurn(t *testing.T) {
 	}
 }
 
+func TestHumanTaskAcceptanceRetryTreatsAmbiguousDuplicateAsSuccess(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	client := &fakeClient{
+		// Model a response that committed remotely but whose reply was lost;
+		// the server-side deduplication makes the second call successful.
+		collabResponseErrors: []error{errors.New("accepted committed but response lost"), nil},
+	}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "human-task-ambiguous-acceptance-test",
+		RoomID:     "room-human-task-ambiguous-acceptance",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	event := scopedEvent(1, "task:T", "Investigate this")
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human",
+		TargetParticipantID: "agent",
+	}
+	rt.acceptEvent(event)
+	rt.drainTurns()
+	if runs, _ := adapter.scopedRunSnapshot(); len(runs) != 0 {
+		t.Fatalf("Harness ran before duplicate accepted success: %v", runs)
+	}
+	if !rt.shouldRetryHumanTaskAcceptance() {
+		t.Fatal("ambiguous accepted failure did not remain retryable")
+	}
+
+	// A heartbeat invokes the same admission seam without a new Room event.
+	rt.drainTurns()
+	if responses := client.snapshotCollabResponses(); len(responses) != 2 {
+		t.Fatalf("expected one original and one deduplicated accepted call: %#v", responses)
+	}
+	if runs, _ := adapter.scopedRunSnapshot(); len(runs) != 1 {
+		t.Fatalf("ambiguous accepted retry ran Harness %d times", len(runs))
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 0 {
+		t.Fatalf("successful retry did not acknowledge Task turn: %v", got)
+	}
+}
+
 func TestAgentOriginatedTaskRequestIsNotAutomaticallyAccepted(t *testing.T) {
 	adapter := &fakeAdapter{name: "pi"}
 	client := &fakeClient{}

--- a/agent/internal/runtime/scoped_sessions_test.go
+++ b/agent/internal/runtime/scoped_sessions_test.go
@@ -192,6 +192,131 @@ func TestTaskScopedHarnessOutputPreservesRequestCorrelation(t *testing.T) {
 	}
 }
 
+func TestHumanTaskIsAcceptedBeforeFirstScopedHarnessTurn(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	client := &fakeClient{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "human-task-lifecycle-test",
+		RoomID:     "room-human-task-lifecycle",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	var acceptedBeforeRun bool
+	adapter.scopedRunHook = func(scope string) {
+		if scope != "task:T" {
+			t.Fatalf("unexpected scope: %s", scope)
+		}
+		responses := client.snapshotCollabResponses()
+		if len(responses) != 1 || responses[0].RequestID != "request-T" || responses[0].Decision != "accepted" {
+			t.Fatalf("Human Task was not accepted before Harness execution: %#v", responses)
+		}
+		acceptedBeforeRun = true
+	}
+
+	event := scopedEvent(1, "task:T", "Investigate this")
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human",
+		TargetParticipantID: "agent",
+		Summary:             "Investigate this",
+	}
+	rt.acceptEvent(event)
+	rt.drainTurns()
+
+	if !acceptedBeforeRun {
+		t.Fatal("scoped Harness turn ran without a canonical accepted response")
+	}
+}
+
+func TestHumanTaskAcceptanceFailureDoesNotStartHarnessTurn(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	client := &fakeClient{collabResponseErr: errors.New("accepted failed")}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "human-task-accept-failure-test",
+		RoomID:     "room-human-task-accept-failure",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	event := scopedEvent(1, "task:T", "Investigate this")
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human",
+		TargetParticipantID: "agent",
+	}
+	rt.acceptEvent(event)
+	rt.drainTurns()
+
+	if runs, _ := adapter.scopedRunSnapshot(); len(runs) != 0 {
+		t.Fatalf("Harness ran after accepted failed: %v", runs)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); !reflect.DeepEqual(got, []int64{1}) {
+		t.Fatalf("failed acceptance was incorrectly acknowledged: %v", got)
+	}
+	if status := rt.Status(); status.State != StateReconnecting || status.LastError != "accepted failed" {
+		t.Fatalf("acceptance failure did not preserve retryable failure state: %+v", status)
+	}
+}
+
+func TestAgentOriginatedTaskRequestIsNotAutomaticallyAccepted(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi"}
+	client := &fakeClient{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "agent-task-lifecycle-test",
+		RoomID:     "room-agent-task-lifecycle",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	rt.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent-b",
+		ParticipantHandle: "room-secret",
+		Cursor:            0,
+		ExpiresAt:         time.Now().Add(time.Hour).UnixMilli(),
+	})
+	defer rt.Stop()
+
+	event := scopedEvent(1, "task:T", "Agent request")
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "agent-a", Name: "Agent A", Kind: types.KindAgent}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-agent-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "agent-a",
+		TargetParticipantID: "agent-b",
+		Summary:             "Agent request",
+	}
+	rt.acceptEvent(event)
+	rt.drainTurns()
+
+	if responses := client.snapshotCollabResponses(); len(responses) != 0 {
+		t.Fatalf("Agent-originated request was automatically accepted: %#v", responses)
+	}
+}
+
 func TestLegacyAdapterFailsClosedForTaskScope(t *testing.T) {
 	adapter := &legacyOnlyAdapter{}
 	rt := NewResidentRuntime(Options{
@@ -519,6 +644,9 @@ func TestLogicalTaskScopeCapacityEmitsCanonicalFailedCollabResult(t *testing.T) 
 	}
 	if results[0].RequestID != "overflow-request" || results[0].Status != "failed" || results[0].Summary != "Agent cannot start another task right now." {
 		t.Fatalf("unexpected capacity result: %#v", results[0])
+	}
+	if responses := client.snapshotCollabResponses(); len(responses) != 0 {
+		t.Fatalf("capacity rejection claimed Working before failure: %#v", responses)
 	}
 
 	// Existing task scopes and ordinary Room remain usable at capacity.

--- a/app/src/common/agentMentions.ts
+++ b/app/src/common/agentMentions.ts
@@ -39,3 +39,17 @@ export function resolveAgentTargetIds(
 
   return [...targets]
 }
+
+/**
+ * Task routing is semantic: visible @Name text is presentation only. The
+ * existing picker records participant ids in selectedAgents; Task composers
+ * use those ids without allowing a hand-typed name to become authority.
+ */
+export function resolveSelectedAgentTargetIds(
+  text: string,
+  selectedAgents: SelectedAgentMention[]
+): string[] {
+  return selectedAgents
+    .filter((selected) => hasCompleteMention(text, selected.name))
+    .map((selected) => selected.id)
+}

--- a/app/src/components/TextChatCard.composer.test.tsx
+++ b/app/src/components/TextChatCard.composer.test.tsx
@@ -144,7 +144,7 @@ describe("composer keyboard semantics", () => {
     )
   })
 
-  it("sends task text with the existing task correlation and no ad hoc picker target", () => {
+  it("sends task text with the existing task correlation and primary routing by default", () => {
     const { composer, onSendText } = renderCard({
       taskRequestId: "task-123",
     })
@@ -152,6 +152,37 @@ describe("composer keyboard semantics", () => {
     fireEvent.keyDown(composer, { key: "Enter" })
     expect(onSendText).toHaveBeenCalledWith("continue the task", [], "task-123")
     expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument()
+  })
+
+  it("sends a selected Agent participant id from a Task composer", async () => {
+    const { composer, onSendText } = renderCard({
+      taskRequestId: "task-123",
+    })
+    typeAtCaret(composer, "@Age please review", 4)
+
+    fireEvent.mouseDown(await screen.findByText("Agent B"))
+    await waitFor(() => expect(composer.value).toContain("@Agent B "))
+    fireEvent.keyDown(composer, { key: "Enter" })
+
+    expect(onSendText).toHaveBeenCalledWith(
+      expect.stringContaining("@Agent B"),
+      ["agent-1"],
+      "task-123"
+    )
+  })
+
+  it("does not route a hand-typed Task @Name without semantic selection", () => {
+    const { composer, onSendText } = renderCard({
+      taskRequestId: "task-123",
+    })
+    typeMessage(composer, "@Agent B please review")
+    fireEvent.keyDown(composer, { key: "Enter" })
+
+    expect(onSendText).toHaveBeenCalledWith(
+      "@Agent B please review",
+      [],
+      "task-123"
+    )
   })
 
   it("dismisses the mention picker with Escape so Enter sends normally", () => {

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -22,7 +22,10 @@ import {
 } from "./collabUi"
 import HumanCollabResultComposer from "./HumanCollabResultComposer"
 import ParticipantAvatar from "./ParticipantAvatar"
-import { resolveAgentTargetIds } from "../common/agentMentions"
+import {
+  resolveAgentTargetIds,
+  resolveSelectedAgentTargetIds,
+} from "../common/agentMentions"
 import type { UserInfo } from "../common/types"
 import type {
   PermissionEvent,
@@ -1552,7 +1555,7 @@ const TextChatCard = memo(function TextChatCard({
   const sendCurrentMessage = () => {
     if (message.trim() === "") return
     const targets = taskScoped
-      ? []
+      ? resolveSelectedAgentTargetIds(message.trim(), selectedAgents)
       : resolveAgentTargetIds(message.trim(), connectedAgents, selectedAgents)
     if (taskRequestId) onSendText(message.trim(), targets, taskRequestId)
     else onSendText(message.trim(), targets)
@@ -1696,8 +1699,7 @@ const TextChatCard = memo(function TextChatCard({
       : connectedAgents.filter((agent) =>
           agent.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
         )
-  const showAgentPicker =
-    !taskScoped && !pickerDismissed && mentionAgents.length > 0
+  const showAgentPicker = !pickerDismissed && mentionAgents.length > 0
 
   const selectAgent = (agent: UserInfo) => {
     if (!agent) return

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -106,6 +106,14 @@ import {
   swapSurfaceAfterPersist,
 } from "./surface"
 import {
+  buildTaskProjectionIndex,
+  projectTaskEvent,
+  resolveAgentTaskTargets,
+  resolveHumanTaskTargets,
+  resolveTaskRequest,
+  type TaskProjectionIndex,
+} from "./taskScope"
+import {
   createRuntimeProviderHandle,
   hashRuntimeProviderHandle,
   isRuntimeProviderClaimHash,
@@ -703,54 +711,6 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       }))
     this.collabRegistry.rebuild(entries)
     this.collabRebuilt = true
-  }
-
-  // #309: task text is allowed only when its correlation resolves to a
-  // retained canonical collaboration request with a connected Agent
-  // endpoint. A request can be Agent→Human or Agent→Agent, so the requester
-  // and target are both considered endpoints rather than assuming the target
-  // is always the sole Agent.
-  private taskRequestFor(
-    room: RoomRecord,
-    rawRequestId: unknown
-  ):
-    | {
-        ok: true
-        requestId: string
-        primaryAgentParticipantId: string
-        agentParticipantIds: string[]
-      }
-    | { ok: false; error: string } {
-    if (typeof rawRequestId !== "string")
-      return { ok: false, error: "invalid_task_request" }
-    const requestId = rawRequestId.trim()
-    if (!requestId) return { ok: false, error: "invalid_task_request" }
-    this.warmCollabRegistry(room)
-    const record = this.collabRegistry.find(requestId)
-    if (!record) return { ok: false, error: "unknown_task_request" }
-    const from = room.participants[record.fromParticipantId]
-    const target = room.participants[record.targetParticipantId]
-    const agentParticipantIds = [from, target]
-      .filter(
-        (participant): participant is NonNullable<typeof participant> =>
-          participant?.kind === "agent" && participant.connected
-      )
-      .map((participant) => participant.id)
-      .filter((id, index, ids) => ids.indexOf(id) === index)
-    if (agentParticipantIds.length === 0)
-      return { ok: false, error: "task_target_not_in_room" }
-    const primaryAgentParticipantId =
-      target?.kind === "agent" && target.connected
-        ? target.id
-        : from?.kind === "agent" && from.connected
-        ? from.id
-        : agentParticipantIds[0]
-    return {
-      ok: true,
-      requestId,
-      primaryAgentParticipantId,
-      agentParticipantIds,
-    }
   }
 
   private async loadRoom(): Promise<RoomRecord | null> {
@@ -1799,23 +1759,22 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
 
   private toAgentEvent(
     message: RoomMessage,
-    participantId: string
-  ): AgentEvent {
-    // #303: reuse the already validated structured collaboration correlation
-    // instead of storing a second scope field in Room state. Either Agent
-    // endpoint may continue an Agent→Human or Agent→Agent request; ordinary
-    // text and non-endpoint context remain in the default Room conversation.
-    const taskRequest = message.taskRequestId
-      ? this.collabRegistry.find(message.taskRequestId)
-      : undefined
-    const scopeId =
-      taskRequest?.fromParticipantId === participantId ||
-      taskRequest?.targetParticipantId === participantId
-        ? `task:${message.taskRequestId}`
-        : message.collab?.targetParticipantId === participantId &&
-          message.collab.requestId
-        ? `task:${message.collab.requestId}`
-        : undefined
+    participantId: string,
+    taskProjection: TaskProjectionIndex,
+    historical = false
+  ): AgentEvent | undefined {
+    const task = projectTaskEvent(
+      taskProjection,
+      message,
+      participantId,
+      historical
+    )
+    if (task.kind === "task" && !task.visible) return undefined
+    const scopeId = task.kind === "task" ? task.scopeId : undefined
+    const addressed =
+      task.kind === "task"
+        ? task.addressed
+        : message.targets?.includes(participantId) === true
     return {
       sequence: message.sequence,
       type: message.type,
@@ -1836,7 +1795,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       ...(message.permission === undefined
         ? {}
         : { permission: message.permission }),
-      addressed: message.targets?.includes(participantId) === true,
+      addressed,
       createdAt: message.createdAt,
     }
   }
@@ -1872,16 +1831,26 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     truncated?: boolean
   } {
     this.warmCollabRegistry(room)
+    const taskProjection = buildTaskProjectionIndex(
+      room.messages,
+      room.participants
+    )
     const serverCursor = room.nextMessageSequence
     const clampedCursor = Math.min(Math.max(cursor, 0), serverCursor)
     const events = [
-      ...room.messages.map((message) => ({
-        sequence: message.sequence,
-        event: this.toAgentEvent(message, participantId),
-        peerId: message.peerId,
-        visible: this.isPermissionVisibleToAgent(message, participantId),
-        deliverOwn: this.permissionEventForMessage(message)?.kind === "expired",
-      })),
+      ...room.messages.flatMap((message) => {
+        const event = this.toAgentEvent(message, participantId, taskProjection)
+        return [
+          {
+            sequence: message.sequence,
+            event,
+            peerId: message.peerId,
+            visible: this.isPermissionVisibleToAgent(message, participantId),
+            deliverOwn:
+              this.permissionEventForMessage(message)?.kind === "expired",
+          },
+        ]
+      }),
       ...room.attachments.map((attachment) => ({
         sequence: attachment.sequence,
         event: this.toAttachmentEvent(attachment),
@@ -1899,9 +1868,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           (entry) =>
             entry.sequence > effectiveCursor &&
             (entry.peerId !== participantId || entry.deliverOwn === true) &&
-            entry.visible !== false
+            entry.visible !== false &&
+            entry.event !== undefined
         )
-        .map((entry) => entry.event),
+        .map((entry) => entry.event!),
       cursor: serverCursor,
       expiresAt: room.expiresAt,
       ...(truncated ? { truncated: true } : {}),
@@ -1917,12 +1887,19 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participantId: string
   ): AgentEvent[] {
     this.warmCollabRegistry(room)
+    const taskProjection = buildTaskProjectionIndex(
+      room.messages,
+      room.participants
+    )
     return [
       ...room.messages
         .filter((message) =>
           this.isPermissionVisibleToAgent(message, participantId)
         )
-        .map((message) => this.toAgentEvent(message, participantId)),
+        .map((message) =>
+          this.toAgentEvent(message, participantId, taskProjection, true)
+        )
+        .filter((event): event is AgentEvent => event !== undefined),
       ...room.attachments.map((attachment) =>
         this.toAttachmentEvent(attachment)
       ),
@@ -2988,18 +2965,32 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         return this.json({ error: "agent_only" }, 403)
       const text = request.text.trim()
       if (!text) return this.json({ error: "text_required" }, 400)
-      const taskRequest =
+      const taskProjection =
         request.taskRequestId === undefined
           ? undefined
-          : this.taskRequestFor(room, request.taskRequestId)
+          : buildTaskProjectionIndex(room.messages, room.participants)
+      const taskRequest =
+        taskProjection === undefined
+          ? undefined
+          : resolveTaskRequest(
+              taskProjection,
+              request.taskRequestId,
+              room.participants
+            )
       if (taskRequest && taskRequest.ok === false)
         return this.json({ error: taskRequest.error }, 409)
-      if (
-        taskRequest &&
-        taskRequest.ok === true &&
-        !taskRequest.agentParticipantIds.includes(participant.id)
-      )
-        return this.json({ error: "task_target_mismatch" }, 403)
+      const taskTargets =
+        taskRequest && taskRequest.ok === true
+          ? resolveAgentTaskTargets(
+              taskRequest,
+              participant,
+              room.participants,
+              request.targetParticipantIds,
+              MAX_TARGETS
+            )
+          : undefined
+      if (taskTargets && taskTargets.ok === false)
+        return this.json({ error: taskTargets.error }, 409)
       participant.lastSeenAt = Date.now()
       const roomMessage = this.appendMessage(room, {
         id: crypto.randomUUID(),
@@ -3011,14 +3002,21 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         ...(taskRequest && taskRequest.ok === true
           ? { taskRequestId: taskRequest.requestId }
           : {}),
-        // #165/#234: Agent-originated explicit addressing reuses the exact
-        // Room target semantics of the Human chat path (dedupe, current
-        // participant filter, MAX_TARGETS). Self-targets are dropped so an
-        // Agent can never wake itself into a loop; malformed or stale
-        // entries can only ever degrade to an ordinary unaddressed message.
-        // Human targets are addressed attention for that Human — they never
-        // create a Human workflow/task concept.
-        ...agentTextTargets(request.targetParticipantIds, participant.id, room),
+        // #165/#234: ordinary Agent text reuses the exact Room target
+        // semantics of the Human chat path (dedupe, current participant
+        // filter, MAX_TARGETS). Task text uses the validated task target
+        // result above. Self-targets are dropped so an Agent can never wake
+        // itself into a loop; Human targets are addressed attention for that
+        // Human and never create a Human workflow/task concept.
+        ...(taskTargets && taskTargets.ok === true
+          ? taskTargets.targets.length
+            ? { targets: taskTargets.targets }
+            : {}
+          : agentTextTargets(
+              request.targetParticipantIds,
+              participant.id,
+              room
+            )),
         createdAt: Date.now(),
       })
       await this.saveRoom(room)
@@ -5058,18 +5056,34 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
 
     if (message.type === "chat" && message.text.trim()) {
-      const taskRequest =
+      const taskProjection =
         message.taskRequestId === undefined
           ? undefined
-          : this.taskRequestFor(room, message.taskRequestId)
+          : buildTaskProjectionIndex(room.messages, room.participants)
+      const taskRequest =
+        taskProjection === undefined
+          ? undefined
+          : resolveTaskRequest(
+              taskProjection,
+              message.taskRequestId,
+              room.participants
+            )
       if (taskRequest && taskRequest.ok === false) {
         socket.send(JSON.stringify({ type: "error", error: taskRequest.error }))
         return
       }
-      if (taskRequest && message.targets?.length) {
-        socket.send(
-          JSON.stringify({ type: "error", error: "task_targets_forbidden" })
-        )
+      const taskTargets =
+        taskRequest && taskRequest.ok === true
+          ? resolveHumanTaskTargets(
+              taskRequest,
+              participant,
+              room.participants,
+              message.targets,
+              MAX_TARGETS
+            )
+          : undefined
+      if (taskTargets && taskTargets.ok === false) {
+        socket.send(JSON.stringify({ type: "error", error: taskTargets.error }))
         return
       }
       const roomMessage = this.appendMessage(room, {
@@ -5082,7 +5096,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         ...(taskRequest && taskRequest.ok === true
           ? {
               taskRequestId: taskRequest.requestId,
-              targets: [taskRequest.primaryAgentParticipantId],
+              targets: taskTargets?.ok ? taskTargets.targets : [],
             }
           : (() => {
               const targets = normalizeChatTargets(room, message.targets)

--- a/app/src/do/roomSessionAgentScope.test.ts
+++ b/app/src/do/roomSessionAgentScope.test.ts
@@ -1,17 +1,24 @@
 import { describe, expect, it } from "vitest"
 
 import { RoomSession } from "./RoomSession"
+import { buildTaskProjectionIndex } from "./taskScope"
+import type { RoomMessage, RoomParticipant } from "../room/types"
 
-describe("RoomSession AgentEvent task scope projection (#303)", () => {
-  it("derives task scopes from targeted collab requestIds and leaves ordinary text in Room scope", () => {
+function participant(id: string, kind: "human" | "agent"): RoomParticipant {
+  return {
+    id,
+    name: id,
+    kind,
+    connected: true,
+    joinedAt: 1,
+    lastSeenAt: 1,
+    token: `${id}-token`,
+  }
+}
+
+describe("RoomSession AgentEvent task scope projection (#314)", () => {
+  it("omits Task events from unrelated Agents instead of falling back to Room", () => {
     const session = new RoomSession({} as never, { SFU_ROOM: {} } as never)
-    const project = (message: unknown, participantId: string) =>
-      (
-        session as unknown as {
-          toAgentEvent: (message: unknown, participantId: string) => unknown
-        }
-      ).toAgentEvent(message, participantId) as Record<string, unknown>
-
     const messages = [
       {
         sequence: 1,
@@ -55,21 +62,36 @@ describe("RoomSession AgentEvent task scope projection (#303)", () => {
         targets: ["agent-a"],
         createdAt: 3,
       },
-    ]
+    ] as RoomMessage[]
+    const participants = {
+      human: participant("human", "human"),
+      "agent-a": participant("agent-a", "agent"),
+      "agent-b": participant("agent-b", "agent"),
+    }
+    const projection = buildTaskProjectionIndex(messages, participants)
+    const project = (message: RoomMessage, participantId: string) =>
+      (
+        session as unknown as {
+          toAgentEvent: (
+            message: RoomMessage,
+            participantId: string,
+            projection: ReturnType<typeof buildTaskProjectionIndex>
+          ) => Record<string, unknown> | undefined
+        }
+      ).toAgentEvent(message, participantId, projection)
 
     const projected = messages.map((message) => project(message, "agent-a"))
-    expect(projected.map((event) => event.scopeId)).toEqual([
+    expect(projected.map((event) => event?.scopeId)).toEqual([
       "task:T",
       "task:U",
       undefined,
     ])
-    expect(projected.every((event) => event.addressed === true)).toBe(true)
+    expect(projected.every((event) => event?.addressed === true)).toBe(true)
 
-    const serialized = JSON.parse(JSON.stringify(projected[0])) as Record<
-      string,
-      unknown
-    >
-    expect(serialized.scopeId).toBe("task:T")
-    expect(project(messages[0], "agent-b").scopeId).toBeUndefined()
+    expect(project(messages[0], "agent-b")).toBeUndefined()
+    expect(project(messages[1], "agent-b")).toBeUndefined()
+    expect(project(messages[2], "agent-b")).toMatchObject({
+      addressed: false,
+    })
   })
 })

--- a/app/src/do/roomSessionAgentSendText.test.ts
+++ b/app/src/do/roomSessionAgentSendText.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { RoomSession } from "./RoomSession"
+import { buildTaskProjectionIndex } from "./taskScope"
 
 const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
 
@@ -98,7 +99,16 @@ function makeRoomSession(stored: ReturnType<typeof buildStoredRoom>) {
     })
   const storedMessages = () =>
     (store.get("room") as { messages: Array<Record<string, unknown>> }).messages
-  return { session: rs, control, sendText, agentWait, storedMessages }
+  const storedRoom = () =>
+    store.get("room") as ReturnType<typeof buildStoredRoom>
+  return {
+    session: rs,
+    control,
+    sendText,
+    agentWait,
+    storedMessages,
+    storedRoom,
+  }
 }
 
 function taskRequest(
@@ -226,24 +236,33 @@ describe("RoomSession agent-send-text structured addressing (#165)", () => {
     const requesterReply = await agentToHuman.sendText(
       "agent-a",
       "requester task output",
-      undefined,
+      ["human-1"],
       "agent-human"
     )
     expect(requesterReply.status).toBe(200)
     expect(agentToHuman.storedMessages()[1]).toMatchObject({
       taskRequestId: "agent-human",
+      targets: ["human-1"],
     })
     expect(
       (
         agentToHuman.session as unknown as {
           toAgentEvent: (
             message: unknown,
-            participantId: string
+            participantId: string,
+            projection: ReturnType<typeof buildTaskProjectionIndex>
           ) => {
             scopeId?: string
           }
         }
-      ).toAgentEvent(agentToHuman.storedMessages()[1], "agent-a").scopeId
+      ).toAgentEvent(
+        agentToHuman.storedMessages()[1] as never,
+        "agent-a",
+        buildTaskProjectionIndex(
+          agentToHuman.storedRoom().messages as never,
+          agentToHuman.storedRoom().participants as never
+        )
+      )?.scopeId
     ).toBe("task:agent-human")
 
     const agentToAgent = makeRoomSession(
@@ -267,11 +286,15 @@ describe("RoomSession agent-send-text structured addressing (#165)", () => {
         await agentToAgent.sendText(
           "agent-b",
           "target output",
-          undefined,
+          ["agent-a"],
           "agent-agent"
         )
       ).status
     ).toBe(200)
+    expect(agentToAgent.storedMessages()[2]).toMatchObject({
+      taskRequestId: "agent-agent",
+      targets: ["agent-a"],
+    })
     expect(
       agentToAgent
         .storedMessages()

--- a/app/src/do/roomSessionContextRead.test.ts
+++ b/app/src/do/roomSessionContextRead.test.ts
@@ -33,17 +33,35 @@ function fixture() {
         },
         messages: [
           {
-            id: "message-1",
+            id: "collab-1",
+            peerId: "agent-b",
+            name: "Agent B",
+            kind: "agent",
+            type: "action",
+            actionType: "collab",
+            collab: {
+              requestId: "request-2",
+              kind: "request",
+              fromParticipantId: "agent-b",
+              targetParticipantId: "agent-a",
+              summary: "review this",
+            },
+            targets: ["agent-a"],
+            createdAt: 1,
+            sequence: 1,
+          },
+          {
+            id: "message-2",
             peerId: "agent-a",
             name: "Agent A",
             kind: "agent",
             type: "text",
             text: "first shared message",
-            createdAt: 1,
-            sequence: 1,
+            createdAt: 2,
+            sequence: 2,
           },
           {
-            id: "collab-2",
+            id: "collab-3",
             peerId: "agent-b",
             name: "Agent B",
             kind: "agent",
@@ -57,22 +75,22 @@ function fixture() {
               summary: "finished review",
             },
             targets: ["agent-a"],
-            createdAt: 2,
-            sequence: 2,
+            createdAt: 3,
+            sequence: 3,
           },
           {
-            id: "message-3",
+            id: "message-4",
             peerId: "agent-b",
             name: "Agent B",
             kind: "agent",
             type: "text",
             text: "third shared message",
-            createdAt: 3,
-            sequence: 3,
+            createdAt: 4,
+            sequence: 4,
           },
         ],
         attachments: [],
-        nextMessageSequence: 3,
+        nextMessageSequence: 4,
         meetingNotes: { active: false },
         agentVoice: {},
         pendingMediaCleanup: [],
@@ -144,15 +162,15 @@ function fixture() {
 describe("RoomSession bounded historical context read (#223)", () => {
   it("is authenticated, paginated, sanitized, and keeps transcript cursors separate", async () => {
     const room = fixture()
-    const first = (await room.read({ limit: 2 })) as {
+    const first = (await room.read({ limit: 3 })) as {
       status: number
       json: Record<string, any>
     }
     expect(first.status).toBe(200)
     expect(
       first.json.events.map((event: { sequence: number }) => event.sequence)
-    ).toEqual([1, 2])
-    expect(first.json.events[1].collab).toMatchObject({
+    ).toEqual([1, 2, 3])
+    expect(first.json.events[2].collab).toMatchObject({
       requestId: "request-2",
       kind: "completed",
       summary: "finished review",
@@ -166,22 +184,22 @@ describe("RoomSession bounded historical context read (#223)", () => {
     expect(JSON.stringify(first.json)).not.toContain("token-a")
     expect(JSON.stringify(first.json)).not.toContain("connectionNonce")
 
-    const forward = (await room.read({ afterSequence: 2, limit: 2 })) as {
+    const forward = (await room.read({ afterSequence: 3, limit: 2 })) as {
       status: number
       json: Record<string, any>
     }
     expect(
       forward.json.events.map((event: { sequence: number }) => event.sequence)
-    ).toEqual([3])
+    ).toEqual([4])
     expect(forward.json.hasMoreBefore).toBe(true)
 
-    const backward = (await room.read({ beforeSequence: 3, limit: 2 })) as {
+    const backward = (await room.read({ beforeSequence: 4, limit: 2 })) as {
       status: number
       json: Record<string, any>
     }
     expect(
       backward.json.events.map((event: { sequence: number }) => event.sequence)
-    ).toEqual([1, 2])
+    ).toEqual([2, 3])
 
     const transcriptPage = (await room.read({
       afterTranscriptSequence: 7,
@@ -191,7 +209,7 @@ describe("RoomSession bounded historical context read (#223)", () => {
       transcriptPage.json.events.map(
         (event: { sequence: number }) => event.sequence
       )
-    ).toEqual([1, 2, 3])
+    ).toEqual([1, 2, 3, 4])
     expect(
       transcriptPage.json.liveTranscript.segments.map(
         (segment: { sequence: number }) => segment.sequence
@@ -212,7 +230,7 @@ describe("RoomSession bounded historical context read (#223)", () => {
     expect(truncated.json.truncated).toBe(true)
     expect(
       truncated.json.events.map((event: { sequence: number }) => event.sequence)
-    ).toEqual([2, 3])
+    ).toEqual([2, 4])
     expect(JSON.stringify(room.store.get("room"))).toBe(beforeRead)
 
     expect((await room.read({ token: "wrong" })).status).toBe(401)

--- a/app/src/do/roomSessionHumanTaskRequest.test.ts
+++ b/app/src/do/roomSessionHumanTaskRequest.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { RoomSession } from "./RoomSession"
+import { buildTaskProjectionIndex } from "./taskScope"
 import type { RoomRecord } from "../room/types"
 
 const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
@@ -43,6 +44,7 @@ function room(): RoomRecord {
       "human-1": human(),
       "agent-a": agent("agent-a"),
       "agent-b": agent("agent-b"),
+      "agent-c": agent("agent-c"),
     },
     messages: [],
     nextMessageSequence: 0,
@@ -107,6 +109,10 @@ function harness() {
       }
     },
     stored: () => store.get("room") as RoomRecord,
+    taskProjection: () => {
+      const stored = store.get("room") as RoomRecord
+      return buildTaskProjectionIndex(stored.messages, stored.participants)
+    },
   }
 }
 
@@ -139,13 +145,14 @@ describe("RoomSession Human task entry (#305)", () => {
       test.session as unknown as {
         toAgentEvent: (
           message: unknown,
-          participantId: string
+          participantId: string,
+          projection: ReturnType<typeof buildTaskProjectionIndex>
         ) => {
           scopeId?: string
           addressed: boolean
         }
       }
-    ).toAgentEvent(message, "agent-a")
+    ).toAgentEvent(message, "agent-a", test.taskProjection())
     expect(event).toMatchObject({
       scopeId: `task:${requestId}`,
       addressed: true,
@@ -158,12 +165,13 @@ describe("RoomSession Human task entry (#305)", () => {
         test.session as unknown as {
           toAgentEvent: (
             message: unknown,
-            participantId: string
+            participantId: string,
+            projection: ReturnType<typeof buildTaskProjectionIndex>
           ) => {
             scopeId?: string
           }
         }
-      ).toAgentEvent(message, "agent-b").scopeId
+      ).toAgentEvent(message, "agent-b", test.taskProjection())?.scopeId
     ).toBeUndefined()
     expect(message.targets).toEqual(["agent-a"])
 
@@ -180,12 +188,13 @@ describe("RoomSession Human task entry (#305)", () => {
         test.session as unknown as {
           toAgentEvent: (
             message: unknown,
-            participantId: string
+            participantId: string,
+            projection: ReturnType<typeof buildTaskProjectionIndex>
           ) => {
             scopeId?: string
           }
         }
-      ).toAgentEvent(second, "agent-a").scopeId
+      ).toAgentEvent(second, "agent-a", test.taskProjection())?.scopeId
     ).toBe(`task:${second.collab?.requestId}`)
   })
 
@@ -264,14 +273,146 @@ describe("RoomSession Human task entry (#305)", () => {
       test.session as unknown as {
         toAgentEvent: (
           message: unknown,
-          participantId: string
-        ) => { scopeId?: string; addressed: boolean }
+          participantId: string,
+          projection: ReturnType<typeof buildTaskProjectionIndex>
+        ) => { scopeId?: string; addressed: boolean } | undefined
       }
-    ).toAgentEvent(test.stored().messages[2], "agent-a")
+    ).toAgentEvent(test.stored().messages[2], "agent-a", test.taskProjection())
     expect(agentEvent).toMatchObject({
       scopeId: `task:${requestId}`,
       addressed: true,
     })
+  })
+
+  it("allows a Human to explicitly add another Agent to an existing Task", async () => {
+    const test = harness()
+
+    await test.sendHuman({
+      type: "collab-request",
+      targetParticipantId: "agent-a",
+      summary: "Bring another reviewer into the task",
+    })
+    const requestId = test.stored().messages[0].collab?.requestId
+    expect(requestId).toEqual(expect.any(String))
+
+    await test.sendHuman({
+      type: "chat",
+      text: "@Other Agent please review this",
+      targets: ["agent-b"],
+      taskRequestId: requestId,
+    })
+    const message = test.stored().messages[1]
+    expect(message).toMatchObject({
+      taskRequestId: requestId,
+      targets: ["agent-b"],
+    })
+
+    const projection = test.taskProjection()
+    const project = (participantId: string) =>
+      (
+        test.session as unknown as {
+          toAgentEvent: (
+            message: unknown,
+            participantId: string,
+            projection: ReturnType<typeof buildTaskProjectionIndex>
+          ) => { scopeId?: string; addressed: boolean } | undefined
+        }
+      ).toAgentEvent(message, participantId, projection)
+    expect(project("agent-a")).toMatchObject({
+      scopeId: `task:${requestId}`,
+      addressed: false,
+    })
+    expect(project("agent-b")).toMatchObject({
+      scopeId: `task:${requestId}`,
+      addressed: true,
+    })
+    expect(project("agent-c")).toBeUndefined()
+  })
+
+  it("keeps unrelated Agents out of live and retained Task context", async () => {
+    const test = harness()
+    await test.sendHuman({
+      type: "collab-request",
+      targetParticipantId: "agent-a",
+      summary: "Keep this context scoped",
+    })
+    const requestId = test.stored().messages[0].collab?.requestId
+
+    const wait = async (participantId: string, cursor = 0) =>
+      test.control({
+        action: "agent-wait",
+        participantId,
+        token: `${participantId}-token`,
+        cursor,
+        timeoutSeconds: 0,
+      })
+    const read = async (participantId: string) =>
+      test.control({
+        action: "agent-read-context",
+        participantId,
+        token: `${participantId}-token`,
+        afterSequence: 0,
+        limit: 50,
+      })
+
+    const unrelatedBefore = await wait("agent-c")
+    expect(unrelatedBefore.json.events).toEqual([])
+    expect((await read("agent-c")).json.events).toEqual([])
+
+    await test.sendHuman({
+      type: "chat",
+      text: "@Other Agent join this task",
+      targets: ["agent-b"],
+      taskRequestId: requestId,
+    })
+    const newlyTargeted = await wait("agent-b", 1)
+    expect(newlyTargeted.json.events).toHaveLength(1)
+    expect(newlyTargeted.json.events[0]).toMatchObject({
+      scopeId: `task:${requestId}`,
+      addressed: true,
+    })
+    expect(
+      ((await read("agent-b")).json.events as Array<{ scopeId?: string }>).map(
+        (event: { scopeId?: string }) => event.scopeId
+      )
+    ).toEqual([`task:${requestId}`, `task:${requestId}`])
+    expect((await wait("agent-c", 1)).json.events).toEqual([])
+    expect((await read("agent-c")).json.events).toEqual([])
+  })
+
+  it("rejects invalid explicit Human Task targets without fallback", async () => {
+    const test = harness()
+    await test.sendHuman({
+      type: "collab-request",
+      targetParticipantId: "agent-a",
+      summary: "Validate targets",
+    })
+    const requestId = test.stored().messages[0].collab?.requestId
+
+    for (const target of ["human-1", "missing", "agent-b"]) {
+      if (target === "agent-b")
+        test.stored().participants[target].connected = false
+      await test.sendHuman({
+        type: "chat",
+        text: "must reject",
+        targets: [target],
+        taskRequestId: requestId,
+      })
+    }
+
+    expect(test.stored().messages).toHaveLength(1)
+    expect(test.socket.send).toHaveBeenNthCalledWith(
+      1,
+      JSON.stringify({ type: "error", error: "task_target_not_agent" })
+    )
+    expect(test.socket.send).toHaveBeenNthCalledWith(
+      2,
+      JSON.stringify({ type: "error", error: "task_target_not_in_room" })
+    )
+    expect(test.socket.send).toHaveBeenNthCalledWith(
+      3,
+      JSON.stringify({ type: "error", error: "task_target_not_in_room" })
+    )
   })
 
   it("rejects arbitrary task correlation instead of creating a task view", async () => {

--- a/app/src/do/taskScope.test.ts
+++ b/app/src/do/taskScope.test.ts
@@ -65,6 +65,30 @@ function taskText(
   }
 }
 
+function orphanLifecycle(
+  sequence: number,
+  kind: "accepted" | "completed" | "failed"
+): RoomMessage {
+  return {
+    id: `lifecycle-${kind}`,
+    peerId: "agent-a",
+    name: "agent-a",
+    kind: "agent",
+    type: "action",
+    actionType: "collab",
+    collab: {
+      requestId: "task-T",
+      kind,
+      fromParticipantId: "agent-a",
+      targetParticipantId: "agent-b",
+      summary: `private ${kind}`,
+    },
+    targets: ["agent-b"],
+    createdAt: sequence,
+    sequence,
+  }
+}
+
 function participants(): Record<string, RoomParticipant> {
   return {
     human: participant("human", "human"),
@@ -130,17 +154,40 @@ describe("Task scope projection", () => {
     })
   })
 
-  it("fails closed for orphaned explicit Task text", () => {
-    const orphaned = {
-      ...taskText(2, "agent-a", ["human"]),
+  it("fails closed for orphaned Task text and lifecycle after ring eviction", () => {
+    const retained = [
+      ...Array.from({ length: 99 }, (_, index) => ({
+        ...taskText(index + 2, "agent-a"),
+        taskRequestId: undefined,
+        collab: undefined,
+        actionType: undefined,
+        text: `room-${index + 2}`,
+      })),
+      orphanLifecycle(101, "accepted"),
+      orphanLifecycle(102, "completed"),
+      orphanLifecycle(103, "failed"),
+    ].slice(-100)
+    const orphanedText = {
+      ...taskText(104, "agent-a", ["agent-b"]),
       taskRequestId: "evicted-task",
     }
-    const index = buildTaskProjectionIndex([], participants())
+    const index = buildTaskProjectionIndex(retained, participants())
 
-    expect(projectTaskEvent(index, orphaned, "agent-a")).toEqual({
-      kind: "task",
-      visible: false,
-    })
+    for (const message of [
+      orphanedText,
+      ...retained.filter((entry) => entry.collab?.requestId === "task-T"),
+    ]) {
+      for (const participantId of ["agent-a", "agent-b"]) {
+        expect(projectTaskEvent(index, message, participantId)).toEqual({
+          kind: "task",
+          visible: false,
+        })
+        expect(projectTaskEvent(index, message, participantId, true)).toEqual({
+          kind: "task",
+          visible: false,
+        })
+      }
+    }
   })
 
   it("validates Human task targets without falling back", () => {

--- a/app/src/do/taskScope.test.ts
+++ b/app/src/do/taskScope.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildTaskProjectionIndex,
+  projectTaskEvent,
+  resolveAgentTaskTargets,
+  resolveHumanTaskTargets,
+  resolveTaskRequest,
+} from "./taskScope"
+import type { RoomMessage, RoomParticipant } from "../room/types"
+
+function participant(
+  id: string,
+  kind: "human" | "agent",
+  connected = true
+): RoomParticipant {
+  return {
+    id,
+    name: id,
+    kind,
+    connected,
+    joinedAt: 1,
+    lastSeenAt: 1,
+    token: `${id}-token`,
+  }
+}
+
+function request(sequence = 1): RoomMessage {
+  return {
+    id: "request-message",
+    peerId: "human",
+    name: "human",
+    kind: "human",
+    type: "action",
+    actionType: "collab",
+    collab: {
+      requestId: "task-T",
+      kind: "request",
+      fromParticipantId: "human",
+      targetParticipantId: "agent-a",
+      summary: "Task T",
+    },
+    targets: ["agent-a"],
+    createdAt: sequence,
+    sequence,
+  }
+}
+
+function taskText(
+  sequence: number,
+  peerId: string,
+  targets?: string[]
+): RoomMessage {
+  return {
+    id: `message-${sequence}`,
+    peerId,
+    name: peerId,
+    kind: peerId === "human" ? "human" : "agent",
+    type: "text",
+    text: `task-${sequence}`,
+    taskRequestId: "task-T",
+    ...(targets ? { targets } : {}),
+    createdAt: sequence,
+    sequence,
+  }
+}
+
+function participants(): Record<string, RoomParticipant> {
+  return {
+    human: participant("human", "human"),
+    "agent-a": participant("agent-a", "agent"),
+    "agent-b": participant("agent-b", "agent"),
+    "agent-c": participant("agent-c", "agent"),
+  }
+}
+
+describe("Task scope projection", () => {
+  it("hides unrelated Agents and admits an explicitly targeted Agent", () => {
+    const messages = [
+      request(),
+      taskText(2, "human", ["agent-b"]),
+      taskText(3, "agent-b"),
+    ]
+    const index = buildTaskProjectionIndex(messages, participants())
+
+    expect(projectTaskEvent(index, messages[0], "agent-a")).toMatchObject({
+      kind: "task",
+      visible: true,
+      scopeId: "task:task-T",
+      addressed: true,
+    })
+    expect(projectTaskEvent(index, messages[0], "agent-c")).toEqual({
+      kind: "task",
+      visible: false,
+    })
+    expect(projectTaskEvent(index, messages[1], "agent-b")).toMatchObject({
+      kind: "task",
+      visible: true,
+      scopeId: "task:task-T",
+      addressed: true,
+    })
+    expect(projectTaskEvent(index, messages[2], "agent-a")).toMatchObject({
+      kind: "task",
+      visible: true,
+      scopeId: "task:task-T",
+      addressed: false,
+    })
+    expect(projectTaskEvent(index, messages[2], "agent-c")).toEqual({
+      kind: "task",
+      visible: false,
+    })
+    expect(projectTaskEvent(index, messages[0], "agent-b", true)).toMatchObject(
+      {
+        kind: "task",
+        visible: true,
+        scopeId: "task:task-T",
+      }
+    )
+  })
+
+  it("reconstructs participation from retained canonical messages", () => {
+    const messages = [request(), taskText(2, "human", ["agent-b"])]
+    const rebuilt = buildTaskProjectionIndex(messages, participants())
+    const resolution = resolveTaskRequest(rebuilt, "task-T", participants())
+
+    expect(resolution).toMatchObject({
+      ok: true,
+      primaryAgentParticipantId: "agent-a",
+      agentParticipantIds: ["agent-a", "agent-b"],
+    })
+  })
+
+  it("fails closed for orphaned explicit Task text", () => {
+    const orphaned = {
+      ...taskText(2, "agent-a", ["human"]),
+      taskRequestId: "evicted-task",
+    }
+    const index = buildTaskProjectionIndex([], participants())
+
+    expect(projectTaskEvent(index, orphaned, "agent-a")).toEqual({
+      kind: "task",
+      visible: false,
+    })
+  })
+
+  it("validates Human task targets without falling back", () => {
+    const index = buildTaskProjectionIndex([request()], participants())
+    const resolution = resolveTaskRequest(index, "task-T", participants())
+    if (!resolution || resolution.ok === false) throw new Error("task missing")
+    const human = participants().human
+
+    expect(
+      resolveHumanTaskTargets(resolution, human, participants(), undefined, 8)
+    ).toEqual({ ok: true, targets: ["agent-a"] })
+    expect(
+      resolveHumanTaskTargets(resolution, human, participants(), ["agent-b"], 8)
+    ).toEqual({ ok: true, targets: ["agent-b"] })
+    expect(
+      resolveHumanTaskTargets(resolution, human, participants(), ["human"], 8)
+    ).toEqual({ ok: false, error: "task_target_not_agent" })
+    expect(
+      resolveHumanTaskTargets(
+        resolution,
+        human,
+        {
+          ...participants(),
+          "agent-b": participant("agent-b", "agent", false),
+        },
+        ["agent-b"],
+        8
+      )
+    ).toEqual({ ok: false, error: "task_target_not_in_room" })
+    expect(
+      resolveHumanTaskTargets(resolution, human, participants(), ["missing"], 8)
+    ).toEqual({ ok: false, error: "task_target_not_in_room" })
+  })
+
+  it("lets a participating Agent extend the Task but rejects a forged sender", () => {
+    const index = buildTaskProjectionIndex([request()], participants())
+    const resolution = resolveTaskRequest(index, "task-T", participants())
+    if (!resolution || resolution.ok === false) throw new Error("task missing")
+
+    expect(
+      resolveAgentTaskTargets(
+        resolution,
+        participants()["agent-a"],
+        participants(),
+        ["agent-b"],
+        8
+      )
+    ).toEqual({ ok: true, targets: ["agent-b"] })
+    expect(
+      resolveAgentTaskTargets(
+        resolution,
+        participants()["agent-c"],
+        participants(),
+        ["agent-b"],
+        8
+      )
+    ).toEqual({ ok: false, error: "task_target_mismatch" })
+  })
+})

--- a/app/src/do/taskScope.ts
+++ b/app/src/do/taskScope.ts
@@ -236,11 +236,9 @@ export function projectTaskEvent(
   const requestId = taskRequestIdFor(message)
   if (!requestId) return { kind: "ordinary" }
   const task = index.tasks.get(requestId)
-  // A structured lifecycle envelope without a retained request is still the
-  // legacy ordinary collaboration projection. Explicit task text carries
-  // taskRequestId, so an orphaned Task message remains fail-closed instead of
-  // falling back to Room context.
-  if (!task && message.taskRequestId === undefined) return { kind: "ordinary" }
+  // Correlation identity can only come from a retained canonical request.
+  // Lifecycle envelopes whose request was evicted therefore fail closed just
+  // like explicit orphaned Task text; they must never become Room context.
   if (!task) return { kind: "task", visible: false }
 
   const participantSet = historical

--- a/app/src/do/taskScope.ts
+++ b/app/src/do/taskScope.ts
@@ -1,0 +1,257 @@
+import type { CollabEvent, RoomMessage, RoomParticipant } from "../room/types"
+
+export type TaskProjectionIndex = {
+  tasks: Map<string, TaskProjectionTask>
+}
+
+type TaskProjectionTask = {
+  request: CollabEvent
+  participatingAgentIds: Set<string>
+  agentsBySequence: Map<number, Set<string>>
+}
+
+export type TaskRequestResolution = {
+  ok: true
+  requestId: string
+  request: CollabEvent
+  primaryAgentParticipantId: string
+  agentParticipantIds: string[]
+}
+
+export type TaskTargetResolution =
+  | { ok: true; targets: string[] }
+  | { ok: false; error: string }
+
+export type TaskEventProjection =
+  | { kind: "ordinary" }
+  | { kind: "task"; visible: false }
+  | {
+      kind: "task"
+      visible: true
+      scopeId: string
+      addressed: boolean
+    }
+
+function taskRequestIdFor(message: RoomMessage): string | undefined {
+  return message.taskRequestId ?? message.collab?.requestId
+}
+
+function connectedAgent(
+  participants: Record<string, RoomParticipant>,
+  participantId: string
+): boolean {
+  const participant = participants[participantId]
+  return participant?.kind === "agent" && participant.connected
+}
+
+function addAgentEndpoint(
+  task: TaskProjectionTask,
+  participants: Record<string, RoomParticipant>,
+  participantId: string
+): void {
+  if (participants[participantId]?.kind === "agent")
+    task.participatingAgentIds.add(participantId)
+}
+
+/**
+ * Derives bounded Task participation from the retained canonical Room log.
+ * The index is intentionally ephemeral: the message ring remains the only
+ * source of truth and a DO restart reconstructs the same decisions.
+ */
+export function buildTaskProjectionIndex(
+  messages: readonly RoomMessage[],
+  participants: Record<string, RoomParticipant>
+): TaskProjectionIndex {
+  const tasks = new Map<string, TaskProjectionTask>()
+  const ordered = [...messages].sort(
+    (left, right) => left.sequence - right.sequence
+  )
+
+  for (const message of ordered) {
+    const collab = message.collab
+    if (collab?.kind === "request" && !tasks.has(collab.requestId)) {
+      const task: TaskProjectionTask = {
+        request: collab,
+        participatingAgentIds: new Set(),
+        agentsBySequence: new Map(),
+      }
+      addAgentEndpoint(task, participants, collab.fromParticipantId)
+      addAgentEndpoint(task, participants, collab.targetParticipantId)
+      task.agentsBySequence.set(
+        message.sequence,
+        new Set(task.participatingAgentIds)
+      )
+      tasks.set(collab.requestId, task)
+      continue
+    }
+
+    const requestId = taskRequestIdFor(message)
+    if (!requestId) continue
+    const task = tasks.get(requestId)
+    if (!task) continue
+
+    const visibleAgents = new Set(task.participatingAgentIds)
+    const sender = participants[message.peerId]
+    const senderMayExtendTask =
+      sender?.kind === "human" ||
+      (sender?.kind === "agent" && task.participatingAgentIds.has(sender.id))
+
+    // Only validated task text can extend participation. The live Room path
+    // rejects stale/non-Agent targets before persistence; reconstruction uses
+    // the same current roster shape and fails closed for anything else.
+    if (message.taskRequestId && senderMayExtendTask) {
+      for (const targetId of message.targets ?? []) {
+        if (participants[targetId]?.kind !== "agent") continue
+        task.participatingAgentIds.add(targetId)
+        visibleAgents.add(targetId)
+      }
+    }
+    task.agentsBySequence.set(message.sequence, visibleAgents)
+  }
+
+  return { tasks }
+}
+
+export function resolveTaskRequest(
+  index: TaskProjectionIndex,
+  rawRequestId: unknown,
+  participants: Record<string, RoomParticipant>
+): TaskRequestResolution | { ok: false; error: string } {
+  if (typeof rawRequestId !== "string")
+    return { ok: false, error: "invalid_task_request" }
+  const requestId = rawRequestId.trim()
+  if (!requestId) return { ok: false, error: "invalid_task_request" }
+  const task = index.tasks.get(requestId)
+  if (!task) return { ok: false, error: "unknown_task_request" }
+
+  const agentParticipantIds = [...task.participatingAgentIds].filter((id) =>
+    connectedAgent(participants, id)
+  )
+  if (agentParticipantIds.length === 0)
+    return { ok: false, error: "task_target_not_in_room" }
+
+  const primaryAgentParticipantId = connectedAgent(
+    participants,
+    task.request.targetParticipantId
+  )
+    ? task.request.targetParticipantId
+    : connectedAgent(participants, task.request.fromParticipantId)
+    ? task.request.fromParticipantId
+    : agentParticipantIds[0]
+
+  return {
+    ok: true,
+    requestId,
+    request: task.request,
+    primaryAgentParticipantId,
+    agentParticipantIds,
+  }
+}
+
+function normalizedExplicitTargets(
+  rawTargets: unknown,
+  maxTargets: number
+): string[] | { error: string } | undefined {
+  if (rawTargets === undefined) return undefined
+  if (
+    !Array.isArray(rawTargets) ||
+    rawTargets.some((id) => typeof id !== "string")
+  )
+    return { error: "invalid_task_targets" }
+  const targets = [...new Set(rawTargets.map((id) => id.trim()))]
+  if (targets.some((id) => !id)) return { error: "invalid_task_targets" }
+  if (targets.length > maxTargets) return { error: "too_many_task_targets" }
+  return targets
+}
+
+export function resolveHumanTaskTargets(
+  resolution: TaskRequestResolution,
+  sender: RoomParticipant,
+  participants: Record<string, RoomParticipant>,
+  rawTargets: unknown,
+  maxTargets: number
+): TaskTargetResolution {
+  if (sender.kind !== "human" || !sender.connected)
+    return { ok: false, error: "task_sender_not_human" }
+  const targets = normalizedExplicitTargets(rawTargets, maxTargets)
+  if (targets && !Array.isArray(targets))
+    return { ok: false, error: targets.error }
+  const validTargets = targets as string[] | undefined
+  if (!validTargets || validTargets.length === 0)
+    return { ok: true, targets: [resolution.primaryAgentParticipantId] }
+
+  for (const targetId of validTargets) {
+    const target = participants[targetId]
+    if (!target || !target.connected)
+      return { ok: false, error: "task_target_not_in_room" }
+    if (target.kind !== "agent")
+      return { ok: false, error: "task_target_not_agent" }
+  }
+  return { ok: true, targets: validTargets }
+}
+
+export function resolveAgentTaskTargets(
+  resolution: TaskRequestResolution,
+  sender: RoomParticipant,
+  participants: Record<string, RoomParticipant>,
+  rawTargets: unknown,
+  maxTargets: number
+): TaskTargetResolution {
+  if (
+    sender.kind !== "agent" ||
+    !sender.connected ||
+    !resolution.agentParticipantIds.includes(sender.id)
+  )
+    return { ok: false, error: "task_target_mismatch" }
+  const targets = normalizedExplicitTargets(rawTargets, maxTargets)
+  if (targets && !Array.isArray(targets))
+    return { ok: false, error: targets.error }
+  const validTargets = targets as string[] | undefined
+  if (!validTargets || validTargets.length === 0)
+    return { ok: true, targets: [] }
+
+  for (const targetId of validTargets) {
+    if (targetId === sender.id) continue
+    const target = participants[targetId]
+    if (!target || !target.connected)
+      return { ok: false, error: "task_target_not_in_room" }
+  }
+  return {
+    ok: true,
+    targets: validTargets.filter((id) => id !== sender.id),
+  }
+}
+
+/**
+ * Returns an explicit decision for Task events. `historical=true` is used by
+ * bounded context reads: an Agent that has since joined may inspect retained
+ * Task context, while live event delivery remains sequence-aware.
+ */
+export function projectTaskEvent(
+  index: TaskProjectionIndex,
+  message: RoomMessage,
+  participantId: string,
+  historical = false
+): TaskEventProjection {
+  const requestId = taskRequestIdFor(message)
+  if (!requestId) return { kind: "ordinary" }
+  const task = index.tasks.get(requestId)
+  // A structured lifecycle envelope without a retained request is still the
+  // legacy ordinary collaboration projection. Explicit task text carries
+  // taskRequestId, so an orphaned Task message remains fail-closed instead of
+  // falling back to Room context.
+  if (!task && message.taskRequestId === undefined) return { kind: "ordinary" }
+  if (!task) return { kind: "task", visible: false }
+
+  const participantSet = historical
+    ? task.participatingAgentIds
+    : task.agentsBySequence.get(message.sequence) ?? new Set<string>()
+  if (!participantSet.has(participantId))
+    return { kind: "task", visible: false }
+  return {
+    kind: "task",
+    visible: true,
+    scopeId: `task:${requestId}`,
+    addressed: message.targets?.includes(participantId) === true,
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #314 as a focused, unmerged spike.

- Adds a small pure `taskScope` projection/validation seam derived from the bounded retained Room message ring.
- Prevents unrelated Agents from receiving Task request/text as Room context in live wait delivery and retained context reads.
- Allows Human Task composers to use the existing semantic Agent picker for explicit participation; the server validates connected Agent targets and never silently falls back on invalid input.
- Preserves Agent→Human and Agent→Agent task addressing with explicit validated targets.
- Automatically emits the canonical `accepted` collaboration result for a Human-originated Task immediately before the first admitted scoped Harness turn; Agent-originated requests retain explicit accept/decline semantics.

## Evidence

- Unrelated Agent live wait/read context contains no Task request or text.
- Explicitly targeted Agent receives addressed `task:<requestId>` context and is included in reconstructed bounded participation.
- Orphaned explicit Task text fails closed instead of degrading to Room context.
- Invalid Human Task targets (Human, unknown, disconnected Agent) are rejected without appending or fallback.
- Human Task picker tests prove semantic participant IDs are sent; hand-typed names do not become routing authority.
- Runtime tests prove accepted precedes first scoped Harness execution, acceptance failure does not start cognition, Agent-originated requests are not auto-accepted, and capacity rejection does not claim Working.

## Validation

- `pnpm --dir app test` — 75 files / 679 tests passed
- `pnpm --dir app run type-check` — passed
- `pnpm --dir app exec eslint src` — passed
- Prettier check / `git diff --check` — passed
- `pnpm --dir app run docs:check` — passed
- `pnpm --dir app run cf-build` — passed (existing OpenNext warnings only)
- `go test ./...` — passed
- `gofmt` check, `go vet ./...`, `go build ./...` — passed

This PR is intentionally OPEN and UNMERGED.