### PR TITLE
fix(task): stabilize Task interaction UI

### DIFF
--- a/app/src/common/taskViews.test.ts
+++ b/app/src/common/taskViews.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { buildTaskProjections, roomMessagesForView } from "./taskViews"
+import {
+  buildTaskProjections,
+  roomMessagesForView,
+  taskHasConnectedAgent,
+} from "./taskViews"
 import type { Message } from "./types"
 
 const request = (requestId: string, summary: string): Message => ({
@@ -104,6 +108,29 @@ describe("task interaction projections (#309)", () => {
       },
     }
     expect(buildTaskProjections([task, terminal])[0]?.status).toBe("Completed")
+  })
+
+  it("keeps secondary Task Agents available from structured Task targets", () => {
+    const task = request("T", "Task")
+    const followUp: Message = {
+      peerId: "human",
+      name: "Human",
+      kind: "human",
+      type: "text",
+      taskRequestId: "T",
+      targets: ["agent-pi"],
+      text: "Pi, please continue this Task",
+    }
+    const projection = buildTaskProjections([task, followUp])[0]
+
+    expect(projection?.participatingAgentIds).toContain("agent-x")
+    expect(projection?.participatingAgentIds).toContain("agent-pi")
+    expect(
+      taskHasConnectedAgent(projection!, [
+        { peerId: "agent-pi", kind: "agent" },
+      ])
+    ).toBe(true)
+    expect(taskHasConnectedAgent(projection!, [])).toBe(false)
   })
 
   it("keeps Task-scoped permission lifecycle messages in the Task view", () => {

--- a/app/src/common/taskViews.ts
+++ b/app/src/common/taskViews.ts
@@ -1,4 +1,4 @@
-import type { Message } from "./types"
+import type { Message, UserInfo } from "./types"
 
 export type TaskStatus = "Starting" | "Working" | "Completed" | "Failed"
 
@@ -7,6 +7,8 @@ export interface TaskProjection {
   title: string
   createdByParticipantId: string
   targetParticipantId: string
+  /** Retained Task endpoint ids, filtered to connected Agents at render time. */
+  participatingAgentIds: string[]
   status: TaskStatus
   messages: Message[]
 }
@@ -32,6 +34,44 @@ function applyTaskLifecycle(
   }
 }
 
+function addParticipantId(ids: Set<string>, value: unknown): void {
+  if (typeof value !== "string") return
+  const participantId = value.trim()
+  if (participantId) ids.add(participantId)
+}
+
+function addTaskParticipants(ids: Set<string>, message: Message): void {
+  const collab = message.collab
+  if (collab) {
+    addParticipantId(ids, collab.fromParticipantId)
+    addParticipantId(ids, collab.targetParticipantId)
+  }
+
+  // Task text uses the same structured targets that the Room authorization
+  // projection uses. Keep the ids here and resolve their current presence at
+  // render time; a departed Agent must remain part of Task history so a
+  // returning/secondary Agent can make the Task available again.
+  if (message.taskRequestId)
+    for (const targetId of message.targets ?? [])
+      addParticipantId(ids, targetId)
+}
+
+export function isTaskTerminal(status: TaskStatus): boolean {
+  return status === "Completed" || status === "Failed"
+}
+
+export function taskHasConnectedAgent(
+  task: Pick<TaskProjection, "participatingAgentIds">,
+  participants: Pick<UserInfo, "peerId" | "kind">[]
+): boolean {
+  return task.participatingAgentIds.some((participantId) =>
+    participants.some(
+      (participant) =>
+        participant.peerId === participantId && participant.kind === "agent"
+    )
+  )
+}
+
 /**
  * Derives bounded Task views from the canonical retained Room message log.
  * This is presentation only: the Room collaboration request remains the
@@ -48,6 +88,13 @@ export function buildTaskProjections(messages: Message[]): TaskProjection[] {
         title: collab.summary ?? "Untitled task",
         createdByParticipantId: collab.fromParticipantId,
         targetParticipantId: collab.targetParticipantId,
+        participatingAgentIds: [
+          ...new Set(
+            [collab.fromParticipantId, collab.targetParticipantId].filter(
+              Boolean
+            )
+          ),
+        ],
         status: "Starting",
         messages: [message],
       })
@@ -59,6 +106,9 @@ export function buildTaskProjections(messages: Message[]): TaskProjection[] {
     const projection = projections.get(requestId)
     if (!projection) continue
     projection.messages.push(message)
+    const participants = new Set(projection.participatingAgentIds)
+    addTaskParticipants(participants, message)
+    projection.participatingAgentIds = [...participants]
     if (collab)
       projection.status = applyTaskLifecycle(projection.status, collab.kind)
   }

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -13,10 +13,11 @@ vi.mock("next/router", () => ({
 }))
 
 // Observe the long-lived analytics calls (AgentInviteCopied,
-// LiveTranscriptStarted/Stopped) without changing any other utility behavior.
+// LiveTranscriptStarted/Stopped) without allowing the browser analytics
+// fallback timer to outlive jsdom teardown.
 vi.mock("@common/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@common/utils")>()
-  return { ...actual, trackAnalyticsEvent: vi.fn() }
+  return { ...actual, trackAnalyticsEvent: vi.fn(), umamiEvent: vi.fn() }
 })
 
 const mockUseSfuChatRoom = vi.fn()

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -378,6 +378,286 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(activity).toHaveTextContent("Pi · Thinking…")
   })
 
+  it("keeps the interaction shell bounded while Task activity is visible", () => {
+    const taskRequest: Message = {
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "action",
+      actionType: "collab",
+      sequence: 1,
+      collab: {
+        requestId: "task-layout",
+        kind: "request",
+        fromParticipantId: "human-local",
+        targetParticipantId: "agent-codex",
+        summary: "Long-running task",
+      },
+    }
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [taskRequest],
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+        {
+          peerId: "agent-codex",
+          name: "Codex",
+          kind: "agent",
+          room: "test-room",
+        },
+      ],
+      agentActivities: [
+        {
+          agentParticipantId: "agent-codex",
+          scopeId: "task:task-layout",
+          state: "using_tools",
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    fireEvent.click(screen.getByTestId("interaction-tab-task-task-layout"))
+
+    expect(screen.getByTestId("interaction-tablist")).toHaveClass("flex-none")
+    expect(screen.getByTestId("interaction-content")).toHaveClass(
+      "flex",
+      "min-h-0",
+      "flex-1",
+      "flex-col"
+    )
+    expect(screen.getByTestId("task-agent-activity")).toHaveClass("flex-none")
+    expect(screen.getByTestId("interaction-chat")).toHaveClass(
+      "min-h-0",
+      "flex-1"
+    )
+  })
+
+  it("marks a non-terminal Task unavailable and disables its composer", () => {
+    const taskRequest: Message = {
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "action",
+      actionType: "collab",
+      sequence: 1,
+      collab: {
+        requestId: "task-orphan",
+        kind: "request",
+        fromParticipantId: "human-local",
+        targetParticipantId: "agent-codex",
+        summary: "Orphaned task",
+      },
+    }
+    const accepted: Message = {
+      peerId: "agent-codex",
+      name: "Codex",
+      kind: "agent",
+      type: "action",
+      actionType: "collab",
+      sequence: 2,
+      collab: {
+        requestId: "task-orphan",
+        kind: "accepted",
+        fromParticipantId: "agent-codex",
+        targetParticipantId: "human-local",
+        summary: "working",
+      },
+    }
+    const sendTextMessage = vi.fn()
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [taskRequest, accepted],
+      sendTextMessage,
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    const { rerender } = render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    fireEvent.click(screen.getByTestId("interaction-tab-task-task-orphan"))
+
+    expect(screen.getByLabelText("Status Working")).toBeInTheDocument()
+    expect(screen.getByLabelText("Task unavailable")).toBeInTheDocument()
+    expect(screen.getByTestId("task-unavailable")).toHaveTextContent(
+      "No participating Agent is currently available."
+    )
+    expect(
+      screen.getByLabelText("Message the room or @ an Agent")
+    ).toBeDisabled()
+    expect(screen.getByLabelText("Send message")).toBeDisabled()
+    expect(sendTextMessage).not.toHaveBeenCalled()
+
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [taskRequest, accepted],
+      sendTextMessage,
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+        {
+          peerId: "agent-codex",
+          name: "Codex",
+          kind: "agent",
+          room: "test-room",
+        },
+      ],
+    })
+    rerender(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    expect(screen.queryByTestId("task-unavailable")).toBeNull()
+    expect(
+      screen.getByLabelText("Message the room or @ an Agent")
+    ).toBeEnabled()
+  })
+
+  it("keeps a Task available when a secondary participating Agent is connected", () => {
+    const taskRequest: Message = {
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "action",
+      actionType: "collab",
+      sequence: 1,
+      collab: {
+        requestId: "task-secondary",
+        kind: "request",
+        fromParticipantId: "human-local",
+        targetParticipantId: "agent-codex",
+        summary: "Secondary Agent task",
+      },
+    }
+    const secondaryTarget: Message = {
+      peerId: "human-local",
+      name: "Hannah",
+      kind: "human",
+      type: "text",
+      sequence: 2,
+      taskRequestId: "task-secondary",
+      targets: ["agent-pi"],
+      text: "Pi, continue this task",
+    }
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [taskRequest, secondaryTarget],
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+        {
+          peerId: "agent-pi",
+          name: "Pi",
+          kind: "agent",
+          room: "test-room",
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+    fireEvent.click(screen.getByTestId("interaction-tab-task-task-secondary"))
+
+    expect(screen.getByLabelText("Status Starting")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Task unavailable")).toBeNull()
+    expect(screen.queryByTestId("task-unavailable")).toBeNull()
+    expect(
+      screen.getByLabelText("Message the room or @ an Agent")
+    ).toBeEnabled()
+  })
+
+  it("keeps terminal Task lifecycle status separate from availability", () => {
+    const makeTask = (
+      requestId: string,
+      kind: "completed" | "failed"
+    ): Message[] => [
+      {
+        peerId: "human-local",
+        name: "Hannah",
+        kind: "human",
+        type: "action",
+        actionType: "collab",
+        sequence: kind === "completed" ? 1 : 3,
+        collab: {
+          requestId,
+          kind: "request",
+          fromParticipantId: "human-local",
+          targetParticipantId: "agent-codex",
+          summary: requestId,
+        },
+      },
+      {
+        peerId: "agent-codex",
+        name: "Codex",
+        kind: "agent",
+        type: "action",
+        actionType: "collab",
+        sequence: kind === "completed" ? 2 : 4,
+        collab: {
+          requestId,
+          kind,
+          fromParticipantId: "agent-codex",
+          targetParticipantId: "human-local",
+          summary: kind,
+        },
+      },
+    ]
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      messages: [
+        ...makeTask("task-completed", "completed"),
+        ...makeTask("task-failed", "failed"),
+      ],
+      participants: [
+        {
+          peerId: "local-peer-id",
+          name: "Hannah",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    expect(screen.getByLabelText("Status Completed")).toBeInTheDocument()
+    expect(screen.getByLabelText("Status Failed")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Task unavailable")).toBeNull()
+  })
+
   it("copies the ordinary Agent invite only through the popover action, without a provider claim", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -12,7 +12,14 @@ import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { agentActivityLabel } from "../common/agentActivity"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
-import { buildTaskProjections, roomMessagesForView } from "../common/taskViews"
+import {
+  buildTaskProjections,
+  isTaskTerminal,
+  roomMessagesForView,
+  taskHasConnectedAgent,
+  type TaskProjection,
+} from "../common/taskViews"
+import type { UserInfo } from "../common/types"
 import {
   umamiEvent,
   trackAnalyticsEvent,
@@ -25,6 +32,15 @@ import { useTurnstile } from "../hooks/useTurnstile"
 const MAX_FILE_SIZE = 20 * 1024 * 1024
 
 type TaskAgent = { peerId: string; name: string }
+
+function taskIsUnavailable(
+  task: Pick<TaskProjection, "participatingAgentIds" | "status">,
+  participants: Pick<UserInfo, "peerId" | "kind">[]
+): boolean {
+  return (
+    !isTaskTerminal(task.status) && !taskHasConnectedAgent(task, participants)
+  )
+}
 
 function ScreenShareViewer({
   stream,
@@ -192,6 +208,9 @@ export default function RoomContent({
           )
       )
     : []
+  const activeTaskUnavailable = Boolean(
+    activeTask && taskIsUnavailable(activeTask, participants)
+  )
 
   useEffect(() => {
     const pending = pendingLocalTaskSummaries.current
@@ -879,6 +898,7 @@ export default function RoomContent({
           <div
             role="tablist"
             aria-label="Room interactions"
+            data-testid="interaction-tablist"
             className="scrollbar-thin flex flex-none gap-1 overflow-x-auto border-b border-gray-800 bg-gray-950/60 px-3 py-2"
           >
             <button
@@ -903,13 +923,18 @@ export default function RoomContent({
                 aria-selected={activeInteraction === task.requestId}
                 data-testid={`interaction-tab-task-${task.requestId}`}
                 onClick={() => setActiveInteraction(task.requestId)}
+                title={
+                  taskIsUnavailable(task, participants)
+                    ? `${task.title} — unavailable`
+                    : task.title
+                }
                 className={`flex max-w-52 shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition ${
                   activeInteraction === task.requestId
                     ? "bg-blue-600 text-white"
                     : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
                 }`}
               >
-                <span className="truncate">{task.title}</span>
+                <span className="min-w-0 flex-1 truncate">{task.title}</span>
                 <span
                   aria-label={`Status ${task.status}`}
                   className="text-[10px] opacity-70"
@@ -920,14 +945,25 @@ export default function RoomContent({
                     ? "×"
                     : "●"}
                 </span>
+                {taskIsUnavailable(task, participants) && (
+                  <span
+                    aria-label="Task unavailable"
+                    className="text-[10px] text-amber-300"
+                  >
+                    !
+                  </span>
+                )}
               </button>
             ))}
           </div>
-          <div className="min-h-0 flex-1">
+          <div
+            data-testid="interaction-content"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
             {activeTaskActivities.length > 0 && (
               <div
                 data-testid="task-agent-activity"
-                className="flex flex-wrap gap-x-3 gap-y-1 border-b border-gray-800 bg-gray-950/40 px-3 py-1.5 text-xs text-blue-200/80"
+                className="flex flex-none flex-wrap gap-x-3 gap-y-1 border-b border-gray-800 bg-gray-950/40 px-3 py-1.5 text-xs text-blue-200/80"
               >
                 {activeTaskActivities.map((activity) => {
                   const participant = participants.find(
@@ -943,24 +979,27 @@ export default function RoomContent({
                 })}
               </div>
             )}
-            <TextChatCard
-              key={activeInteraction}
-              room={roomName}
-              nickName={nickName}
-              messages={interactionMessages}
-              attachments={activeTask ? [] : attachments}
-              participants={participants}
-              pendingFiles={activeTask ? [] : pendingFiles}
-              onSendText={wrappedSendText}
-              onSendFile={wrappedSendFile}
-              onSendAction={sendActionMessage}
-              localParticipantId={effectiveLocalParticipantId}
-              onCollabRespond={handleCollabRespond}
-              onReadArtifact={handleReadArtifact}
-              onCollabResult={handleCollabResult}
-              onPermissionRespond={handlePermissionResponse}
-              taskRequestId={activeTask?.requestId}
-            />
+            <div data-testid="interaction-chat" className="min-h-0 flex-1">
+              <TextChatCard
+                key={activeInteraction}
+                room={roomName}
+                nickName={nickName}
+                messages={interactionMessages}
+                attachments={activeTask ? [] : attachments}
+                participants={participants}
+                pendingFiles={activeTask ? [] : pendingFiles}
+                onSendText={wrappedSendText}
+                onSendFile={wrappedSendFile}
+                onSendAction={sendActionMessage}
+                localParticipantId={effectiveLocalParticipantId}
+                onCollabRespond={handleCollabRespond}
+                onReadArtifact={handleReadArtifact}
+                onCollabResult={handleCollabResult}
+                onPermissionRespond={handlePermissionResponse}
+                taskAvailable={!activeTaskUnavailable}
+                taskRequestId={activeTask?.requestId}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/app/src/components/TextChatCard.composer.test.tsx
+++ b/app/src/components/TextChatCard.composer.test.tsx
@@ -154,6 +154,44 @@ describe("composer keyboard semantics", () => {
     expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument()
   })
 
+  it("scrolls only the timeline container when messages change", () => {
+    const originalScrollTo = HTMLElement.prototype.scrollTo
+    const scrollTo = vi.fn()
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    })
+
+    const { view } = renderCard()
+    scrollTo.mockClear()
+    view.rerender(
+      <TextChatCard
+        room="room"
+        nickName="Human"
+        messages={[
+          {
+            peerId: "agent-1",
+            name: "Agent B",
+            kind: "agent",
+            type: "text",
+            text: "new",
+          },
+        ]}
+        participants={[agentParticipant()]}
+        onSendText={vi.fn()}
+        onSendFile={vi.fn()}
+        onSendAction={vi.fn()}
+      />
+    )
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" })
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: originalScrollTo,
+    })
+  })
+
   it("sends a selected Agent participant id from a Task composer", async () => {
     const { composer, onSendText } = renderCard({
       taskRequestId: "task-123",

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -86,6 +86,8 @@ interface TextChatCardProps {
   /** #309: when set, this composer sends ordinary text into one existing
    * canonical task and targets its primary Agent only. */
   taskRequestId?: string
+  /** Current presentation availability for the active Task. */
+  taskAvailable?: boolean
 }
 
 const GAMES = [
@@ -1187,10 +1189,14 @@ const RoomTimeline = memo(function RoomTimeline({
   onOpenResultComposer,
   onPermissionRespond,
 }: RoomTimelineProps) {
-  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const timelineRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    const timeline = timelineRef.current
+    if (!timeline) return
+    if (typeof timeline.scrollTo === "function")
+      timeline.scrollTo({ top: timeline.scrollHeight, behavior: "smooth" })
+    else timeline.scrollTop = timeline.scrollHeight
   }, [messages, pendingFiles])
 
   const timeline = useMemo(
@@ -1227,7 +1233,11 @@ const RoomTimeline = memo(function RoomTimeline({
   }, [participants, timeline])
 
   return (
-    <div className="scrollbar-thin flex-1 overflow-y-auto p-4 text-sm">
+    <div
+      ref={timelineRef}
+      data-testid="room-timeline"
+      className="scrollbar-thin min-h-0 flex-1 overflow-y-auto p-4 text-sm"
+    >
       {messages.length === 0 && attachments.length === 0 && (
         <p className="mt-4 text-center text-xs text-gray-500">
           No messages yet
@@ -1351,7 +1361,6 @@ const RoomTimeline = memo(function RoomTimeline({
           </div>
         </div>
       ))}
-      <div ref={messagesEndRef} />
     </div>
   )
 })
@@ -1486,8 +1495,10 @@ const TextChatCard = memo(function TextChatCard({
   onCollabResult,
   onPermissionRespond,
   taskRequestId,
+  taskAvailable = true,
 }: TextChatCardProps) {
   const taskScoped = Boolean(taskRequestId)
+  const taskUnavailable = taskScoped && !taskAvailable
   const [message, setMessage] = useState<string>("")
   const [submenu, setSubmenu] = useState<"more" | "games" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
@@ -1553,7 +1564,7 @@ const TextChatCard = memo(function TextChatCard({
   }
 
   const sendCurrentMessage = () => {
-    if (message.trim() === "") return
+    if (message.trim() === "" || taskUnavailable) return
     const targets = taskScoped
       ? resolveSelectedAgentTargetIds(message.trim(), selectedAgents)
       : resolveAgentTargetIds(message.trim(), connectedAgents, selectedAgents)
@@ -1788,6 +1799,15 @@ const TextChatCard = memo(function TextChatCard({
           />
         )}
 
+        {taskUnavailable && (
+          <p
+            data-testid="task-unavailable"
+            role="status"
+            className="flex-none border-t border-gray-700 px-3 pt-2 text-xs text-amber-200/80"
+          >
+            No participating Agent is currently available.
+          </p>
+        )}
         <div className="relative flex flex-none items-end gap-2 border-t border-gray-700 p-3">
           {pickerVisible && (
             <div className="absolute bottom-full left-3 right-3 mb-1 overflow-hidden rounded-lg border border-gray-600 bg-gray-800 shadow-xl">
@@ -1922,6 +1942,7 @@ const TextChatCard = memo(function TextChatCard({
             rows={1}
             className="scrollbar-thin max-h-40 flex-1 resize-none overflow-y-auto rounded-xl bg-gray-900 px-3 py-2 text-sm leading-relaxed text-white placeholder-gray-500 focus:outline-none"
             value={message}
+            disabled={taskUnavailable}
             onKeyDown={handleKeyDown}
             onChange={(e) => {
               const nextMessage = e.target.value
@@ -1948,7 +1969,7 @@ const TextChatCard = memo(function TextChatCard({
           <button
             type="button"
             onClick={handleSend}
-            disabled={message.trim() === ""}
+            disabled={message.trim() === "" || taskUnavailable}
             className="rounded-lg bg-blue-600 p-2 transition hover:bg-blue-500 disabled:opacity-30"
             title="Send"
             aria-label="Send message"


### PR DESCRIPTION
Fixes #336

## Summary

Production dogfood exposed two presentation-only Task UI problems: interaction tabs could be vertically clipped while Agent activity was visible, and a retained non-terminal Task remained apparently actionable after its participating Agents had left.

## Root cause

- The interaction shell did not establish an explicit bounded flex-column layout, so the activity row and chat content could compete for vertical space.
- The browser Task projection retained the Task lifecycle and messages but did not derive current availability from the retained Task endpoints and the current connected Agent roster.
- Chat scrolling was anchored through a bottom sentinel rather than the bounded timeline element.

## Fix

- Give the interaction shell, activity row, and chat timeline explicit flex/min-height boundaries; keep scrolling on the actual chat timeline and preserve horizontal tab overflow with truncated titles.
- Retain Task participant endpoint IDs from collab lifecycle and structured Task-targeted messages, then derive availability from the current connected Agent roster at render time.
- Keep non-terminal unavailable Tasks visible with their canonical lifecycle status, show `No participating Agent is currently available.`, and disable the Task composer until a participating Agent reconnects.
- Preserve secondary-Agent semantics: a later Agent explicitly targeted inside a Task keeps that Task available while connected.
- Keep terminal status and current availability as separate concepts; no lifecycle, ownership, permission, Runtime, Room protocol, reassignment, or membership model changes.

## Tests

- Focused Task projection, RoomContent, and TextChatCard tests: 42 passed
- Full App test suite: 78 suites passed, 696 tests passed
- `yarn type-check`: passed
- `yarn eslint src --no-fix`: passed
- `yarn prettier --check .`: passed
- `yarn docs:check`: passed
- `yarn cf-build`: passed
- `git diff --check`: passed

## Scope

App-only change. No Agent Runtime, ACP, Durable Object protocol, recurring RoomInfo polling, persistence, alarm, or PR B changes are included.
