### PR TITLE
feat: show transient Agent activity

### DIFF
--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -531,6 +531,69 @@ func (c *Client) RequestPermission(
 	return &Error{Message: "Room permission request rejected", Code: CodeToolError}
 }
 
+// UpdateAgentActivity publishes a bounded transient activity transition. The
+// participant handle stays in private request headers; the body contains no
+// Harness payload and an empty state clears the projection.
+func (c *Client) UpdateAgentActivity(
+	participantHandle, scope string, activity types.AgentActivityState,
+) error {
+	if !validAgentActivityScope(scope) || (activity != "" && !activity.Valid()) {
+		return &Error{Message: "invalid Agent activity", Code: CodeToolError}
+	}
+	handle, err := parseRoomControlHandle(participantHandle)
+	if err != nil {
+		return err
+	}
+	endpoint, err := c.roomControlEndpoint("/api/room/agent-activity")
+	if err != nil {
+		return err
+	}
+	var wireActivity any
+	if activity != "" {
+		wireActivity = activity
+	}
+	payload, err := json.Marshal(map[string]any{
+		"scopeId":  scope,
+		"activity": wireActivity,
+	})
+	if err != nil {
+		return &Error{Message: "encode Agent activity", Code: CodeTransient}
+	}
+	request, err := http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return &Error{Message: "create Agent activity request", Code: CodeTransient}
+	}
+	request.Header.Set("Content-Type", headerContentType)
+	request.Header.Set("Accept", headerContentType)
+	request.Header.Set("User-Agent", defaultUserAgent)
+	request.Header.Set("Origin", endpoint.Scheme+"://"+endpoint.Host)
+	request.Header.Set("X-Room-Id", handle.Room)
+	request.Header.Set("X-Room-Participant-Id", handle.ParticipantID)
+	request.Header.Set("X-Room-Participant-Token", handle.ParticipantToken)
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return &Error{Message: "Agent activity request failed", Code: CodeTransient}
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= 200 && response.StatusCode <= 299 {
+		return nil
+	}
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
+		return &Error{Message: "Agent activity temporarily unavailable", Code: CodeTransient}
+	}
+	return &Error{Message: "Agent activity rejected", Code: CodeToolError}
+}
+
+func validAgentActivityScope(value string) bool {
+	if len(value) == 0 || len(value) > types.MaxLogicalScopeLength || strings.TrimSpace(value) != value {
+		return false
+	}
+	if value == "room" {
+		return true
+	}
+	return strings.HasPrefix(value, "task:") && validPermissionRequestID(strings.TrimPrefix(value, "task:"))
+}
+
 func validPermissionRequestID(value string) bool {
 	if len(value) < 4 || len(value) > 64 {
 		return false

--- a/agent/internal/free4chat/client_test.go
+++ b/agent/internal/free4chat/client_test.go
@@ -203,6 +203,62 @@ func TestRequestPermissionUsesNarrowRoomControlWire(t *testing.T) {
 	}
 }
 
+func TestUpdateAgentActivityUsesBoundedRoomControlWire(t *testing.T) {
+	var seenPath string
+	var seenHeaders http.Header
+	var seenBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenHeaders = r.Header.Clone()
+		if err := json.NewDecoder(r.Body).Decode(&seenBody); err != nil {
+			t.Fatal(err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	handleBytes, _ := json.Marshal(map[string]string{
+		"room": "room-activity", "participantId": "agent-activity", "participantToken": "secret-token",
+	})
+	handle := base64.RawURLEncoding.EncodeToString(handleBytes)
+	client := New(server.URL + "/mcp")
+	if err := client.UpdateAgentActivity(handle, "task:req-1", types.AgentActivityThinking); err != nil {
+		t.Fatal(err)
+	}
+	if seenPath != "/api/room/agent-activity" ||
+		seenHeaders.Get("X-Room-Id") != "room-activity" ||
+		seenHeaders.Get("X-Room-Participant-Id") != "agent-activity" ||
+		seenHeaders.Get("X-Room-Participant-Token") != "secret-token" ||
+		seenBody["scopeId"] != "task:req-1" || seenBody["activity"] != string(types.AgentActivityThinking) {
+		t.Fatalf("wrong activity wire: path=%q headers=%v body=%#v", seenPath, seenHeaders, seenBody)
+	}
+	if err := client.UpdateAgentActivity(handle, "room", ""); err != nil {
+		t.Fatal(err)
+	}
+	if seenBody["activity"] != nil {
+		t.Fatalf("clear activity must be null: %#v", seenBody)
+	}
+}
+
+func TestUpdateAgentActivityRejectsInvalidScopeAndState(t *testing.T) {
+	client := New("http://127.0.0.1:1/mcp")
+	handleBytes, _ := json.Marshal(map[string]string{
+		"room": "room", "participantId": "agent", "participantToken": "token",
+	})
+	handle := base64.RawURLEncoding.EncodeToString(handleBytes)
+	for _, test := range []struct {
+		scope string
+		state types.AgentActivityState
+	}{
+		{"task:", types.AgentActivityWorking},
+		{"room?", types.AgentActivityWorking},
+		{"room", "private"},
+	} {
+		if err := client.UpdateAgentActivity(handle, test.scope, test.state); err == nil || CodeOf(err) != CodeToolError {
+			t.Fatalf("invalid activity %q/%q error = %v", test.scope, test.state, err)
+		}
+	}
+}
+
 // fakeServer emulates the deployed /mcp wire contract closely enough to
 // exercise transport classification and payload parsing.
 type fakeServer struct {

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -53,6 +53,9 @@ type AdapterOptions struct {
 	// ACP session/request_permission calls. A nil responder preserves the
 	// production fail-closed behavior and cancels the request immediately.
 	PermissionResponder ACPPermissionResponder
+	// ActivityHandler is an optional transient projection callback. Repeated
+	// ACP chunks are coalesced by the Runtime before any Room request.
+	ActivityHandler ACPActivityHandler
 }
 
 // ACPMode is the Harness-native session mode advertised by session/new.
@@ -149,6 +152,10 @@ type ACPPermissionResponse struct {
 // chooses one of the Harness-provided options.
 type ACPPermissionResponder func(context.Context, ACPPermissionRequest) (ACPPermissionResponse, error)
 
+// ACPActivityHandler receives only a logical scope and coarse normalized
+// state. The ACP payload remains private to the adapter.
+type ACPActivityHandler func(scope string, state types.AgentActivityState)
+
 // ACPCapabilities is the parsed initialize response projection.
 type ACPCapabilities struct {
 	Images bool
@@ -203,6 +210,7 @@ type acpSession struct {
 	sessionID  string
 	caps       *ACPCapabilities
 	generation int64
+	scope      string
 }
 
 // harnessProcess owns the ONE cmd.Wait() call for a child lifecycle. Both
@@ -331,6 +339,14 @@ func (a *ACPAdapter) PendingPermissionCount() int {
 func (a *ACPAdapter) SetPermissionResponder(responder ACPPermissionResponder) {
 	a.mu.Lock()
 	a.options.PermissionResponder = responder
+	a.mu.Unlock()
+}
+
+// SetActivityHandler installs the coarse Runtime projection seam. It never
+// exposes native ACP payloads outside this process.
+func (a *ACPAdapter) SetActivityHandler(handler ACPActivityHandler) {
+	a.mu.Lock()
+	a.options.ActivityHandler = handler
 	a.mu.Unlock()
 }
 
@@ -684,6 +700,7 @@ func (a *ACPAdapter) EnsureSessionFor(scope string) error {
 		sessionID:  sessionResponse.SessionID,
 		caps:       base,
 		generation: a.nextScopeGeneration,
+		scope:      scope,
 	}
 	return nil
 }
@@ -960,6 +977,7 @@ func (a *ACPAdapter) dispatch(message *acpMessage) {
 	// Notification.
 	if message.Method == "session/update" {
 		a.applySessionUpdate(message.Params)
+		a.dispatchActivity(message.Params)
 		if chunk, ok := extractTextChunk(message.Params); ok && chunk != "" {
 			a.mu.Lock()
 			if a.promptActive {
@@ -967,6 +985,43 @@ func (a *ACPAdapter) dispatch(message *acpMessage) {
 			}
 			a.mu.Unlock()
 		}
+	}
+}
+
+func (a *ACPAdapter) dispatchActivity(params json.RawMessage) {
+	state, ok := mapACPActivity(params)
+	if !ok {
+		return
+	}
+	var envelope struct {
+		SessionID string `json:"sessionId"`
+	}
+	if json.Unmarshal(params, &envelope) != nil || envelope.SessionID == "" {
+		return
+	}
+	a.mu.Lock()
+	// ACP notifications arriving after session/prompt settles must not
+	// resurrect a cleared activity state or bleed into the next serialized
+	// turn. The current prompt/session fence is the adapter-local ordering
+	// boundary.
+	if !a.promptActive || a.turnSessionID != envelope.SessionID {
+		a.mu.Unlock()
+		return
+	}
+	scope := "room"
+	if envelope.SessionID != a.sessionID {
+		scope = ""
+		for logicalScope, session := range a.sessions {
+			if session != nil && session.sessionID == envelope.SessionID {
+				scope = logicalScope
+				break
+			}
+		}
+	}
+	handler := a.options.ActivityHandler
+	a.mu.Unlock()
+	if handler != nil && scope != "" {
+		handler(scope, state)
 	}
 }
 

--- a/agent/internal/harness/activity.go
+++ b/agent/internal/harness/activity.go
@@ -1,0 +1,49 @@
+package harness
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+// mapACPActivity projects only the ACP update kind/status. Raw ACP content is
+// intentionally not returned or retained by this mapper.
+func mapACPActivity(params json.RawMessage) (types.AgentActivityState, bool) {
+	var document struct {
+		Update struct {
+			SessionUpdate string `json:"sessionUpdate"`
+			Status        string `json:"status"`
+			ToolCall      struct {
+				Status string `json:"status"`
+			} `json:"toolCall"`
+			ToolCallUpdate struct {
+				Status string `json:"status"`
+			} `json:"toolCallUpdate"`
+		} `json:"update"`
+	}
+	if json.Unmarshal(params, &document) != nil {
+		return "", false
+	}
+	switch document.Update.SessionUpdate {
+	case "agent_thought_chunk":
+		return types.AgentActivityThinking, true
+	case "agent_message_chunk":
+		return types.AgentActivityResponding, true
+	case "tool_call":
+		return types.AgentActivityUsingTools, true
+	case "tool_call_update":
+		status := strings.ToLower(strings.TrimSpace(document.Update.Status))
+		if status == "" {
+			status = strings.ToLower(strings.TrimSpace(document.Update.ToolCallUpdate.Status))
+		}
+		if status == "completed" || status == "complete" || status == "failed" ||
+			status == "cancelled" || status == "canceled" || status == "rejected" ||
+			status == "done" {
+			return "", false
+		}
+		return types.AgentActivityUsingTools, true
+	default:
+		return "", false
+	}
+}

--- a/agent/internal/harness/activity_test.go
+++ b/agent/internal/harness/activity_test.go
@@ -1,0 +1,31 @@
+package harness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+func TestMapACPActivityIsCoarseAndDropsCompletedToolUpdates(t *testing.T) {
+	tests := []struct {
+		name   string
+		update string
+		want   types.AgentActivityState
+		ok     bool
+	}{
+		{"thought", `{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"private"}}}`, types.AgentActivityThinking, true},
+		{"tool", `{"update":{"sessionUpdate":"tool_call","toolCall":{"rawInput":{"command":"secret"}}}}`, types.AgentActivityUsingTools, true},
+		{"active tool update", `{"update":{"sessionUpdate":"tool_call_update","status":"in_progress"}}`, types.AgentActivityUsingTools, true},
+		{"completed tool update", `{"update":{"sessionUpdate":"tool_call_update","status":"completed"}}`, "", false},
+		{"message", `{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"public"}}}`, types.AgentActivityResponding, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := mapACPActivity(json.RawMessage(test.update))
+			if got != test.want || ok != test.ok {
+				t.Fatalf("mapACPActivity() = %q, %v; want %q, %v", got, ok, test.want, test.ok)
+			}
+		})
+	}
+}

--- a/agent/internal/runtime/activity.go
+++ b/agent/internal/runtime/activity.go
@@ -34,13 +34,61 @@ func validActivityScope(scope string) bool {
 	return strings.HasPrefix(scope, "task:") && len(strings.TrimPrefix(scope, "task:")) >= 4
 }
 
+type activityPublication struct {
+	handle string
+	state  types.AgentActivityState
+}
+
+// publishActivity enqueues only the newest state for each scope. It is called
+// from the ACP reader and serialized turn path, so it must never wait for
+// Room/HTTP I/O.
 func (r *ResidentRuntime) publishActivity(scope string, state types.AgentActivityState) {
-	client, ok := r.options.Client.(types.ResidentActivityClient)
-	if !ok {
-		return
-	}
 	handle := r.currentHandle()
 	if handle == "" {
+		return
+	}
+	r.activityPublishMu.Lock()
+	if r.activityPublishQueue == nil {
+		r.activityPublishQueue = make(map[string]activityPublication)
+	}
+	r.activityPublishQueue[scope] = activityPublication{handle: handle, state: state}
+	if r.activityPublisherActive {
+		r.activityPublishMu.Unlock()
+		return
+	}
+	r.activityPublisherActive = true
+	r.activityPublishMu.Unlock()
+	go r.drainActivityPublications()
+}
+
+// drainActivityPublications is deliberately a small, per-Runtime publisher,
+// not a general event bus. A single sender preserves application order for a
+// scope: if an old state is already in flight, a later clear waits behind it;
+// if it is still queued, latest-state replacement removes it. Thus a final
+// clear cannot be overtaken by stale Working/Thinking network traffic.
+func (r *ResidentRuntime) drainActivityPublications() {
+	for {
+		r.activityPublishMu.Lock()
+		if len(r.activityPublishQueue) == 0 {
+			r.activityPublisherActive = false
+			r.activityPublishMu.Unlock()
+			return
+		}
+		var scope string
+		var publication activityPublication
+		for queuedScope, queuedPublication := range r.activityPublishQueue {
+			scope, publication = queuedScope, queuedPublication
+			break
+		}
+		delete(r.activityPublishQueue, scope)
+		r.activityPublishMu.Unlock()
+		r.publishActivityNow(publication.handle, scope, publication.state)
+	}
+}
+
+func (r *ResidentRuntime) publishActivityNow(handle, scope string, state types.AgentActivityState) {
+	client, ok := r.options.Client.(types.ResidentActivityClient)
+	if !ok {
 		return
 	}
 	if err := client.UpdateAgentActivity(handle, scope, state); err != nil {
@@ -132,4 +180,7 @@ func (r *ResidentRuntime) resetActivityLocal() {
 	r.activityTurnActive = false
 	r.activityScope = ""
 	r.activityMu.Unlock()
+	r.activityPublishMu.Lock()
+	r.activityPublishQueue = nil
+	r.activityPublishMu.Unlock()
 }

--- a/agent/internal/runtime/activity.go
+++ b/agent/internal/runtime/activity.go
@@ -181,6 +181,14 @@ func (r *ResidentRuntime) resetActivityLocal() {
 	r.activityScope = ""
 	r.activityMu.Unlock()
 	r.activityPublishMu.Lock()
-	r.activityPublishQueue = nil
+	// A normal resident stream reconnect keeps the same participant handle.
+	// Preserve a queued clear behind any in-flight publication so the old
+	// state cannot be resurrected after the server has fail-closed it. Any
+	// queued non-empty state is stale at this boundary and must not be replayed.
+	for scope, publication := range r.activityPublishQueue {
+		if publication.state != "" {
+			delete(r.activityPublishQueue, scope)
+		}
+	}
 	r.activityPublishMu.Unlock()
 }

--- a/agent/internal/runtime/activity.go
+++ b/agent/internal/runtime/activity.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"strings"
+
+	"github.com/i365dev/free4chat/agent/internal/free4chat"
+	"github.com/i365dev/free4chat/agent/internal/harness"
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+// configureActivityHandler connects the optional generic ACP projection
+// without changing the mandatory HarnessAdapter contract. Unexpected Harness
+// death also clears the public projection and fails closed for media.
+func configureActivityHandler(r *ResidentRuntime) {
+	if r.options.Adapter == nil {
+		return
+	}
+	if setter, ok := r.options.Adapter.(interface {
+		SetActivityHandler(harness.ACPActivityHandler)
+	}); ok {
+		setter.SetActivityHandler(r.observeHarnessActivity)
+	}
+	r.options.Adapter.OnFailure(func(error) {
+		r.clearActivity()
+		r.failClosedResidentMediaState()
+	})
+}
+
+func validActivityScope(scope string) bool {
+	scope = normalizeScope(scope)
+	if scope == roomScope {
+		return true
+	}
+	return strings.HasPrefix(scope, "task:") && len(strings.TrimPrefix(scope, "task:")) >= 4
+}
+
+func (r *ResidentRuntime) publishActivity(scope string, state types.AgentActivityState) {
+	client, ok := r.options.Client.(types.ResidentActivityClient)
+	if !ok {
+		return
+	}
+	handle := r.currentHandle()
+	if handle == "" {
+		return
+	}
+	if err := client.UpdateAgentActivity(handle, scope, state); err != nil {
+		r.log("agent_activity_update_failed", map[string]string{
+			"reason": string(free4chat.CodeOf(err)),
+		})
+	}
+}
+
+// beginActivity is called at the serialized prompt admission boundary. The
+// local map suppresses repeated normalized ACP chunks before they can become
+// HTTP requests, DO broadcasts, or writes.
+func (r *ResidentRuntime) beginActivity(scope string) {
+	if !validActivityScope(scope) {
+		return
+	}
+	r.activityMu.Lock()
+	r.activityTurnActive = true
+	r.activityScope = scope
+	previous, existed := r.activities[scope]
+	if existed && previous == types.AgentActivityWorking {
+		r.activityMu.Unlock()
+		return
+	}
+	r.activities[scope] = types.AgentActivityWorking
+	r.activityMu.Unlock()
+	r.publishActivity(scope, types.AgentActivityWorking)
+}
+
+// observeHarnessActivity accepts normalized events only while the adapter's
+// current serialized prompt is active. It therefore ignores late events from
+// a settled/cancelled turn and cannot resurrect a cleared state.
+func (r *ResidentRuntime) observeHarnessActivity(scope string, state types.AgentActivityState) {
+	if !validActivityScope(scope) || !state.Valid() {
+		return
+	}
+	r.activityMu.Lock()
+	if !r.activityTurnActive || r.activityScope != scope {
+		r.activityMu.Unlock()
+		return
+	}
+	if r.activities[scope] == state {
+		r.activityMu.Unlock()
+		return
+	}
+	r.activities[scope] = state
+	r.activityMu.Unlock()
+	r.publishActivity(scope, state)
+}
+
+func (r *ResidentRuntime) finishActivity(scope string) {
+	if !validActivityScope(scope) {
+		return
+	}
+	r.activityMu.Lock()
+	if r.activityScope == scope {
+		r.activityTurnActive = false
+		r.activityScope = ""
+	}
+	_, existed := r.activities[scope]
+	delete(r.activities, scope)
+	r.activityMu.Unlock()
+	if existed {
+		r.publishActivity(scope, "")
+	}
+}
+
+// clearActivity is best-effort externally but authoritative locally. It is
+// used on stop, Harness failure, and resident transport loss. The server also
+// clears the same projection when the authenticated resident socket closes.
+func (r *ResidentRuntime) clearActivity() {
+	r.activityMu.Lock()
+	entries := make([]string, 0, len(r.activities))
+	for scope := range r.activities {
+		entries = append(entries, scope)
+	}
+	r.activities = make(map[string]types.AgentActivityState)
+	r.activityTurnActive = false
+	r.activityScope = ""
+	r.activityMu.Unlock()
+	for _, scope := range entries {
+		r.publishActivity(scope, "")
+	}
+}
+
+func (r *ResidentRuntime) resetActivityLocal() {
+	r.activityMu.Lock()
+	r.activities = make(map[string]types.AgentActivityState)
+	r.activityTurnActive = false
+	r.activityScope = ""
+	r.activityMu.Unlock()
+}

--- a/agent/internal/runtime/activity_test.go
+++ b/agent/internal/runtime/activity_test.go
@@ -2,7 +2,9 @@ package runtime
 
 import (
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/i365dev/free4chat/agent/internal/types"
 )
@@ -14,40 +16,70 @@ type activityUpdate struct {
 
 type activityClient struct {
 	*fakeClient
-	updates []activityUpdate
+	mu        sync.Mutex
+	updates   []activityUpdate
+	started   chan struct{}
+	release   chan struct{}
+	blockOnce sync.Once
+	updateErr error
 }
 
 func (c *activityClient) UpdateAgentActivity(_ string, scope string, state types.AgentActivityState) error {
+	if c.release != nil {
+		c.blockOnce.Do(func() {
+			close(c.started)
+			<-c.release
+		})
+	}
+	c.mu.Lock()
 	c.updates = append(c.updates, activityUpdate{scope: scope, state: state})
-	return nil
+	c.mu.Unlock()
+	return c.updateErr
+}
+
+func (c *activityClient) snapshot() []activityUpdate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]activityUpdate(nil), c.updates...)
 }
 
 func TestResidentActivityCoalescesACPStatesAndClearsOnCompletion(t *testing.T) {
-	client := &activityClient{}
+	client := &activityClient{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
 	runtime := NewResidentRuntime(Options{Client: client})
 	runtime.mu.Lock()
 	runtime.participantHandle = "private-handle"
 	runtime.mu.Unlock()
 
 	runtime.beginActivity("task:request-1")
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first activity publication")
+	}
 	runtime.observeHarnessActivity("task:request-1", types.AgentActivityThinking)
 	runtime.observeHarnessActivity("task:request-1", types.AgentActivityThinking)
 	runtime.observeHarnessActivity("task:request-1", types.AgentActivityUsingTools)
 	runtime.finishActivity("task:request-1")
 	runtime.observeHarnessActivity("task:request-1", types.AgentActivityResponding)
+	close(client.release)
 
 	want := []activityUpdate{
 		{scope: "task:request-1", state: types.AgentActivityWorking},
-		{scope: "task:request-1", state: types.AgentActivityThinking},
-		{scope: "task:request-1", state: types.AgentActivityUsingTools},
 		{scope: "task:request-1", state: ""},
 	}
-	if len(client.updates) != len(want) {
-		t.Fatalf("activity updates = %#v, want %#v", client.updates, want)
+	waitFor(t, time.Second, func() bool {
+		return len(client.snapshot()) == len(want)
+	}, "coalesced activity updates")
+	updates := client.snapshot()
+	if len(updates) != len(want) {
+		t.Fatalf("activity updates = %#v, want %#v", updates, want)
 	}
 	for index := range want {
-		if client.updates[index] != want[index] {
-			t.Fatalf("activity update %d = %#v, want %#v", index, client.updates[index], want[index])
+		if updates[index] != want[index] {
+			t.Fatalf("activity update %d = %#v, want %#v", index, updates[index], want[index])
 		}
 	}
 }
@@ -61,15 +93,28 @@ func TestResidentActivityDoesNotCrossLogicalScopes(t *testing.T) {
 
 	runtime.beginActivity("task:request-t")
 	runtime.observeHarnessActivity("task:request-u", types.AgentActivityThinking)
-	if len(client.updates) != 1 || client.updates[0].scope != "task:request-t" {
-		t.Fatalf("cross-scope activity was published: %#v", client.updates)
+	waitFor(t, time.Second, func() bool {
+		updates := client.snapshot()
+		return len(updates) == 1 && updates[0].scope == "task:request-t"
+	}, "room activity publication")
+	updates := client.snapshot()
+	if len(updates) != 1 || updates[0].scope != "task:request-t" {
+		t.Fatalf("cross-scope activity was published: %#v", updates)
 	}
 	runtime.clearActivity()
 }
 
 func TestResidentActivityStartsAtTurnAdmissionAndClearsAfterFailure(t *testing.T) {
-	client := &activityClient{fakeClient: &fakeClient{}}
-	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("harness failed")}
+	client := &activityClient{
+		fakeClient: &fakeClient{},
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	adapter := &fakeAdapter{
+		name:     "pi",
+		turnErr:  errors.New("harness failed"),
+		turnWait: client.started,
+	}
 	runtime := NewResidentRuntime(Options{
 		RoomID:  "room",
 		Name:    "Pi",
@@ -83,10 +128,63 @@ func TestResidentActivityStartsAtTurnAdmissionAndClearsAfterFailure(t *testing.T
 	})
 	runtime.acceptEvent(roomEvent(1, true))
 	runtime.drainTurns()
-
-	if len(client.updates) != 2 ||
-		client.updates[0] != (activityUpdate{scope: "room", state: types.AgentActivityWorking}) ||
-		client.updates[1] != (activityUpdate{scope: "room", state: ""}) {
-		t.Fatalf("failed turn activity lifecycle = %#v", client.updates)
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the turn activity publication")
 	}
+	close(client.release)
+
+	waitFor(t, time.Second, func() bool {
+		return len(client.snapshot()) == 2
+	}, "failed turn activity lifecycle")
+	updates := client.snapshot()
+	if len(updates) != 2 ||
+		updates[0] != (activityUpdate{scope: "room", state: types.AgentActivityWorking}) ||
+		updates[1] != (activityUpdate{scope: "room", state: ""}) {
+		t.Fatalf("failed turn activity lifecycle = %#v", updates)
+	}
+}
+
+func TestResidentActivityPublisherDoesNotBlockTurnPath(t *testing.T) {
+	client := &activityClient{
+		fakeClient: &fakeClient{},
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+		updateErr:  errors.New("activity endpoint failed"),
+	}
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("harness failed")}
+	runtime := NewResidentRuntime(Options{
+		RoomID:  "room",
+		Name:    "Pi",
+		Client:  client,
+		Adapter: adapter,
+	})
+	runtime.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "private-handle",
+		Cursor:            0,
+	})
+	runtime.acceptEvent(roomEvent(1, true))
+
+	done := make(chan struct{})
+	go func() {
+		runtime.drainTurns()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Harness turn path was blocked by the activity endpoint")
+	}
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the blocked activity endpoint")
+	}
+	close(client.release)
+	waitFor(t, time.Second, func() bool {
+		updates := client.snapshot()
+		return len(updates) > 0 && updates[len(updates)-1].state == ""
+	}, "final activity clear")
 }

--- a/agent/internal/runtime/activity_test.go
+++ b/agent/internal/runtime/activity_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+type activityUpdate struct {
+	scope string
+	state types.AgentActivityState
+}
+
+type activityClient struct {
+	*fakeClient
+	updates []activityUpdate
+}
+
+func (c *activityClient) UpdateAgentActivity(_ string, scope string, state types.AgentActivityState) error {
+	c.updates = append(c.updates, activityUpdate{scope: scope, state: state})
+	return nil
+}
+
+func TestResidentActivityCoalescesACPStatesAndClearsOnCompletion(t *testing.T) {
+	client := &activityClient{}
+	runtime := NewResidentRuntime(Options{Client: client})
+	runtime.mu.Lock()
+	runtime.participantHandle = "private-handle"
+	runtime.mu.Unlock()
+
+	runtime.beginActivity("task:request-1")
+	runtime.observeHarnessActivity("task:request-1", types.AgentActivityThinking)
+	runtime.observeHarnessActivity("task:request-1", types.AgentActivityThinking)
+	runtime.observeHarnessActivity("task:request-1", types.AgentActivityUsingTools)
+	runtime.finishActivity("task:request-1")
+	runtime.observeHarnessActivity("task:request-1", types.AgentActivityResponding)
+
+	want := []activityUpdate{
+		{scope: "task:request-1", state: types.AgentActivityWorking},
+		{scope: "task:request-1", state: types.AgentActivityThinking},
+		{scope: "task:request-1", state: types.AgentActivityUsingTools},
+		{scope: "task:request-1", state: ""},
+	}
+	if len(client.updates) != len(want) {
+		t.Fatalf("activity updates = %#v, want %#v", client.updates, want)
+	}
+	for index := range want {
+		if client.updates[index] != want[index] {
+			t.Fatalf("activity update %d = %#v, want %#v", index, client.updates[index], want[index])
+		}
+	}
+}
+
+func TestResidentActivityDoesNotCrossLogicalScopes(t *testing.T) {
+	client := &activityClient{}
+	runtime := NewResidentRuntime(Options{Client: client})
+	runtime.mu.Lock()
+	runtime.participantHandle = "private-handle"
+	runtime.mu.Unlock()
+
+	runtime.beginActivity("task:request-t")
+	runtime.observeHarnessActivity("task:request-u", types.AgentActivityThinking)
+	if len(client.updates) != 1 || client.updates[0].scope != "task:request-t" {
+		t.Fatalf("cross-scope activity was published: %#v", client.updates)
+	}
+	runtime.clearActivity()
+}
+
+func TestResidentActivityStartsAtTurnAdmissionAndClearsAfterFailure(t *testing.T) {
+	client := &activityClient{fakeClient: &fakeClient{}}
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("harness failed")}
+	runtime := NewResidentRuntime(Options{
+		RoomID:  "room",
+		Name:    "Pi",
+		Client:  client,
+		Adapter: adapter,
+	})
+	runtime.adoptJoin(types.JoinResult{
+		ParticipantID:     "agent",
+		ParticipantHandle: "private-handle",
+		Cursor:            0,
+	})
+	runtime.acceptEvent(roomEvent(1, true))
+	runtime.drainTurns()
+
+	if len(client.updates) != 2 ||
+		client.updates[0] != (activityUpdate{scope: "room", state: types.AgentActivityWorking}) ||
+		client.updates[1] != (activityUpdate{scope: "room", state: ""}) {
+		t.Fatalf("failed turn activity lifecycle = %#v", client.updates)
+	}
+}

--- a/agent/internal/runtime/activity_test.go
+++ b/agent/internal/runtime/activity_test.go
@@ -188,3 +188,38 @@ func TestResidentActivityPublisherDoesNotBlockTurnPath(t *testing.T) {
 		return len(updates) > 0 && updates[len(updates)-1].state == ""
 	}, "final activity clear")
 }
+
+func TestResidentActivityReconnectRetainsQueuedClear(t *testing.T) {
+	client := &activityClient{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	runtime := NewResidentRuntime(Options{Client: client})
+	runtime.mu.Lock()
+	runtime.participantHandle = "private-handle"
+	runtime.mu.Unlock()
+
+	runtime.beginActivity("room")
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the in-flight Working publication")
+	}
+
+	// Stream loss fail-closes the public state while the old HTTP request is
+	// still in flight. A reconnect resets local state but must retain this
+	// queued clear because the participant handle remains valid.
+	runtime.clearActivity()
+	runtime.resetActivityLocal()
+	close(client.release)
+
+	waitFor(t, time.Second, func() bool {
+		updates := client.snapshot()
+		return len(updates) == 2 && updates[1].state == ""
+	}, "reconnect activity clear")
+	updates := client.snapshot()
+	if updates[0] != (activityUpdate{scope: "room", state: types.AgentActivityWorking}) ||
+		updates[1] != (activityUpdate{scope: "room", state: ""}) {
+		t.Fatalf("reconnect activity lifecycle = %#v", updates)
+	}
+}

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -216,6 +216,9 @@ type ResidentRuntime struct {
 	activities              map[string]types.AgentActivityState
 	activityTurnActive      bool
 	activityScope           string
+	activityPublishMu       sync.Mutex
+	activityPublishQueue    map[string]activityPublication
+	activityPublisherActive bool
 	// mediaGeneration invalidates callbacks from a stopped/replaced bridge.
 	// Bridge teardown reports TrackEnded asynchronously so it cannot re-enter
 	// mediaMu; without this generation fence, a late old callback could end a

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -212,6 +212,10 @@ type ResidentRuntime struct {
 	residentMediaStateMu    sync.Mutex
 	residentMediaState      types.ResidentMediaState
 	residentMediaStateValid bool
+	activityMu              sync.Mutex
+	activities              map[string]types.AgentActivityState
+	activityTurnActive      bool
+	activityScope           string
 	// mediaGeneration invalidates callbacks from a stopped/replaced bridge.
 	// Bridge teardown reports TrackEnded asynchronously so it cannot re-enter
 	// mediaMu; without this generation fence, a late old callback could end a
@@ -345,8 +349,10 @@ func NewResidentRuntime(options Options) *ResidentRuntime {
 		providerClaim:      providerClaim,
 		providerHandles:    providerHandles,
 		pendingPermissions: make(map[string]*pendingRoomPermission),
+		activities:         make(map[string]types.AgentActivityState),
 	}
 	configurePermissionResponder(runtime)
+	configureActivityHandler(runtime)
 	return runtime
 }
 
@@ -637,6 +643,9 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 		r.participatingSince = time.Now().UnixMilli()
 	}
 	r.mu.Unlock()
+	// The Room clears transient activity when the resident event connection is
+	// replaced. A new join/rejoin therefore starts with a fresh local cache too.
+	r.resetActivityLocal()
 	// Media controller (re)build happens OUTSIDE the runtime lock: it may
 	// stop the previous bridge, create a transcriber, and perform a compatibility
 	// RoomInfo bootstrap — none of that may hold the runtime mutex.
@@ -755,6 +764,7 @@ func (r *ResidentRuntime) residentWaitLoop(client types.ResidentEventClient) {
 		// local bridge can run again.
 		if !r.isStopped() {
 			r.failClosedResidentMediaState()
+			r.clearActivity()
 		}
 		if r.isStopped() {
 			return
@@ -900,13 +910,15 @@ func (r *ResidentRuntime) setResidentStream(
 	stream types.ResidentEventStream,
 ) bool {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	if r.stopped {
+		r.mu.Unlock()
 		return false
 	}
 	r.residentMu.Lock()
 	r.resident = stream
 	r.residentMu.Unlock()
+	r.mu.Unlock()
+	r.resetActivityLocal()
 	return true
 }
 
@@ -1220,7 +1232,9 @@ func (r *ResidentRuntime) drainTurns() {
 			voiceOutput.Cancel()
 		}
 
+		r.beginActivity(scope)
 		result, err := r.runHarnessTurn(scope, *input, generation)
+		r.finishActivity(scope)
 		if err != nil {
 			r.mu.Lock()
 			r.lastError = err.Error()
@@ -1585,6 +1599,7 @@ func (r *ResidentRuntime) beginStop(lastError string) bool {
 		r.eventBuffer.Clear()
 		r.mu.Unlock()
 		r.cancelPendingPermissions(errors.New("runtime stopped"))
+		r.clearActivity()
 		close(r.stopCh)
 		r.closeResidentStream()
 		transitioned = true

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -840,6 +840,7 @@ type fakeAdapter struct {
 	// turnResults scripts complete Harness results for lifecycle tests. When
 	// absent, the legacy reply-N/turnTargets behavior stays unchanged.
 	turnResults []types.HarnessTurnResult
+	turnWait    <-chan struct{}
 	onFail      func(error)
 	sessions    int
 	generation  int64
@@ -927,7 +928,12 @@ func (a *fakeAdapter) RunTurn(input types.HarnessTurnInput, expectedGeneration i
 	combined := strings.Join(texts, ",")
 	err := a.turnErr
 	delay := a.delay
+	turnWait := a.turnWait
+	a.turnWait = nil
 	a.mu.Unlock()
+	if turnWait != nil {
+		<-turnWait
+	}
 	if delay > 0 {
 		time.Sleep(delay)
 	}

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -217,6 +217,28 @@ const (
 	KindAgent ParticipantKind = "agent"
 )
 
+// AgentActivityState is the deliberately coarse, transient activity
+// projection shown to other Room participants. It is not a Harness trace and
+// must never carry thought text, tool arguments, commands, or paths.
+type AgentActivityState string
+
+const (
+	AgentActivityWorking    AgentActivityState = "working"
+	AgentActivityThinking   AgentActivityState = "thinking"
+	AgentActivityUsingTools AgentActivityState = "using_tools"
+	AgentActivityResponding AgentActivityState = "responding"
+)
+
+func (state AgentActivityState) Valid() bool {
+	switch state {
+	case AgentActivityWorking, AgentActivityThinking,
+		AgentActivityUsingTools, AgentActivityResponding:
+		return true
+	default:
+		return false
+	}
+}
+
 // RoomPermissionToolCall is the bounded Human-facing projection of one ACP
 // tool call. Raw ACP input/content and native protocol identifiers stay local
 // to the Harness adapter.
@@ -826,6 +848,15 @@ type LiveTranscriptAppendClient interface {
 // clients and compatibility adapters do not acquire a new mutation surface.
 type PermissionRequestClient interface {
 	RequestPermission(participantHandle string, request RoomPermissionRequest) error
+}
+
+// ResidentActivityClient is an optional narrow Runtime-to-Room transport for
+// coarse transient Harness activity. Empty activity means clear. Keeping it
+// outside Free4ChatClient preserves existing test doubles and compatibility
+// clients while allowing the production client to expose only this bounded
+// mutation.
+type ResidentActivityClient interface {
+	UpdateAgentActivity(participantHandle, scope string, activity AgentActivityState) error
 }
 
 // AttachmentRead is read_attachment's normalized result: either an image

--- a/app/src/common/agentActivity.ts
+++ b/app/src/common/agentActivity.ts
@@ -1,0 +1,14 @@
+import type { AgentActivityState } from "../room/types"
+
+export function agentActivityLabel(state: AgentActivityState): string {
+  switch (state) {
+    case "working":
+      return "Working"
+    case "thinking":
+      return "Thinking"
+    case "using_tools":
+      return "Using tools"
+    case "responding":
+      return "Responding"
+  }
+}

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -1,4 +1,9 @@
-import type { CollabEvent, PermissionEvent, RoomSurfaceV1 } from "../room/types"
+import type {
+  AgentActivityState,
+  CollabEvent,
+  PermissionEvent,
+  RoomSurfaceV1,
+} from "../room/types"
 
 export interface UserInfo {
   name: string
@@ -19,6 +24,7 @@ export interface UserInfo {
   // participant-specific agentVoice authorization. Never persisted here.
   voiceAvailable?: boolean
   voiceEnabled?: boolean
+  activity?: AgentActivityState
 }
 
 export type MessageType = "text" | "image" | "file" | "action"

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -311,6 +311,73 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     )
   })
 
+  it("shows activity from every connected Agent in the active task", () => {
+    const taskRequest: Message = {
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "action",
+      actionType: "collab",
+      sequence: 1,
+      collab: {
+        requestId: "task-t",
+        kind: "request",
+        fromParticipantId: "human-local",
+        targetParticipantId: "agent-codex",
+        summary: "Review this task",
+      },
+    }
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [taskRequest],
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+        {
+          peerId: "agent-codex",
+          name: "Codex",
+          kind: "agent",
+          room: "test-room",
+        },
+        {
+          peerId: "agent-pi",
+          name: "Pi",
+          kind: "agent",
+          room: "test-room",
+        },
+      ],
+      agentActivities: [
+        {
+          agentParticipantId: "agent-codex",
+          scopeId: "task:task-t",
+          state: "responding",
+        },
+        {
+          agentParticipantId: "agent-pi",
+          scopeId: "task:task-t",
+          state: "thinking",
+        },
+      ],
+      localParticipantId: "human-local",
+      getLocalRoomAuth: vi.fn(() => ({ participantId: "human-local" })),
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-task-t"))
+    const activity = screen.getByTestId("task-agent-activity")
+    expect(activity).toHaveTextContent("Codex · Responding…")
+    expect(activity).toHaveTextContent("Pi · Thinking…")
+  })
+
   it("copies the ordinary Agent invite only through the popover action, without a provider claim", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -10,6 +10,7 @@ import { LiveTranscriptControl, LiveTranscriptSegments } from "./LiveTranscript"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
+import { agentActivityLabel } from "../common/agentActivity"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
 import { buildTaskProjections, roomMessagesForView } from "../common/taskViews"
 import {
@@ -163,6 +164,7 @@ export default function RoomContent({
     runtimeConnectionStatus,
     leaveRoom,
     localParticipantId,
+    agentActivities,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
   })
@@ -179,6 +181,27 @@ export default function RoomContent({
   const interactionMessages = activeTask
     ? activeTask.messages
     : roomMessagesForView(messages)
+  const activeTaskActivity = activeTask
+    ? (agentActivities ?? []).find(
+        (activity) =>
+          activity.scopeId === `task:${activeTask.requestId}` &&
+          [
+            activeTask.targetParticipantId,
+            activeTask.createdByParticipantId,
+          ].includes(activity.agentParticipantId) &&
+          participants.some(
+            (participant) =>
+              participant.peerId === activity.agentParticipantId &&
+              participant.kind === "agent"
+          )
+      )
+    : undefined
+  const activeTaskActivityAgent = activeTaskActivity
+    ? participants.find(
+        (participant) =>
+          participant.peerId === activeTaskActivity.agentParticipantId
+      )
+    : undefined
 
   useEffect(() => {
     const pending = pendingLocalTaskSummaries.current
@@ -911,6 +934,15 @@ export default function RoomContent({
             ))}
           </div>
           <div className="min-h-0 flex-1">
+            {activeTaskActivity && (
+              <div
+                data-testid="task-agent-activity"
+                className="border-b border-gray-800 bg-gray-950/40 px-3 py-1.5 text-xs text-blue-200/80"
+              >
+                {activeTaskActivityAgent?.name ?? "Agent"} ·{" "}
+                {agentActivityLabel(activeTaskActivity.state)}…
+              </div>
+            )}
             <TextChatCard
               key={activeInteraction}
               room={roomName}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -181,27 +181,17 @@ export default function RoomContent({
   const interactionMessages = activeTask
     ? activeTask.messages
     : roomMessagesForView(messages)
-  const activeTaskActivity = activeTask
-    ? (agentActivities ?? []).find(
+  const activeTaskActivities = activeTask
+    ? (agentActivities ?? []).filter(
         (activity) =>
           activity.scopeId === `task:${activeTask.requestId}` &&
-          [
-            activeTask.targetParticipantId,
-            activeTask.createdByParticipantId,
-          ].includes(activity.agentParticipantId) &&
           participants.some(
             (participant) =>
               participant.peerId === activity.agentParticipantId &&
               participant.kind === "agent"
           )
       )
-    : undefined
-  const activeTaskActivityAgent = activeTaskActivity
-    ? participants.find(
-        (participant) =>
-          participant.peerId === activeTaskActivity.agentParticipantId
-      )
-    : undefined
+    : []
 
   useEffect(() => {
     const pending = pendingLocalTaskSummaries.current
@@ -934,13 +924,23 @@ export default function RoomContent({
             ))}
           </div>
           <div className="min-h-0 flex-1">
-            {activeTaskActivity && (
+            {activeTaskActivities.length > 0 && (
               <div
                 data-testid="task-agent-activity"
-                className="border-b border-gray-800 bg-gray-950/40 px-3 py-1.5 text-xs text-blue-200/80"
+                className="flex flex-wrap gap-x-3 gap-y-1 border-b border-gray-800 bg-gray-950/40 px-3 py-1.5 text-xs text-blue-200/80"
               >
-                {activeTaskActivityAgent?.name ?? "Agent"} ·{" "}
-                {agentActivityLabel(activeTaskActivity.state)}…
+                {activeTaskActivities.map((activity) => {
+                  const participant = participants.find(
+                    (candidate) =>
+                      candidate.peerId === activity.agentParticipantId
+                  )
+                  return (
+                    <span key={activity.agentParticipantId}>
+                      {participant?.name ?? "Agent"} ·{" "}
+                      {agentActivityLabel(activity.state)}…
+                    </span>
+                  )
+                })}
               </div>
             )}
             <TextChatCard

--- a/app/src/components/UserCard.agentVoice.test.tsx
+++ b/app/src/components/UserCard.agentVoice.test.tsx
@@ -17,6 +17,13 @@ function card(overrides: Record<string, unknown> = {}) {
 }
 
 describe("UserCard Agent Voice", () => {
+  it("renders only the coarse transient Agent activity label", () => {
+    const { getByTestId } = render(
+      <UserCard {...card({ activity: "using_tools" })} />
+    )
+    expect(getByTestId("agent-activity")).toHaveTextContent("Using tools")
+  })
+
   it("shows an accessible per-Agent enable control", () => {
     const props = card()
     const { getByRole } = render(<UserCard {...props} />)

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 
+import { agentActivityLabel } from "../common/agentActivity"
 import { UserInfo } from "../common/types"
 import AudioVisualizer from "../components/AudioVisualizer"
 import ParticipantAvatar from "../components/ParticipantAvatar"
@@ -95,6 +96,14 @@ function UserCard(user: UserCardProps) {
           {user.kind === "agent" && (
             <span className="participant-card__kind mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
               🤖 Agent
+            </span>
+          )}
+          {user.kind === "agent" && user.activity && (
+            <span
+              data-testid="agent-activity"
+              className="mt-1 max-w-full truncate text-[9px] text-blue-200/80"
+            >
+              {agentActivityLabel(user.activity)}…
             </span>
           )}
           {user.kind === "agent" && user.voiceAvailable && (
@@ -273,6 +282,14 @@ function UserCard(user: UserCardProps) {
           <span className="participant-card__kind rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
             {user.kind === "agent" ? "🤖 Agent" : "Human"}
           </span>
+          {user.kind === "agent" && user.activity && (
+            <span
+              data-testid="agent-activity"
+              className="text-[10px] text-blue-200/80"
+            >
+              {agentActivityLabel(user.activity)}…
+            </span>
+          )}
           {user.kind === "agent" && user.voiceAvailable && (
             <button
               type="button"

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1443,6 +1443,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     // A recycled room name must not inherit collaboration bookkeeping from
     // the expired generation (stale requestIds could suppress new ones).
     this.resetCollabTracking()
+    // Activity is transient in-memory state. Clear it at the same generation
+    // boundary so an expired Room cannot consume capacity in its replacement.
+    this.transientAgentActivities.clear()
     // Best-effort, single attempt only — deliberately not retried through
     // the usual pendingMediaCleanup/alarm mechanism like the other
     // revocation sites: room expiry only fires for an *empty* room (see

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1,6 +1,11 @@
 import { DurableObject } from "cloudflare:workers"
 
 import {
+  agentActivityKey,
+  isAgentActivityScope,
+  isAgentActivityState,
+} from "./agentActivity"
+import {
   agentCapabilitiesFrom,
   CollabRegistry,
   COLLAB_ACTION_TYPE,
@@ -139,6 +144,7 @@ import type {
   PermissionEvent,
   PermissionRequestRecord,
   RuntimeHostProjection,
+  AgentActivityProjection,
 } from "../room/types"
 
 const RECONNECT_GRACE_MS = 30 * 1000
@@ -164,6 +170,7 @@ const RESIDENT_EVENT_MAX_BYTES = 2 << 20
 // silently truncating older, still-active mids — see the
 // "agent-track-subscribed" action.
 const MAX_AGENT_SUBSCRIBED_MIDS = 64
+const MAX_AGENT_ACTIVITY_ENTRIES = 64
 // How soon to retry a failed Cloudflare tracks/close call (Blocker 1): must
 // be much sooner than the lease/reconnect-driven alarm deadlines that
 // otherwise dominate scheduleNextAlarm(), since a stuck pending cleanup
@@ -557,6 +564,15 @@ type ControlRequest =
       transcriptLimit?: number
     }
   | {
+      // Runtime-only coarse Harness activity. This is transient in-memory
+      // state: it never enters RoomRecord, the message ring, or waiters.
+      action: "agent-activity"
+      participantId: string
+      token: string
+      scopeId: unknown
+      activity: unknown
+    }
+  | {
       action: "agent-media-attach"
       participantId: string
       token: string
@@ -687,6 +703,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   // after an eviction/restart (collabRebuilt flag below).
   private readonly collabRegistry = new CollabRegistry()
   private collabRebuilt = false
+  private readonly transientAgentActivities = new Map<
+    string,
+    AgentActivityProjection
+  >()
 
   // Correlation must never leak across room generations on the same DO
   // instance (a recycled room name after expiry would otherwise inherit
@@ -1271,6 +1291,16 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       meetingNotesMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
       agentVoice: room.agentVoice,
       agentVoiceMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+      agentActivities: [...this.transientAgentActivities.values()].filter(
+        (activity) => room.participants[activity.agentParticipantId]?.connected
+      ),
+    }
+  }
+
+  private clearAgentActivitiesForParticipant(participantId: string): void {
+    for (const [key, activity] of this.transientAgentActivities) {
+      if (activity.agentParticipantId === participantId)
+        this.transientAgentActivities.delete(key)
     }
   }
 
@@ -2189,6 +2219,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participant.connected = false
     participant.connectionNonce = undefined
     participant.lastSeenAt = Date.now()
+    this.clearAgentActivitiesForParticipant(participant.id)
     await this.saveRoom(room)
     await this.scheduleNextAlarm(room)
     await this.broadcastState(room)
@@ -2234,6 +2265,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       }
     }
     const wasConnected = participant.connected
+    // A reconnect is a fresh transient-activity boundary. Do not replay a
+    // state that belonged to the replaced resident socket.
+    this.clearAgentActivitiesForParticipant(participant.id)
     const connectionNonce = crypto.randomUUID()
     participant.connected = true
     participant.connectionNonce = connectionNonce
@@ -2455,6 +2489,71 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
 
     if (request.action === "agent-wait") return this.waitForAgent(request)
+
+    if (request.action === "agent-activity") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      if (participant.kind !== "agent")
+        return this.json({ error: "agent_only" }, 403)
+      if (!isAgentActivityScope(request.scopeId))
+        return this.json({ error: "invalid_activity_scope" }, 400)
+      const activityState = request.activity
+      let normalizedActivity: AgentActivityProjection["state"] | null
+      if (activityState === null) normalizedActivity = null
+      else if (isAgentActivityState(activityState))
+        normalizedActivity = activityState
+      else return this.json({ error: "invalid_activity_state" }, 400)
+      if (normalizedActivity !== null && !participant.connected)
+        return this.json({ error: "agent_disconnected" }, 409)
+
+      if (request.scopeId.startsWith("task:")) {
+        const resolution = resolveTaskRequest(
+          buildTaskProjectionIndex(room.messages, room.participants),
+          request.scopeId.slice("task:".length),
+          room.participants
+        )
+        if (
+          resolution.ok === false ||
+          !resolution.agentParticipantIds.includes(participant.id)
+        )
+          return this.json({ error: "invalid_activity_scope" }, 403)
+      }
+
+      const key = agentActivityKey(participant.id, request.scopeId)
+      const previous = this.transientAgentActivities.get(key)
+      if (normalizedActivity === null) {
+        if (!previous) return this.json({ ok: true, changed: false })
+        this.transientAgentActivities.delete(key)
+        await this.broadcast({
+          type: "agentActivity",
+          activity: null,
+          agentParticipantId: participant.id,
+          scopeId: request.scopeId,
+        })
+        return this.json({ ok: true, changed: true })
+      }
+      if (previous?.state === normalizedActivity)
+        return this.json({ ok: true, changed: false })
+      if (
+        !previous &&
+        this.transientAgentActivities.size >= MAX_AGENT_ACTIVITY_ENTRIES
+      )
+        return this.json({ error: "activity_capacity" }, 429)
+      const activity: AgentActivityProjection = {
+        agentParticipantId: participant.id,
+        scopeId: request.scopeId,
+        state: normalizedActivity,
+      }
+      this.transientAgentActivities.set(key, activity)
+      await this.broadcast({ type: "agentActivity", activity })
+      return this.json({ ok: true, changed: true })
+    }
 
     if (request.action === "agent-read-context") {
       const room = await this.activeRoom()
@@ -3764,6 +3863,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         this.stageAgentMediaRevocation(room, participant.id, "subscribed")
       this.expirePermissionRequests(room, Date.now(), participant.id)
       const departingSurface = participant.surface
+      this.clearAgentActivitiesForParticipant(participant.id)
       delete room.participants[participant.id]
       this.garbageCollectRuntimeHostAuthorization(room)
       const pendingDuration = this.updateCollaborationActivity(room)
@@ -4190,6 +4290,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     this.stageMediaGrantRevocations(room, grantTransition.revocations)
     if (participant.kind === "agent")
       this.expirePermissionRequests(room, Date.now(), participant.id)
+    if (participant.kind === "agent")
+      this.clearAgentActivitiesForParticipant(participant.id)
     if (participant.kind === "human")
       this.removeRuntimeHostProviderAuthorizationForHuman(room, participant.id)
     delete room.participants[participant.id]
@@ -5530,6 +5632,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           permissionExpired = true
           changed = true
         }
+        if (expiredAgent) this.clearAgentActivitiesForParticipant(id)
         delete room.participants[id]
         this.garbageCollectRuntimeHostAuthorization(room)
         const pendingDuration = this.updateCollaborationActivity(room)

--- a/app/src/do/agentActivity.ts
+++ b/app/src/do/agentActivity.ts
@@ -1,0 +1,33 @@
+import type { AgentActivityState } from "../room/types"
+
+export const AGENT_ACTIVITY_STATES = [
+  "working",
+  "thinking",
+  "using_tools",
+  "responding",
+] as const satisfies readonly AgentActivityState[]
+
+export const MAX_AGENT_ACTIVITY_SCOPE_LENGTH = 128
+const TASK_SCOPE_PATTERN = /^task:[A-Za-z0-9][A-Za-z0-9._:-]{3,63}$/
+
+export function isAgentActivityState(
+  value: unknown
+): value is AgentActivityState {
+  return (
+    typeof value === "string" &&
+    (AGENT_ACTIVITY_STATES as readonly string[]).includes(value)
+  )
+}
+
+export function isAgentActivityScope(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_AGENT_ACTIVITY_SCOPE_LENGTH &&
+    (value === "room" || TASK_SCOPE_PATTERN.test(value))
+  )
+}
+
+export function agentActivityKey(agentParticipantId: string, scopeId: string) {
+  return `${agentParticipantId}\u0000${scopeId}`
+}

--- a/app/src/do/roomSessionAgentActivity.test.ts
+++ b/app/src/do/roomSessionAgentActivity.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+
+function makeRoom() {
+  const now = Date.now()
+  return {
+    createdAt: now,
+    expiresAt: now + 60_000,
+    participants: {
+      human: {
+        id: "human",
+        name: "Human",
+        kind: "human",
+        connected: true,
+        joinedAt: now,
+        lastSeenAt: now,
+        token: "human-token",
+      },
+      agentT: {
+        id: "agentT",
+        name: "Agent T",
+        kind: "agent",
+        connected: true,
+        joinedAt: now,
+        lastSeenAt: now,
+        token: "agentT-token",
+      },
+      agentU: {
+        id: "agentU",
+        name: "Agent U",
+        kind: "agent",
+        connected: true,
+        joinedAt: now,
+        lastSeenAt: now,
+        token: "agentU-token",
+      },
+    },
+    messages: [
+      {
+        id: "request-message",
+        peerId: "human",
+        name: "Human",
+        kind: "human",
+        type: "action",
+        actionType: "collab",
+        sequence: 1,
+        createdAt: now,
+        collab: {
+          requestId: "request-1",
+          kind: "request",
+          fromParticipantId: "human",
+          targetParticipantId: "agentT",
+          summary: "Task T",
+        },
+        targets: ["agentT"],
+      },
+    ],
+    nextMessageSequence: 1,
+    liveTranscript: { active: false },
+    liveTranscriptSegments: [],
+    nextLiveTranscriptEpoch: 1,
+    nextTranscriptSequence: 1,
+    attachments: [],
+    meetingNotes: { active: false },
+    agentVoice: {},
+    pendingMediaCleanup: [],
+  }
+}
+
+function harness() {
+  const stored = makeRoom()
+  const store = new Map<string, unknown>([["room", stored]])
+  const ctx = {
+    storage: {
+      get: async (key: string) => store.get(key),
+      put: async (key: string, value: unknown) => void store.set(key, value),
+      delete: async () => undefined,
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+    getWebSockets: () => [] as WebSocket[],
+  }
+  const session = new RoomSession(ctx as never, { SFU_ROOM: {} } as never)
+  const control = async (body: Record<string, unknown>) => {
+    const response = await session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    )
+    return { status: response.status, json: await response.json() }
+  }
+  return { session, control, store }
+}
+
+describe("RoomSession transient Agent activity", () => {
+  it("authenticates task ownership, coalesces states, and never persists activity", async () => {
+    const room = harness()
+    const working = await room.control({
+      action: "agent-activity",
+      participantId: "agentT",
+      token: "agentT-token",
+      scopeId: "task:request-1",
+      activity: "working",
+    })
+    expect(working).toMatchObject({ status: 200, json: { changed: true } })
+    const duplicate = await room.control({
+      action: "agent-activity",
+      participantId: "agentT",
+      token: "agentT-token",
+      scopeId: "task:request-1",
+      activity: "working",
+    })
+    expect(duplicate).toMatchObject({ status: 200, json: { changed: false } })
+    const thinking = await room.control({
+      action: "agent-activity",
+      participantId: "agentT",
+      token: "agentT-token",
+      scopeId: "task:request-1",
+      activity: "thinking",
+    })
+    expect(thinking.status).toBe(200)
+    const clear = await room.control({
+      action: "agent-activity",
+      participantId: "agentT",
+      token: "agentT-token",
+      scopeId: "task:request-1",
+      activity: null,
+    })
+    expect(clear).toMatchObject({ status: 200, json: { changed: true } })
+    expect((room.session as any).transientAgentActivities.size).toBe(0)
+    expect((room.store.get("room") as any).messages).toHaveLength(1)
+  })
+
+  it("rejects another Agent's task scope and invalid authentication", async () => {
+    const room = harness()
+    const wrongAgent = await room.control({
+      action: "agent-activity",
+      participantId: "agentU",
+      token: "agentU-token",
+      scopeId: "task:request-1",
+      activity: "working",
+    })
+    expect(wrongAgent.status).toBe(403)
+    const wrongToken = await room.control({
+      action: "agent-activity",
+      participantId: "agentT",
+      token: "wrong",
+      scopeId: "room",
+      activity: "working",
+    })
+    expect(wrongToken.status).toBe(401)
+    const human = await room.control({
+      action: "agent-activity",
+      participantId: "human",
+      token: "human-token",
+      scopeId: "room",
+      activity: "working",
+    })
+    expect(human.status).toBe(403)
+  })
+})

--- a/app/src/do/roomSessionLifecycle.test.ts
+++ b/app/src/do/roomSessionLifecycle.test.ts
@@ -252,6 +252,15 @@ describe("RoomSession expiry cleanup", () => {
 
   it("allows a fresh create to start without any prior-generation keys", async () => {
     const { session, room, store } = lifecycleHarness()
+    ;(
+      session as unknown as {
+        transientAgentActivities: Map<string, unknown>
+      }
+    ).transientAgentActivities.set("old-agent:room", {
+      agentParticipantId: "agent",
+      scopeId: "room",
+      state: "thinking",
+    })
     await (
       session as unknown as {
         expireRoom: (room: RoomRecord) => Promise<void>
@@ -280,6 +289,13 @@ describe("RoomSession expiry cleanup", () => {
     expect(fresh.messages).toEqual([])
     expect(store.get("live-transcript")).not.toEqual({ stale: true })
     expect(store.has("future-unknown-key")).toBe(false)
+    expect(
+      (
+        session as unknown as {
+          transientAgentActivities: Map<string, unknown>
+        }
+      ).transientAgentActivities.size
+    ).toBe(0)
   })
 
   it("does not expire waiters or sockets from a recycled Room generation", async () => {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -27,6 +27,7 @@ import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 import type {
   LiveTranscriptSegment,
   LiveTranscriptState,
+  AgentActivityProjection,
   RoomAttachmentProjection,
   RoomAttachmentRead,
   RuntimeHostProjection,
@@ -408,6 +409,7 @@ interface SfuServerMessage {
     | "expired"
     | "error"
     | "runtime-provider-claim-created"
+    | "agentActivity"
   state?: SfuRoomState
   attachment?: RoomAttachmentProjection
   participant?: Partial<SfuParticipant> & {
@@ -420,6 +422,9 @@ interface SfuServerMessage {
   error?: string
   requestId?: string
   expiresAt?: number
+  activity?: AgentActivityProjection | null
+  agentParticipantId?: string
+  scopeId?: string
 }
 
 const roomMessageToMessage = (
@@ -488,12 +493,16 @@ export function useSfuChatRoom(
   const [agentVoice, setAgentVoiceState] = useState<SfuAgentVoiceState>({})
   const [agentVoiceMediaAvailable, setAgentVoiceMediaAvailable] =
     useState(false)
+  const [agentActivities, setAgentActivities] = useState<
+    AgentActivityProjection[]
+  >([])
   const [runtimeConnectionStatus, setRuntimeConnectionStatus] = useState<
     "idle" | "preparing" | "copied"
   >("idle")
 
   const sessionRef = useRef<SfuSession | null>(null)
   const roomStateRef = useRef<SfuRoomState | null>(null)
+  const agentActivitiesRef = useRef<AgentActivityProjection[]>([])
   const websocketRef = useRef<WebSocket | null>(null)
   const peerConnectionRef = useRef<RTCPeerConnection | null>(null)
   const localAudioTrackRef = useRef<MediaStreamTrack | null>(null)
@@ -679,6 +688,14 @@ export function useSfuChatRoom(
         voiceEnabled:
           participant.kind === "agent" &&
           state?.agentVoice?.[participant.id]?.enabled === true,
+        activity:
+          participant.kind === "agent"
+            ? agentActivitiesRef.current.find(
+                (activity) =>
+                  activity.agentParticipantId === participant.id &&
+                  activity.scopeId === "room"
+              )?.state
+            : undefined,
         audioStream: remoteAudioStreamsRef.current.get(participant.id) ?? null,
         screenShareEnabled: hasScreenShare,
         screenShareStream:
@@ -2232,6 +2249,9 @@ export function useSfuChatRoom(
       setLiveTranscriptMediaAvailable(state.meetingNotesMediaAvailable)
       setAgentVoiceState(state.agentVoice)
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
+      const nextActivities = state.agentActivities ?? []
+      agentActivitiesRef.current = nextActivities
+      setAgentActivities(nextActivities)
       const localParticipantId = sessionRef.current?.participantId
       const currentParticipantIds = new Set(
         state.participants.map((participant) => participant.id)
@@ -2435,6 +2455,34 @@ export function useSfuChatRoom(
       const message = JSON.parse(event.data) as SfuServerMessage
       if (message.type === "state" && message.state) {
         applyRoomState(message.state)
+      } else if (message.type === "agentActivity") {
+        if (message.activity) {
+          const next = [
+            ...agentActivitiesRef.current.filter(
+              (activity) =>
+                !(
+                  activity.agentParticipantId ===
+                    message.activity!.agentParticipantId &&
+                  activity.scopeId === message.activity!.scopeId
+                )
+            ),
+            message.activity,
+          ]
+          agentActivitiesRef.current = next
+          setAgentActivities(next)
+          rebuildParticipants()
+        } else if (message.agentParticipantId && message.scopeId) {
+          const next = agentActivitiesRef.current.filter(
+            (activity) =>
+              !(
+                activity.agentParticipantId === message.agentParticipantId &&
+                activity.scopeId === message.scopeId
+              )
+          )
+          agentActivitiesRef.current = next
+          setAgentActivities(next)
+          rebuildParticipants()
+        }
       } else if (
         message.type === "trackPublished" &&
         message.participant?.track
@@ -3398,6 +3446,7 @@ export function useSfuChatRoom(
     leaveRoom,
     agentVoice,
     agentVoiceMediaAvailable,
+    agentActivities,
     setAgentVoice,
     createRuntimeProviderClaim,
     connectLocalRuntime,

--- a/app/src/room/server.agentActivity.test.ts
+++ b/app/src/room/server.agentActivity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  handleRoomRequest,
+  isRoomRequestPath,
+  type RoomProtocolEnv,
+} from "./server"
+
+describe("Runtime Agent activity route", () => {
+  it("keeps the route on the Worker protocol allowlist and forwards only its bounded body", async () => {
+    let forwarded: { body: Record<string, unknown>; url: string } | undefined
+    const env = {
+      SFU_ROOM: {
+        idFromName: (name: string) => ({ name }),
+        get: () => ({
+          fetch: async (url: string | URL, init?: RequestInit) => {
+            forwarded = {
+              url: String(url),
+              body: JSON.parse(String(init?.body ?? "{}")) as Record<
+                string,
+                unknown
+              >,
+            }
+            return Response.json({ ok: true })
+          },
+        }),
+      },
+    } as unknown as RoomProtocolEnv
+
+    expect(isRoomRequestPath("/api/room/agent-activity")).toBe(true)
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/agent-activity", {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+          "X-Room-Id": "room-1",
+          "X-Room-Participant-Id": "agent-1",
+          "X-Room-Participant-Token": "private-token",
+        },
+        body: JSON.stringify({ scopeId: "task:req-1", activity: "thinking" }),
+      }),
+      env
+    )
+    expect(response.status).toBe(200)
+    expect(forwarded).toEqual({
+      url: "https://room/control",
+      body: {
+        action: "agent-activity",
+        participantId: "agent-1",
+        token: "private-token",
+        scopeId: "task:req-1",
+        activity: "thinking",
+      },
+    })
+  })
+
+  it("rejects the wrong method before touching the Durable Object", async () => {
+    const env = {
+      SFU_ROOM: {
+        idFromName: () => ({}),
+        get: () => ({
+          fetch: () => Promise.reject(new Error("must not call DO")),
+        }),
+      },
+    } as unknown as RoomProtocolEnv
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/agent-activity", {
+        method: "GET",
+        headers: { Origin: "http://localhost:3000" },
+      }),
+      env
+    )
+    expect(response.status).toBe(405)
+  })
+})

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -7,10 +7,12 @@ const MAX_ROOM_LENGTH = 64
 const MAX_AGENT_ATTACHMENT_BYTES = 768 * 1024
 const MAX_PERMISSION_REQUEST_BODY_BYTES = 64 * 1024
 const AGENT_EVENT_PATH = "/api/room/agent-events"
+const AGENT_ACTIVITY_PATH = "/api/room/agent-activity"
 const ROOM_REQUEST_PATHS = new Set([
   "/api/room/attachments",
   "/api/room/live-transcript/append",
   AGENT_EVENT_PATH,
+  AGENT_ACTIVITY_PATH,
   "/api/room/permissions/request",
   "/api/room/runtime-provider/connect",
   "/api/room/surfaces/read",
@@ -91,6 +93,45 @@ export async function handleRoomRequest(
     const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
     const doRequest = new Request("https://room/agent-events", request)
     return stub.fetch(doRequest)
+  }
+
+  // Runtime-only coarse Harness activity. This is intentionally a tiny
+  // authenticated control request rather than a reverse resident WebSocket
+  // protocol: the body carries only a scope and one enum, and the DO keeps it
+  // transient without waking Agents or writing the Room message log.
+  if (pathname === AGENT_ACTIVITY_PATH) {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const room = request.headers.get("X-Room-Id")?.trim() ?? ""
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    if (!room || room.length > MAX_ROOM_LENGTH || !participantId || !token)
+      return json({ error: "missing_room_capability" }, 400)
+    const declaredSize = Number(request.headers.get("Content-Length") ?? "0")
+    if (declaredSize > 4096) return json({ error: "request_too_large" }, 413)
+    let body: { scopeId?: unknown; activity?: unknown }
+    try {
+      const bytes = new Uint8Array(await request.arrayBuffer())
+      if (bytes.byteLength > 4096)
+        return json({ error: "request_too_large" }, 413)
+      body = JSON.parse(new TextDecoder().decode(bytes)) as typeof body
+    } catch {
+      return json({ error: "invalid_request" }, 400)
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body))
+      return json({ error: "invalid_request" }, 400)
+    const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+    return stub.fetch("https://room/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "agent-activity",
+        participantId,
+        token,
+        scopeId: body.scopeId,
+        activity: body.activity ?? null,
+      }),
+    })
   }
 
   // Runtime-only control transport for a committed STT result. This is not

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -1,5 +1,17 @@
 export type ParticipantKind = "human" | "agent"
 
+export type AgentActivityState =
+  | "working"
+  | "thinking"
+  | "using_tools"
+  | "responding"
+
+export interface AgentActivityProjection {
+  agentParticipantId: string
+  scopeId: string
+  state: AgentActivityState
+}
+
 export type RoomMediaTrackKind = "audio" | "video"
 
 export interface RoomMediaTrack {
@@ -420,6 +432,9 @@ export interface RoomState {
   // room-visible grant.
   meetingNotesMediaAvailable: boolean
   agentVoice: AgentVoiceState
+  // Transient coarse Runtime activity. This is kept outside RoomRecord and
+  // disappears on Runtime disconnect or Durable Object restart.
+  agentActivities?: AgentActivityProjection[]
   // Coarse Worker media admission switch. Per-Agent UI availability still
   // comes from the Runtime Host's TTS readiness, never from this field.
   agentVoiceMediaAvailable: boolean


### PR DESCRIPTION
## Summary

- project coarse transient Agent activity (`Working`, `Thinking`, `Using tools`, `Responding`) from the canonical Go ACP Runtime into the Room UI
- keep activity scoped to the authenticated Agent and `room` / owned `task:<requestId>` scope
- add the narrow authenticated Runtime-to-Room activity control route, including the Worker route allowlist entry
- keep activity in transient DO memory only; it does not enter the Room message log, resident event stream, Harness wakeup path, or analytics
- clear activity on turn completion/failure, Harness failure, Runtime stop, resident stream loss, reconnect, Agent departure, and lease expiry
- preserve serialized Harness turns, existing media event-loop behavior, and the PR #317 no-polling design

## Validation

- `cd app && yarn test` — 78 files, 686 tests passed
- `cd app && yarn type-check` — passed
- `cd app && yarn eslint src --no-fix` — passed
- `cd app && yarn prettier --check .` — passed
- `cd app && yarn docs:check` — passed
- `cd app && yarn cf-build` — passed
- `cd agent && go test ./... -count=1` — passed
- `cd agent && go vet ./...` — passed
- `cd agent && go build ./...` — passed
