### PR TITLE
chore(agent): bump runtime version to 0.5.28

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.27"
+var Version = "0.5.28"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary\n\n- bump the canonical Go Agent Runtime version to 0.5.28\n- prepare the merged #328 runtime for the official four-target release\n\n## Validation\n\n- go test ./... -count=1\n- go vet ./...\n- go build ./...\n- release, bootstrap, cleanup, and installer contract checks\n- four-target release artifacts and SHA256SUMS\n