### PR TITLE
chore(agent): bump Runtime to 0.5.30

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.29"
+var Version = "0.5.30"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary\n- bump the canonical Go Agent Runtime doctor version from 0.5.29 to 0.5.30\n- keep live bootstrap and generated docs on the latest published native release until activation\n\n## Validation\n- go test ./...\n- go vet ./...\n- go build ./cmd/free4chat-agent\n- bash scripts/test-install-agent.sh\n- bash scripts/test-bootstrap-contract.sh\n- git diff --check\n\nThis is the source-version PR only; release tag and bootstrap activation remain separate phases.