### PR TITLE
chore(agent): activate Runtime 0.5.31 bootstrap

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -328,7 +328,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.30` (release tag `agent-v0.5.30`).
+`0.5.31` (release tag `agent-v0.5.31`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -389,7 +389,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.30"
+expected_version="0.5.31"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1837,7 +1837,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.30` (release tag `agent-v0.5.30`).
+`0.5.31` (release tag `agent-v0.5.31`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -1898,7 +1898,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.30"
+expected_version="0.5.31"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
## Summary

- Activate the verified native Agent Runtime `0.5.31` in the live bootstrap document.
- Regenerate `app/public/llms-full.txt` from the canonical docs.

The native `agent-v0.5.31` GitHub Release was published and verified before this activation PR. This PR intentionally contains no Runtime source or product behavior changes.

## Validation

- App: `81 test files / 729 tests passed`
- `yarn type-check`
- `yarn eslint src --no-fix`
- `yarn prettier --check .`
- `yarn docs:check`
- `yarn cf-build`
- `go test ./... -count=1 -timeout 300s`
- `go vet ./...`
- `go build ./cmd/free4chat-agent`
- `bash scripts/test-bootstrap-contract.sh`
- `git diff --check`

All passed.
