### PR TITLE
fix(task): preserve pending permission delivery across root eviction

### DIFF
--- a/app/src/do/roomSessionPermission.test.ts
+++ b/app/src/do/roomSessionPermission.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { RoomSession } from "./RoomSession"
+import { buildTaskProjectionIndex, resolveTaskRequest } from "./taskScope"
 
 const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
 
@@ -136,6 +137,7 @@ function makeRoomSession() {
       messages: Array<Record<string, unknown>>
       permissionRequests?: Record<string, Record<string, unknown>>
       nextMessageSequence: number
+      participants: Record<string, Record<string, unknown>>
     }
   const agentWait = async (participantId: string, cursor = 0) =>
     control({
@@ -384,6 +386,129 @@ describe("RoomSession structured permission lifecycle (#286)", () => {
       kind: "resolved",
       selectedOptionId: "allow-once",
     })
+  })
+
+  it("delivers an admitted Task permission after the Task root is evicted", async () => {
+    const room = makeRoomSession()
+    await room.sendHuman("human-1", {
+      type: "collab-request",
+      targetParticipantId: "agent-a",
+      summary: "Task T",
+    })
+    const taskRequestId = collabRequestId(room.storedRoom().messages[0])
+    if (typeof taskRequestId !== "string")
+      throw new Error("Task was not created")
+
+    await room.requestPermission("agent-a", "permission-evicted", taskRequestId)
+    for (let index = 0; index < 101; index += 1) {
+      const result = await room.control({
+        action: "agent-send-text",
+        participantId: "agent-a",
+        token: "tok-agent-a",
+        text: `eviction-${index}`,
+      })
+      expect(result.status).toBe(200)
+    }
+
+    const stored = room.storedRoom()
+    expect(stored.messages.some((message) => message.collab)).toBe(false)
+    const projection = buildTaskProjectionIndex(
+      stored.messages as never,
+      stored.participants as never
+    )
+    expect(
+      resolveTaskRequest(
+        projection,
+        taskRequestId,
+        stored.participants as never
+      )
+    ).toEqual({
+      ok: false,
+      error: "unknown_task_request",
+    })
+
+    await room.sendHuman("human-1", {
+      type: "permission-response",
+      requestId: "permission-evicted",
+      selectedOptionId: "allow-once",
+    })
+    const target = await room.agentWait("agent-a")
+    expect(target.json.events).toContainEqual(
+      expect.objectContaining({
+        scopeId: `task:${taskRequestId}`,
+        addressed: true,
+        permission: expect.objectContaining({
+          requestId: "permission-evicted",
+          kind: "resolved",
+          selectedOptionId: "allow-once",
+        }),
+      })
+    )
+    expect(room.storedRoom().permissionRequests).toEqual({})
+
+    const unrelated = await room.agentWait("agent-b")
+    expect(
+      (unrelated.json.events as Array<Record<string, unknown>>).some(
+        (event) => event.permission !== undefined
+      )
+    ).toBe(false)
+  })
+
+  it("delivers Deny and expiry terminals through the same evicted Task correlation", async () => {
+    for (const [permissionId, selectedOptionId] of [
+      ["permission-deny", "deny"],
+      ["permission-expired", undefined],
+    ] as const) {
+      const room = makeRoomSession()
+      await room.sendHuman("human-1", {
+        type: "collab-request",
+        targetParticipantId: "agent-a",
+        summary: "Task T",
+      })
+      const taskRequestId = collabRequestId(room.storedRoom().messages[0])
+      if (typeof taskRequestId !== "string")
+        throw new Error("Task was not created")
+      await room.requestPermission("agent-a", permissionId, taskRequestId)
+      for (let index = 0; index < 101; index += 1) {
+        const result = await room.control({
+          action: "agent-send-text",
+          participantId: "agent-a",
+          token: "tok-agent-a",
+          text: `eviction-${index}`,
+        })
+        expect(result.status).toBe(200)
+      }
+
+      if (selectedOptionId !== undefined) {
+        await room.sendHuman("human-1", {
+          type: "permission-response",
+          requestId: permissionId,
+          selectedOptionId,
+        })
+      } else {
+        const pending = room.storedRoom().permissionRequests?.[permissionId]
+        ;(pending?.event as Record<string, unknown>).expiresAt = Date.now() - 1
+        await room.roomSession.alarm()
+      }
+
+      const target = await room.agentWait("agent-a")
+      expect(target.json.events).toContainEqual(
+        expect.objectContaining({
+          scopeId: `task:${taskRequestId}`,
+          permission: expect.objectContaining({
+            requestId: permissionId,
+            kind: selectedOptionId === undefined ? "expired" : "resolved",
+            ...(selectedOptionId === undefined ? {} : { selectedOptionId }),
+          }),
+        })
+      )
+      const unrelated = await room.agentWait("agent-b")
+      expect(
+        (unrelated.json.events as Array<Record<string, unknown>>).some(
+          (event) => event.permission !== undefined
+        )
+      ).toBe(false)
+    }
   })
 
   it("derives the Agent identity from authentication and exposes the request to Humans", async () => {

--- a/app/src/do/taskScope.test.ts
+++ b/app/src/do/taskScope.test.ts
@@ -190,6 +190,59 @@ describe("Task scope projection", () => {
     }
   })
 
+  it("delivers only an admitted permission terminal to its originating Agent after eviction", () => {
+    const terminal: RoomMessage = {
+      id: "permission-terminal",
+      peerId: "human",
+      name: "human",
+      kind: "human",
+      type: "action",
+      actionType: "permission",
+      taskRequestId: "task-T",
+      permission: {
+        requestId: "task-T-permission",
+        kind: "resolved",
+        agentParticipantId: "agent-a",
+        selectedOptionId: "allow-once",
+        humanParticipantId: "human",
+        humanName: "human",
+        createdAt: 10,
+        expiresAt: 100,
+      },
+      targets: ["agent-a"],
+      createdAt: 10,
+      sequence: 10,
+    }
+    const index = buildTaskProjectionIndex([], participants())
+
+    expect(projectTaskEvent(index, terminal, "agent-a")).toEqual({
+      kind: "task",
+      visible: true,
+      scopeId: "task:task-T",
+      addressed: true,
+    })
+    expect(projectTaskEvent(index, terminal, "agent-b")).toEqual({
+      kind: "task",
+      visible: false,
+    })
+    const requestTerminal = {
+      ...terminal,
+      permission: {
+        requestId: "task-T-permission",
+        kind: "request" as const,
+        agentParticipantId: "agent-a",
+        toolCall: { title: "Run command" },
+        options: [{ optionId: "allow-once", name: "Allow once" }],
+        createdAt: 10,
+        expiresAt: 100,
+      },
+    }
+    expect(projectTaskEvent(index, requestTerminal, "agent-a")).toEqual({
+      kind: "task",
+      visible: false,
+    })
+  })
+
   it("validates Human task targets without falling back", () => {
     const index = buildTaskProjectionIndex([request()], participants())
     const resolution = resolveTaskRequest(index, "task-T", participants())

--- a/app/src/do/taskScope.ts
+++ b/app/src/do/taskScope.ts
@@ -239,7 +239,28 @@ export function projectTaskEvent(
   // Correlation identity can only come from a retained canonical request.
   // Lifecycle envelopes whose request was evicted therefore fail closed just
   // like explicit orphaned Task text; they must never become Room context.
-  if (!task) return { kind: "task", visible: false }
+  if (!task) {
+    const permission = message.permission
+    // A permission terminal is the one narrow exception: Room can only append
+    // this structured event after a matching pending permission was admitted,
+    // and the server copies both the exact originating Agent and Task id from
+    // that record. Keep this exception scoped to that Agent and terminal
+    // lifecycle; generic orphaned Task events remain invisible.
+    if (
+      message.actionType === "permission" &&
+      permission !== undefined &&
+      (permission.kind === "resolved" || permission.kind === "expired") &&
+      permission.agentParticipantId === participantId &&
+      message.targets?.includes(participantId) === true
+    )
+      return {
+        kind: "task",
+        visible: true,
+        scopeId: `task:${requestId}`,
+        addressed: true,
+      }
+    return { kind: "task", visible: false }
+  }
 
   const participantSet = historical
     ? task.participatingAgentIds


### PR DESCRIPTION
Closes #337.

## Root cause

Task participation is intentionally reconstructed from the bounded retained Room message ring. After the canonical Task request was evicted, `projectTaskEvent()` fail-closed every correlated event, including a server-generated ACP permission resolution/expiry. A valid pending permission could therefore be decided by a Human but never delivered to its originating Agent scope.

## Fix

Add one narrow exception in the existing Task projection seam: a structured `permission` terminal (`resolved` or `expired`) with the server-preserved `taskRequestId`, exact originating `agentParticipantId`, and exact target remains visible only to that Agent as `task:<requestId>` when the Task root is gone. The terminal event can only be appended by the existing admitted pending-permission response/expiry paths.

Generic orphaned Task text and collab lifecycle events remain invisible and never fall back to Room context. No new persistence, Task store, membership state, replay framework, or Runtime change was added.

## Regression coverage

- Pushes the retained message ring beyond its 100-message bound so the canonical Task root is actually evicted.
- Allow terminal reaches the originating Agent with `task:T` and the exact native option id.
- Deny terminal follows the same exact correlation.
- Expiry terminal follows the same exact correlation.
- Agent B cannot observe or consume Agent A's result.
- Generic orphan Task text/lifecycle remains fail-closed.
- Projection can no longer resolve the evicted Task root before the permission decision.

## Validation

- App `yarn test`: 78 test files, 693 tests passed.
- App `yarn type-check`: pass.
- App `yarn eslint src --no-fix`: pass.
- App `yarn prettier --check .`: pass.
- App `yarn docs:check`: pass.
- App `yarn cf-build`: pass; existing Durable Object/dependency-copy warnings remain non-fatal.
- No Agent Runtime code changed; no Agent release was cut.

Keep this PR open and unmerged for review.
