### PR TITLE
docs(agent): activate runtime version 0.5.27

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -316,7 +316,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.26` (release tag `agent-v0.5.26`).
+`0.5.27` (release tag `agent-v0.5.27`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -377,7 +377,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.26"
+expected_version="0.5.27"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1825,7 +1825,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.26` (release tag `agent-v0.5.26`).
+`0.5.27` (release tag `agent-v0.5.27`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1886,7 +1886,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.26"
+expected_version="0.5.27"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary
- activate the published Free4Chat Agent Runtime 0.5.27 in the live bootstrap document
- regenerate the matching public/llms-full.txt asset
- keep the source-version and native Release steps separate and verified

## Validation
- bash agent/scripts/test-bootstrap-contract.sh
- yarn docs:check
- yarn type-check
- yarn eslint src --no-fix
- yarn prettier --check .
- yarn cf-build

Note: fresh local Vitest 4 installation exposes an existing repository-wide JSX/WebSocketPair test incompatibility from dependency update 696ada8; no dependency or test changes are included in this documentation-only activation PR.