### PR TITLE
chore(agent): activate Runtime 0.5.30 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -323,7 +323,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.29` (release tag `agent-v0.5.29`).
+`0.5.30` (release tag `agent-v0.5.30`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -384,7 +384,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.29"
+expected_version="0.5.30"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1832,7 +1832,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.29` (release tag `agent-v0.5.29`).
+`0.5.30` (release tag `agent-v0.5.30`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1893,7 +1893,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.29"
+expected_version="0.5.30"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary\n- activate the live bootstrap pin from 0.5.29 to verified native release 0.5.30\n- regenerate the matching public llms-full.txt docs asset\n\n## Release prerequisite\n- native release: https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.30\n- four native assets and SHA256SUMS verified\n- current darwin/arm64 asset reports doctor version 0.5.30\n\n## Validation\n- bash agent/scripts/test-bootstrap-contract.sh\n- yarn docs:check\n- yarn test (81 files / 718 tests)\n- yarn type-check\n- yarn eslint src --no-fix\n- yarn prettier --check .\n\nThis is the separate post-release bootstrap activation phase.