### PR TITLE
docs(agent): activate runtime version 0.5.28 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -316,7 +316,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.27` (release tag `agent-v0.5.27`).
+`0.5.28` (release tag `agent-v0.5.28`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -377,7 +377,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.27"
+expected_version="0.5.28"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1825,7 +1825,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.27` (release tag `agent-v0.5.27`).
+`0.5.28` (release tag `agent-v0.5.28`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1886,7 +1886,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.27"
+expected_version="0.5.28"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary\n\n- pin the public Agent bootstrap contract to released Runtime 0.5.28\n- refresh the generated llms-full contract copy\n\nThe 0.5.28 GitHub Release is published and checksum-verified.\n\n## Validation\n\n- App tests: 78 files / 687 tests passed\n- type-check passed\n- ESLint passed\n- Prettier passed\n- docs:check passed\n- post-merge production build will be verified by CI\n