### PR TITLE
test: restore full App suite on Vitest 4

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -60,9 +60,31 @@ jobs:
         run: npx vitest run src/__tests__/docs src/__tests__/discovery/crawl-surface.test.ts
         working-directory: app
 
+  app-tests:
+    name: App Tests
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: app/.nvmrc
+          cache: yarn
+          cache-dependency-path: app/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: app
+
+      - name: Full App test suite
+        run: yarn test
+        working-directory: app
+
   deploy:
     name: Build & Deploy
-    needs: lint
+    needs: [lint, app-tests]
     if: >-
       github.ref == 'refs/heads/cf-sfu' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/agent/internal/runtime/resident_events_test.go
+++ b/agent/internal/runtime/resident_events_test.go
@@ -218,7 +218,12 @@ func TestResidentRuntimeRetriesHumanTaskAcceptanceOnHeartbeat(t *testing.T) {
 	waitFor(t, time.Second, func() bool {
 		responses := client.snapshotCollabResponses()
 		runs, _ := adapter.scopedRunSnapshot()
-		return len(responses) == 2 && len(runs) == 1 && len(rt.pendingAddressedSnapshotFor("task:T")) == 0
+		status := rt.Status()
+		return len(responses) == 2 &&
+			len(runs) == 1 &&
+			len(rt.pendingAddressedSnapshotFor("task:T")) == 0 &&
+			status.LastError == "" &&
+			status.State == StateWaiting
 	}, "heartbeat acceptance retry and single Harness turn")
 	if len(stream.heartbeats) == 0 {
 		t.Fatal("accepted retry completed without a resident heartbeat")

--- a/app/src/do/roomSessionLifecycle.test.ts
+++ b/app/src/do/roomSessionLifecycle.test.ts
@@ -131,6 +131,26 @@ class TestAgentEventSocket {
   }
 }
 
+type TestWebSocketPair = {
+  0: TestAgentEventSocket
+  1: TestAgentEventSocket
+}
+
+function stubWebSocketPairs(...pairs: TestWebSocketPair[]) {
+  let nextPair = 0
+  class WebSocketPairMock {
+    0: TestAgentEventSocket
+    1: TestAgentEventSocket
+
+    constructor() {
+      const pair = pairs[Math.min(nextPair++, pairs.length - 1)]
+      this[0] = pair[0]
+      this[1] = pair[1]
+    }
+  }
+  vi.stubGlobal("WebSocketPair", WebSocketPairMock)
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>((resolvePromise) => {
@@ -368,13 +388,7 @@ describe("RoomSession expiry cleanup", () => {
       }
     }
     vi.stubGlobal("Response", UpgradeResponse)
-    vi.stubGlobal(
-      "WebSocketPair",
-      vi.fn().mockReturnValue({
-        0: new TestAgentEventSocket(),
-        1: freshSocket,
-      })
-    )
+    stubWebSocketPairs({ 0: new TestAgentEventSocket(), 1: freshSocket })
     const freshConnection = await (
       session as unknown as {
         handleAgentEventConnection: (request: Request) => Promise<Response>
@@ -548,14 +562,7 @@ describe("RoomSession expiry cleanup", () => {
       0: new TestAgentEventSocket(),
       1: new TestAgentEventSocket(),
     }
-    vi.stubGlobal(
-      "WebSocketPair",
-      vi
-        .fn()
-        .mockReturnValueOnce(first)
-        .mockReturnValueOnce(second)
-        .mockReturnValueOnce(third)
-    )
+    stubWebSocketPairs(first, second, third)
     const request = () =>
       new Request("https://room/agent-events", {
         method: "GET",
@@ -739,7 +746,7 @@ describe("RoomSession expiry cleanup", () => {
     }
     const session = new RoomSession(ctx as never, { SFU_ROOM: {} } as never)
     const pair = { 0: new TestAgentEventSocket(), 1: socket }
-    vi.stubGlobal("WebSocketPair", vi.fn().mockReturnValue(pair))
+    stubWebSocketPairs(pair)
 
     const response = await (
       session as unknown as {

--- a/app/vitest.config.mts
+++ b/app/vitest.config.mts
@@ -4,6 +4,14 @@ import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
+  // Vitest 4 resolves Vite 8/Rolldown, where the React plugin's legacy
+  // esbuild JSX option is ignored. Keep the existing plugin for React
+  // behavior, but configure the native transformer explicitly for TSX.
+  oxc: {
+    jsx: {
+      runtime: "automatic",
+    },
+  },
   resolve: {
     alias: {
       // Workers-runtime module: real one exists only inside wrangler/opennext


### PR DESCRIPTION
## Summary

Closes #325.

This is a narrow test-infrastructure/reliability PR from a fresh worktree based on the latest `cf-sfu` (`b3a2e4df620c4a7af3467237ec7f491d5b9b395f`). It does not change product or Runtime architecture.

## Reproduced baseline

Using the repository-declared Node 22 / Yarn 1.22.22 toolchain and `yarn install --frozen-lockfile`:

- `yarn test`: 23 failed files, 53 passed files; 3 failed tests, 536 passed tests.
- 22 TSX suites failed before executing because Vite 8/Rolldown ignored the React plugin's legacy `esbuild.jsx` setting.
- `roomSessionLifecycle.test.ts` failed three paths because Vitest 4 no longer accepts `mockReturnValue` for a mock used with `new WebSocketPair()`.
- The existing heartbeat retry regression had a timing-sensitive final Runtime-state assertion.

## Fixes

- Configure Vite's native Oxc transformer with automatic React JSX runtime for the existing Vitest config. Vitest is not downgraded and no tests are skipped.
- Replace the three legacy WebSocketPair stubs with one constructor-compatible local helper.
- Include the healthy final Runtime state in the existing eventual wait for the resident heartbeat retry test; no production sleep or retry behavior changed.
- Add a dedicated full App test job to `CI / Deploy`, running in parallel with lint/typecheck/docs checks. `deploy` now needs both `lint` and `app-tests`.

## Validation

- App `yarn test`: `76 passed` files, `681 passed` tests.
- App `yarn type-check`: pass.
- App `yarn eslint src --no-fix`: pass.
- App `yarn prettier --check .`: pass.
- App `yarn docs:check`: pass.
- App `yarn cf-build`: pass; existing Durable Object/dependency-copy warnings remain non-fatal.
- Agent `go test ./... -count=1`: pass.
- Agent heartbeat regression `go test ./internal/runtime -run '^TestResidentRuntimeRetriesHumanTaskAcceptanceOnHeartbeat$' -count=100`: pass.
- Agent heartbeat regression with race `go test -race ./internal/runtime -run '^TestResidentRuntimeRetriesHumanTaskAcceptanceOnHeartbeat$' -count=20`: pass.
- Agent `go vet ./...`: pass.
- Agent `go build ./...`: pass.

No merge is requested for this PR.
