### PR TITLE
chore(agent): bump Runtime to 0.5.31

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.30"
+var Version = "0.5.31"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
## Summary

- Bump the Agent Runtime source version from `0.5.30` to `0.5.31`.
- This source-version PR prepares the native `agent-v0.5.31` release for the already-merged #351 Runtime changes.

## Release sequencing

This PR intentionally does not update `app/public/agent.md` or `app/public/llms-full.txt`. Bootstrap activation belongs in the separate activation PR after the native GitHub Release is published and verified.

## Validation

- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`
- `go build ./cmd/free4chat-agent`
- `bash scripts/test-install-agent.sh`
- `bash scripts/test-bootstrap-contract.sh`
- `git diff --check`

All passed.
