### PR TITLE
[codex] stabilize SFU reconnect reliability test

### DIFF
--- a/app/src/hooks/useSfuChatRoom.reliability.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.reliability.test.tsx
@@ -771,7 +771,11 @@ describe("useSfuChatRoom remote SFU subscriber reliability", () => {
     })
 
     expect(pc.connectionState).toBe("closed")
-    expect(TestPeerConnection.instances).toHaveLength(2)
+    vi.useRealTimers()
+    await waitFor(() => {
+      expect(TestPeerConnection.instances).toHaveLength(2)
+      expect(TestWebSocket.instances).toHaveLength(2)
+    })
     const newPc = TestPeerConnection.instances[1]
     const newSocket = TestWebSocket.instances[1]
     sendState(newSocket, state)


### PR DESCRIPTION
## Summary

Fix the intermittent post-merge App Tests failure in `useSfuChatRoom.reliability.test.tsx`.

## Failure and root cause

The reconnect regression test advances the 5-second remote-track admission timeout with fake timers, then assumes that the second PeerConnection and its control WebSocket have both been created after a fixed microtask flush. The reconnect path is asynchronous and creates the WebSocket only after several awaited SFU setup operations. Under full-suite scheduling, the test reached `TestWebSocket.instances[1]` before that socket existed and failed while trying to deliver the resync state.

This was observed in the merged `cf-sfu` workflow at [run 34497600734](https://github.com/i365dev/free4chat/actions/runs/34497600734/job/102940776000), with 77 of 78 suites and 698 of 699 tests passing.

## Fix

- Keep fake timers only for deterministically firing the 5-second admission timeout.
- Restore real timers before waiting for the asynchronous reconnect completion.
- Wait for both the replacement PeerConnection and replacement WebSocket before sending the replacement Room state.

No production code or runtime behavior is changed.

## Validation

- Focused reliability suite: 19/19 passed in three consecutive runs
- Full App tests: 78 suites, 699 tests passed
- `yarn type-check`: passed
- `yarn eslint src --no-fix`: passed
- `yarn prettier --check .`: passed
- `yarn docs:check`: passed
- `git diff --check`: passed
