### PR TITLE
chore(agent): activate runtime v0.5.29 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -316,7 +316,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.28` (release tag `agent-v0.5.28`).
+`0.5.29` (release tag `agent-v0.5.29`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -377,7 +377,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.28"
+expected_version="0.5.29"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1825,7 +1825,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.28` (release tag `agent-v0.5.28`).
+`0.5.29` (release tag `agent-v0.5.29`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1886,7 +1886,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.28"
+expected_version="0.5.29"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary\n\nActivate the already-published and verified Agent Runtime v0.5.29 for fresh production bootstrap.\n\nUpdated:\n- app/public/agent.md release/version pin\n- generated app/public/llms-full.txt\n\nNo Runtime code, route, permission, or product behavior changes are included.\n\n## Release verification\n\n- merged source commit: 69237f4c57da47a0d5e9e27f9541ec7b7b84967b\n- native tag: agent-v0.5.29\n- GitHub Release contains darwin-arm64, darwin-amd64, linux-arm64, linux-amd64, and SHA256SUMS\n- darwin-arm64 checksum verified\n- published binary doctor --json reports version 0.5.29 and runtime go\n\n## Validation\n\n- bash agent/scripts/test-bootstrap-contract.sh\n- cd app && yarn docs:check\n- cd app && yarn test\n- cd app && yarn type-check\n- cd app && yarn eslint src --no-fix\n- cd app && yarn prettier --check .\n- cd app && yarn cf-build\n