### PR TITLE
chore(agent): bump runtime version to 0.5.27

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.26"
+var Version = "0.5.27"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary
- bump the canonical Go Agent Runtime version to 0.5.27 after PR #319
- keep bootstrap documentation unchanged until the native release is published

## Validation
- go test ./...
- go vet ./...
- go build ./cmd/free4chat-agent
- bash scripts/test-install-agent.sh
- bash scripts/test-bootstrap-contract.sh