### PR TITLE
Add Phase 0 Room App host and bounded realtime bridge

### DIFF
--- a/app/src/common/roomApp.test.ts
+++ b/app/src/common/roomApp.test.ts
@@ -6,9 +6,11 @@ import {
   decodeRoomAppClientMessage,
   decodeRoomAppEnvelope,
   encodeRoomAppEnvelope,
+  isRoomAppInstanceForRoom,
   isRoomAppAllowlisted,
   projectRoomAppParticipants,
   roomAppRateGuard,
+  roomAppInstanceId,
   validateRoomAppDefinition,
 } from "./roomApp"
 
@@ -51,6 +53,13 @@ describe("Room App Phase 0 bridge contract", () => {
         payload: { text: "界".repeat(ROOM_APP_MAX_PAYLOAD_BYTES) },
       })
     ).toBeNull()
+    expect(
+      encodeRoomAppEnvelope({
+        appInstanceId: "shared-canvas:abc123",
+        lane: "reliable",
+        payload: { sourceParticipantId: "spoofed" },
+      })
+    ).toBeNull()
     expect(decodeRoomAppEnvelope(JSON.stringify({ type: "bogus" }))).toBeNull()
   })
 
@@ -77,6 +86,18 @@ describe("Room App Phase 0 bridge contract", () => {
     ).toBeNull()
   })
 
+  it("accepts only curated instances for the current Room", () => {
+    expect(isRoomAppInstanceForRoom("room-a", "shared-canvas:00000000")).toBe(
+      false
+    )
+    expect(
+      isRoomAppInstanceForRoom(
+        "room-a",
+        roomAppInstanceId("room-a", "shared-canvas")
+      )
+    ).toBe(true)
+  })
+
   it("bounds the participant projection and separates reliable/realtime rate", () => {
     expect(
       projectRoomAppParticipants([
@@ -93,5 +114,11 @@ describe("Room App Phase 0 bridge contract", () => {
     expect(guard.allow("reliable", 1, 1000)).toBe(false)
     expect(guard.allow("realtime", 1, 1000)).toBe(true)
     expect(guard.allow("reliable", 1, 2001)).toBe(true)
+  })
+
+  it("prunes stale bytes from both lanes before applying the shared budget", () => {
+    const guard = roomAppRateGuard()
+    expect(guard.allow("realtime", 200_000, 1000)).toBe(true)
+    expect(guard.allow("reliable", 100_000, 2001)).toBe(true)
   })
 })

--- a/app/src/common/roomApp.test.ts
+++ b/app/src/common/roomApp.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ROOM_APP_CATALOG,
+  ROOM_APP_MAX_PAYLOAD_BYTES,
+  decodeRoomAppClientMessage,
+  decodeRoomAppEnvelope,
+  encodeRoomAppEnvelope,
+  isRoomAppAllowlisted,
+  projectRoomAppParticipants,
+  roomAppRateGuard,
+  validateRoomAppDefinition,
+} from "./roomApp"
+
+describe("Room App Phase 0 bridge contract", () => {
+  it("accepts only curated app definitions and rejects arbitrary origins", () => {
+    expect(
+      validateRoomAppDefinition({
+        id: "shared-canvas",
+        label: "Shared Canvas",
+        url: "https://room-apps.free4.chat/shared-canvas",
+        origin: "https://room-apps.free4.chat",
+      })
+    ).toBe(true)
+    expect(isRoomAppAllowlisted(ROOM_APP_CATALOG[0])).toBe(true)
+    expect(
+      isRoomAppAllowlisted({
+        id: "user-app",
+        label: "User app",
+        url: "https://evil.example/app",
+        origin: "https://room-apps.free4.chat",
+      })
+    ).toBe(false)
+  })
+
+  it("keeps transport envelopes bounded and UTF-8 sized", () => {
+    const encoded = encodeRoomAppEnvelope({
+      appInstanceId: "shared-canvas:abc123",
+      lane: "reliable",
+      payload: { type: "stroke", points: [[1, 2]] },
+    })
+    expect(encoded).toBeTruthy()
+    expect(decodeRoomAppEnvelope(encoded)).toMatchObject({
+      lane: "reliable",
+      appInstanceId: "shared-canvas:abc123",
+    })
+    expect(
+      encodeRoomAppEnvelope({
+        appInstanceId: "shared-canvas:abc123",
+        lane: "reliable",
+        payload: { text: "界".repeat(ROOM_APP_MAX_PAYLOAD_BYTES) },
+      })
+    ).toBeNull()
+    expect(decodeRoomAppEnvelope(JSON.stringify({ type: "bogus" }))).toBeNull()
+  })
+
+  it("requires the exact current instance and handshake token", () => {
+    expect(
+      decodeRoomAppClientMessage(
+        {
+          type: "ready",
+          appInstanceId: "shared-canvas:abc123",
+          handshakeToken: "nonce",
+        },
+        "shared-canvas:abc123"
+      )
+    ).toMatchObject({ type: "ready", handshakeToken: "nonce" })
+    expect(
+      decodeRoomAppClientMessage(
+        {
+          type: "sendReliable",
+          appInstanceId: "other:abc123",
+          payload: { type: "stroke" },
+        },
+        "shared-canvas:abc123"
+      )
+    ).toBeNull()
+  })
+
+  it("bounds the participant projection and separates reliable/realtime rate", () => {
+    expect(
+      projectRoomAppParticipants([
+        { participantId: "a", name: "Alice", kind: "human" },
+        { participantId: "b", name: "Pi", kind: "agent" },
+      ])
+    ).toEqual([
+      { participantId: "a", name: "Alice", kind: "human" },
+      { participantId: "b", name: "Pi", kind: "agent" },
+    ])
+    const guard = roomAppRateGuard()
+    for (let index = 0; index < 20; index += 1)
+      expect(guard.allow("reliable", 1, 1000)).toBe(true)
+    expect(guard.allow("reliable", 1, 1000)).toBe(false)
+    expect(guard.allow("realtime", 1, 1000)).toBe(true)
+    expect(guard.allow("reliable", 1, 2001)).toBe(true)
+  })
+})

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -67,8 +67,11 @@ export interface RoomAppTransportEnvelope {
   protocolVersion: typeof ROOM_APP_PROTOCOL_VERSION
   appInstanceId: string
   lane: RoomAppLane
+  sourceParticipantId: string
   payload: Record<string, unknown>
 }
+
+type RoomAppWireEnvelope = Omit<RoomAppTransportEnvelope, "sourceParticipantId">
 
 export type RoomAppHostMessage =
   | {
@@ -86,6 +89,7 @@ export type RoomAppHostMessage =
   | {
       type: RoomAppLane
       appInstanceId: string
+      sourceParticipantId: string
       payload: Record<string, unknown>
     }
   | {
@@ -124,19 +128,19 @@ export function validateRoomAppPayload(
 ):
   | { ok: true; payload: Record<string, unknown>; bytes: number }
   | { ok: false } {
-  if (!isRecord(value)) return { ok: false }
+  if (!isRecord(value) || "sourceParticipantId" in value) return { ok: false }
   const bytes = serializedRoomAppBytes(value)
   if (bytes === null || bytes > ROOM_APP_MAX_PAYLOAD_BYTES) return { ok: false }
   return { ok: true, payload: value, bytes }
 }
 
 export function encodeRoomAppEnvelope(
-  envelope: Omit<RoomAppTransportEnvelope, "protocolVersion">
+  envelope: Omit<RoomAppWireEnvelope, "protocolVersion">
 ): string | null {
   const payload = validateRoomAppPayload(envelope.payload)
   if (!payload.ok || !/^[a-z0-9][a-z0-9:-]{0,95}$/.test(envelope.appInstanceId))
     return null
-  const full: RoomAppTransportEnvelope = {
+  const full: RoomAppWireEnvelope = {
     protocolVersion: ROOM_APP_PROTOCOL_VERSION,
     appInstanceId: envelope.appInstanceId,
     lane: envelope.lane,
@@ -149,7 +153,7 @@ export function encodeRoomAppEnvelope(
 
 export function decodeRoomAppEnvelope(
   value: unknown
-): RoomAppTransportEnvelope | null {
+): RoomAppWireEnvelope | null {
   if (typeof value !== "string") return null
   let parsed: unknown
   try {
@@ -212,6 +216,18 @@ export function roomAppInstanceId(roomName: string, appId: string): string {
   return `${appId}:${hash.toString(16).padStart(8, "0")}`
 }
 
+export function isRoomAppInstanceForRoom(
+  roomName: string,
+  appInstanceId: string
+): boolean {
+  return experimentalRoomAppCatalog().some(
+    (app) =>
+      validateRoomAppDefinition(app) &&
+      isRoomAppAllowlisted(app) &&
+      roomAppInstanceId(roomName, app.id) === appInstanceId
+  )
+}
+
 export function validateRoomAppDefinition(app: RoomAppDefinition): boolean {
   try {
     const url = new URL(app.url)
@@ -267,8 +283,11 @@ export function roomAppRateGuard() {
   return {
     allow(lane: RoomAppLane, bytes: number, now = Date.now()): boolean {
       const windowStart = now - 1000
-      const samples = events[lane].filter((sample) => sample.at > windowStart)
-      events[lane] = samples
+      for (const currentLane of ["reliable", "realtime"] as const)
+        events[currentLane] = events[currentLane].filter(
+          (sample) => sample.at > windowStart
+        )
+      const samples = events[lane]
       const countLimit =
         lane === "reliable"
           ? ROOM_APP_RELIABLE_MESSAGES_PER_SECOND

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -1,0 +1,288 @@
+import type { ParticipantKind } from "../room/types"
+
+export const ROOM_APP_PROTOCOL_VERSION = 1 as const
+export const ROOM_APP_MAX_PAYLOAD_BYTES = 16 * 1024
+export const ROOM_APP_MAX_INSTANCES = 2
+export const ROOM_APP_RELIABLE_MESSAGES_PER_SECOND = 20
+export const ROOM_APP_REALTIME_MESSAGES_PER_SECOND = 60
+export const ROOM_APP_BYTES_PER_SECOND = 256 * 1024
+
+export type RoomAppLane = "reliable" | "realtime"
+
+export interface RoomAppDefinition {
+  id: string
+  label: string
+  url: string
+  origin: string
+}
+
+// These are build-time curated fixture identities, not a user-controlled URL
+// loader. The Worker-side flag keeps the catalog hidden until the experiment is
+// deliberately enabled in an environment. Both fixtures share this origin
+// contract and may later be deployed under these paths without changing the
+// host/bridge protocol.
+export const ROOM_APP_CATALOG: readonly RoomAppDefinition[] = [
+  {
+    id: "shared-canvas",
+    label: "Shared Canvas",
+    url: "https://room-apps.free4.chat/shared-canvas",
+    origin: "https://room-apps.free4.chat",
+  },
+  {
+    id: "tiny-arena",
+    label: "Tiny Arena",
+    url: "https://room-apps.free4.chat/tiny-arena",
+    origin: "https://room-apps.free4.chat",
+  },
+]
+
+export const ROOM_APP_LOCAL_CATALOG: readonly RoomAppDefinition[] = [
+  {
+    id: "shared-canvas",
+    label: "Shared Canvas",
+    url: "http://localhost:8787/shared-canvas",
+    origin: "http://localhost:8787",
+  },
+  {
+    id: "tiny-arena",
+    label: "Tiny Arena",
+    url: "http://localhost:8787/tiny-arena",
+    origin: "http://localhost:8787",
+  },
+]
+
+export function experimentalRoomAppCatalog(): readonly RoomAppDefinition[] {
+  return process.env.NODE_ENV === "development"
+    ? ROOM_APP_LOCAL_CATALOG
+    : ROOM_APP_CATALOG
+}
+
+export interface RoomAppParticipantProjection {
+  participantId: string
+  name: string
+  kind: ParticipantKind
+}
+
+export interface RoomAppTransportEnvelope {
+  protocolVersion: typeof ROOM_APP_PROTOCOL_VERSION
+  appInstanceId: string
+  lane: RoomAppLane
+  payload: Record<string, unknown>
+}
+
+export type RoomAppHostMessage =
+  | {
+      type: "ready"
+      protocolVersion: typeof ROOM_APP_PROTOCOL_VERSION
+      appInstanceId: string
+      self: RoomAppParticipantProjection
+      participants: RoomAppParticipantProjection[]
+    }
+  | {
+      type: "participant_join" | "participant_leave"
+      appInstanceId: string
+      participant: RoomAppParticipantProjection
+    }
+  | {
+      type: RoomAppLane
+      appInstanceId: string
+      payload: Record<string, unknown>
+    }
+  | {
+      type: "error"
+      appInstanceId: string
+      error: "unsupported_message" | "rate_limited" | "payload_too_large"
+    }
+
+export type RoomAppClientMessage =
+  | {
+      type: "ready"
+      appInstanceId: string
+      handshakeToken: string
+    }
+  | {
+      type: "sendReliable" | "sendRealtime"
+      appInstanceId: string
+      payload: Record<string, unknown>
+    }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+export function serializedRoomAppBytes(value: unknown): number | null {
+  try {
+    const encoded = new TextEncoder().encode(JSON.stringify(value))
+    return encoded.byteLength
+  } catch {
+    return null
+  }
+}
+
+export function validateRoomAppPayload(
+  value: unknown
+):
+  | { ok: true; payload: Record<string, unknown>; bytes: number }
+  | { ok: false } {
+  if (!isRecord(value)) return { ok: false }
+  const bytes = serializedRoomAppBytes(value)
+  if (bytes === null || bytes > ROOM_APP_MAX_PAYLOAD_BYTES) return { ok: false }
+  return { ok: true, payload: value, bytes }
+}
+
+export function encodeRoomAppEnvelope(
+  envelope: Omit<RoomAppTransportEnvelope, "protocolVersion">
+): string | null {
+  const payload = validateRoomAppPayload(envelope.payload)
+  if (!payload.ok || !/^[a-z0-9][a-z0-9:-]{0,95}$/.test(envelope.appInstanceId))
+    return null
+  const full: RoomAppTransportEnvelope = {
+    protocolVersion: ROOM_APP_PROTOCOL_VERSION,
+    appInstanceId: envelope.appInstanceId,
+    lane: envelope.lane,
+    payload: payload.payload,
+  }
+  const bytes = serializedRoomAppBytes(full)
+  if (bytes === null || bytes > ROOM_APP_MAX_PAYLOAD_BYTES) return null
+  return JSON.stringify(full)
+}
+
+export function decodeRoomAppEnvelope(
+  value: unknown
+): RoomAppTransportEnvelope | null {
+  if (typeof value !== "string") return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+  if (
+    parsed.protocolVersion !== ROOM_APP_PROTOCOL_VERSION ||
+    typeof parsed.appInstanceId !== "string" ||
+    !/^[a-z0-9][a-z0-9:-]{0,95}$/.test(parsed.appInstanceId) ||
+    (parsed.lane !== "reliable" && parsed.lane !== "realtime")
+  )
+    return null
+  const payload = validateRoomAppPayload(parsed.payload)
+  if (!payload.ok) return null
+  return {
+    protocolVersion: ROOM_APP_PROTOCOL_VERSION,
+    appInstanceId: parsed.appInstanceId,
+    lane: parsed.lane,
+    payload: payload.payload,
+  }
+}
+
+export function decodeRoomAppClientMessage(
+  value: unknown,
+  appInstanceId: string
+): RoomAppClientMessage | null {
+  if (!isRecord(value) || value.appInstanceId !== appInstanceId) return null
+  if (
+    value.type === "ready" &&
+    typeof value.handshakeToken === "string" &&
+    value.handshakeToken.length > 0 &&
+    value.handshakeToken.length <= 128
+  )
+    return {
+      type: "ready",
+      appInstanceId,
+      handshakeToken: value.handshakeToken,
+    }
+  if (value.type !== "sendReliable" && value.type !== "sendRealtime")
+    return null
+  const payload = validateRoomAppPayload(value.payload)
+  if (!payload.ok) return null
+  return {
+    type: value.type,
+    appInstanceId,
+    payload: payload.payload,
+  }
+}
+
+export function roomAppInstanceId(roomName: string, appId: string): string {
+  let hash = 0x811c9dc5
+  const input = `${roomName}:${appId}`
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return `${appId}:${hash.toString(16).padStart(8, "0")}`
+}
+
+export function validateRoomAppDefinition(app: RoomAppDefinition): boolean {
+  try {
+    const url = new URL(app.url)
+    return (
+      /^[a-z0-9][a-z0-9-]{0,31}$/.test(app.id) &&
+      app.label.length > 0 &&
+      app.label.length <= 64 &&
+      url.origin === app.origin &&
+      (url.protocol === "https:" ||
+        (url.protocol === "http:" && url.hostname === "localhost"))
+    )
+  } catch {
+    return false
+  }
+}
+
+export function isRoomAppAllowlisted(app: RoomAppDefinition): boolean {
+  return [ROOM_APP_CATALOG, ROOM_APP_LOCAL_CATALOG].some((catalog) =>
+    catalog.some(
+      (candidate) =>
+        candidate.id === app.id &&
+        candidate.url === app.url &&
+        candidate.origin === app.origin &&
+        validateRoomAppDefinition(candidate)
+    )
+  )
+}
+
+export function projectRoomAppParticipants(
+  participants: readonly RoomAppParticipantProjection[]
+): RoomAppParticipantProjection[] {
+  return participants
+    .filter(
+      (participant) =>
+        typeof participant.participantId === "string" &&
+        participant.participantId.length > 0 &&
+        typeof participant.name === "string" &&
+        (participant.kind === "human" || participant.kind === "agent")
+    )
+    .slice(0, 32)
+    .map((participant) => ({
+      participantId: participant.participantId,
+      name: participant.name.slice(0, 64),
+      kind: participant.kind,
+    }))
+}
+
+export function roomAppRateGuard() {
+  const events: Record<RoomAppLane, Array<{ at: number; bytes: number }>> = {
+    reliable: [],
+    realtime: [],
+  }
+  return {
+    allow(lane: RoomAppLane, bytes: number, now = Date.now()): boolean {
+      const windowStart = now - 1000
+      const samples = events[lane].filter((sample) => sample.at > windowStart)
+      events[lane] = samples
+      const countLimit =
+        lane === "reliable"
+          ? ROOM_APP_RELIABLE_MESSAGES_PER_SECOND
+          : ROOM_APP_REALTIME_MESSAGES_PER_SECOND
+      const totalBytes = Object.values(events)
+        .flat()
+        .reduce((sum, sample) => sum + sample.bytes, 0)
+      if (
+        samples.length >= countLimit ||
+        totalBytes + bytes > ROOM_APP_BYTES_PER_SECOND
+      )
+        return false
+      samples.push({ at: now, bytes })
+      return true
+    },
+  }
+}

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -200,12 +200,14 @@ describe("RoomAppHost", () => {
         protocolVersion: 1,
         appInstanceId: "shared-canvas:room",
         lane: "realtime",
+        sourceParticipantId: "human-b",
         payload: { type: "cursor", x: 2 },
       })
     })
     expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
       type: "realtime",
       appInstanceId: "shared-canvas:room",
+      sourceParticipantId: "human-b",
       payload: { type: "cursor", x: 2 },
     })
     rerender(

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -1,0 +1,229 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import RoomAppHost from "./RoomAppHost"
+import type {
+  RoomAppParticipantProjection,
+  RoomAppTransportEnvelope,
+} from "../common/roomApp"
+
+class TestPort {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  postMessage = vi.fn()
+  start = vi.fn()
+  close = vi.fn()
+
+  emit(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent)
+  }
+}
+
+let lastChannel: { port1: TestPort; port2: TestPort } | null = null
+
+class TestMessageChannel {
+  port1 = new TestPort()
+  port2 = new TestPort()
+
+  constructor() {
+    lastChannel = this
+  }
+}
+
+const app = {
+  id: "shared-canvas",
+  label: "Shared Canvas",
+  url: "https://room-apps.free4.chat/shared-canvas",
+  origin: "https://room-apps.free4.chat",
+} as const
+
+const self: RoomAppParticipantProjection = {
+  participantId: "human-a",
+  name: "Alice",
+  kind: "human",
+}
+
+const participants = [
+  self,
+  { participantId: "human-b", name: "Bob", kind: "human" as const },
+]
+
+afterEach(() => {
+  lastChannel = null
+  vi.unstubAllGlobals()
+})
+
+describe("RoomAppHost", () => {
+  it("sandboxes an allowlisted App and establishes an owned MessagePort", () => {
+    vi.stubGlobal("MessageChannel", TestMessageChannel)
+    const onClose = vi.fn()
+    const subscribe = vi.fn(() => () => undefined)
+    const send = vi.fn(() => true)
+    const rendered = render(
+      <RoomAppHost
+        app={app}
+        appInstanceId="shared-canvas:room"
+        self={self}
+        participants={participants}
+        subscribe={subscribe}
+        send={send}
+        onClose={onClose}
+      />
+    )
+    const iframe = screen.getByTestId("room-app-iframe") as HTMLIFrameElement
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts")
+    expect(iframe.getAttribute("allow")).toBe("")
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer")
+    expect(iframe.src).toContain(app.url)
+
+    const frameWindow = { postMessage: vi.fn() }
+    Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+    fireEvent.load(iframe)
+    expect(frameWindow.postMessage).toHaveBeenCalledTimes(1)
+    const [bootstrap, targetOrigin, ports] =
+      frameWindow.postMessage.mock.calls[0]
+    expect(targetOrigin).toBe("*")
+    expect(bootstrap).toMatchObject({
+      type: "room-app-bootstrap",
+      appInstanceId: "shared-canvas:room",
+    })
+    expect(bootstrap).not.toHaveProperty("token")
+    expect(bootstrap).not.toHaveProperty("participantToken")
+    expect(ports).toHaveLength(1)
+    expect(lastChannel).not.toBeNull()
+
+    act(() => {
+      lastChannel!.port1.emit({
+        type: "ready",
+        appInstanceId: "shared-canvas:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+    })
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ready",
+        appInstanceId: "shared-canvas:room",
+        self,
+        participants,
+      })
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    rendered.unmount()
+    expect(lastChannel!.port1.close).toHaveBeenCalled()
+    expect(subscribe).toHaveBeenCalledTimes(1)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed or wrong-instance messages and forwards bounded lanes", () => {
+    vi.stubGlobal("MessageChannel", TestMessageChannel)
+    const send = vi.fn(() => true)
+    render(
+      <RoomAppHost
+        app={app}
+        appInstanceId="shared-canvas:room"
+        self={self}
+        participants={participants}
+        subscribe={() => () => undefined}
+        send={send}
+        onClose={() => undefined}
+      />
+    )
+    const iframe = screen.getByTestId("room-app-iframe") as HTMLIFrameElement
+    const frameWindow = { postMessage: vi.fn() }
+    Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+    fireEvent.load(iframe)
+    const bootstrap = frameWindow.postMessage.mock.calls[0][0]
+    const port = lastChannel!.port1
+    act(() => {
+      port.emit({ type: "bogus", appInstanceId: "shared-canvas:room" })
+    })
+    expect(port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", error: "unsupported_message" })
+    )
+    act(() => {
+      port.emit({
+        type: "ready",
+        appInstanceId: "other:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+    })
+    expect(send).not.toHaveBeenCalled()
+    act(() => {
+      port.emit({
+        type: "ready",
+        appInstanceId: "shared-canvas:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+      port.emit({
+        type: "sendReliable",
+        appInstanceId: "shared-canvas:room",
+        payload: { type: "stroke", points: [[1, 2]] },
+      })
+    })
+    expect(send).toHaveBeenCalledWith("reliable", "shared-canvas:room", {
+      type: "stroke",
+      points: [[1, 2]],
+    })
+  })
+
+  it("forwards remote lanes and emits participant lifecycle changes", () => {
+    vi.stubGlobal("MessageChannel", TestMessageChannel)
+    let listener: ((message: RoomAppTransportEnvelope) => void) | undefined
+    const subscribe = vi.fn((next: typeof listener) => {
+      listener = next
+      return () => undefined
+    })
+    const { rerender } = render(
+      <RoomAppHost
+        app={app}
+        appInstanceId="shared-canvas:room"
+        self={self}
+        participants={participants}
+        subscribe={subscribe}
+        send={() => true}
+        onClose={() => undefined}
+      />
+    )
+    const iframe = screen.getByTestId("room-app-iframe") as HTMLIFrameElement
+    const frameWindow = { postMessage: vi.fn() }
+    Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+    fireEvent.load(iframe)
+    const bootstrap = frameWindow.postMessage.mock.calls[0][0]
+    act(() => {
+      lastChannel!.port1.emit({
+        type: "ready",
+        appInstanceId: "shared-canvas:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+      listener?.({
+        protocolVersion: 1,
+        appInstanceId: "shared-canvas:room",
+        lane: "realtime",
+        payload: { type: "cursor", x: 2 },
+      })
+    })
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
+      type: "realtime",
+      appInstanceId: "shared-canvas:room",
+      payload: { type: "cursor", x: 2 },
+    })
+    rerender(
+      <RoomAppHost
+        app={app}
+        appInstanceId="shared-canvas:room"
+        self={self}
+        participants={[self]}
+        subscribe={subscribe}
+        send={() => true}
+        onClose={() => undefined}
+      />
+    )
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "participant_leave",
+        participant: participants[1],
+      })
+    )
+  })
+})

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import {
+  decodeRoomAppClientMessage,
+  isRoomAppAllowlisted,
+  projectRoomAppParticipants,
+  serializedRoomAppBytes,
+  validateRoomAppDefinition,
+  type RoomAppDefinition,
+  type RoomAppHostMessage,
+  type RoomAppParticipantProjection,
+  type RoomAppTransportEnvelope,
+} from "../common/roomApp"
+
+interface RoomAppHostProps {
+  app: RoomAppDefinition
+  appInstanceId: string
+  self: RoomAppParticipantProjection
+  participants: RoomAppParticipantProjection[]
+  subscribe: (
+    listener: (message: RoomAppTransportEnvelope) => void
+  ) => () => void
+  send: (
+    lane: "reliable" | "realtime",
+    appInstanceId: string,
+    payload: Record<string, unknown>
+  ) => boolean
+  onClose: () => void
+}
+
+function handshakeToken(): string {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  }
+}
+
+export default function RoomAppHost({
+  app,
+  appInstanceId,
+  self,
+  participants,
+  subscribe,
+  send,
+  onClose,
+}: RoomAppHostProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const portRef = useRef<MessagePort | null>(null)
+  const tokenRef = useRef(handshakeToken())
+  const readyRef = useRef(false)
+  const previousParticipantsRef = useRef<RoomAppParticipantProjection[]>([])
+  const sendRef = useRef(send)
+  sendRef.current = send
+  const [ready, setReady] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  const post = useCallback((message: RoomAppHostMessage) => {
+    try {
+      portRef.current?.postMessage(message)
+    } catch {
+      setFailed(true)
+    }
+  }, [])
+
+  const sendBootstrap = useCallback(() => {
+    const frame = iframeRef.current
+    if (!frame?.contentWindow) return
+    tokenRef.current = handshakeToken()
+    readyRef.current = false
+    setReady(false)
+    const channel = new MessageChannel()
+    const port = channel.port1
+    portRef.current?.close()
+    portRef.current = port
+    port.start()
+    port.onmessage = (event) => {
+      const message = decodeRoomAppClientMessage(event.data, appInstanceId)
+      if (!message) {
+        post({
+          type: "error",
+          appInstanceId,
+          error: "unsupported_message",
+        })
+        return
+      }
+      if (message.type === "ready") {
+        if (message.handshakeToken !== tokenRef.current) {
+          setFailed(true)
+          return
+        }
+        readyRef.current = true
+        setReady(true)
+        const projected = projectRoomAppParticipants(participants)
+        previousParticipantsRef.current = projected
+        post({
+          type: "ready",
+          protocolVersion: 1,
+          appInstanceId,
+          self,
+          participants: projected,
+        })
+        return
+      }
+      const serializedBytes = serializedRoomAppBytes(message.payload)
+      if (serializedBytes === null) return
+      const lane = message.type === "sendReliable" ? "reliable" : "realtime"
+      if (!sendRef.current(lane, appInstanceId, message.payload))
+        post({ type: "error", appInstanceId, error: "rate_limited" })
+    }
+    frame.contentWindow.postMessage(
+      {
+        type: "room-app-bootstrap",
+        protocolVersion: 1,
+        appInstanceId,
+        handshakeToken: tokenRef.current,
+      },
+      app.origin === window.location.origin ? app.origin : "*",
+      [channel.port2]
+    )
+  }, [app.origin, appInstanceId, participants, post, self])
+
+  useEffect(() => {
+    if (!validateRoomAppDefinition(app) || !isRoomAppAllowlisted(app)) {
+      setFailed(true)
+      return
+    }
+    return () => {
+      readyRef.current = false
+      portRef.current?.close()
+      portRef.current = null
+    }
+  }, [app])
+
+  useEffect(() => {
+    return subscribe((message) => {
+      if (!readyRef.current || message.appInstanceId !== appInstanceId) return
+      post({
+        type: message.lane,
+        appInstanceId,
+        payload: message.payload,
+      })
+    })
+  }, [appInstanceId, post, subscribe])
+
+  useEffect(() => {
+    const next = projectRoomAppParticipants(participants)
+    const previous = previousParticipantsRef.current
+    if (!readyRef.current) {
+      previousParticipantsRef.current = next
+      return
+    }
+    const previousById = new Map(
+      previous.map((participant) => [participant.participantId, participant])
+    )
+    const nextById = new Map(
+      next.map((participant) => [participant.participantId, participant])
+    )
+    for (const participant of next) {
+      if (!previousById.has(participant.participantId))
+        post({
+          type: "participant_join",
+          appInstanceId,
+          participant,
+        })
+    }
+    for (const participant of previous) {
+      if (!nextById.has(participant.participantId))
+        post({
+          type: "participant_leave",
+          appInstanceId,
+          participant,
+        })
+    }
+    previousParticipantsRef.current = next
+  }, [appInstanceId, participants, post])
+
+  if (!validateRoomAppDefinition(app) || !isRoomAppAllowlisted(app))
+    return <div role="alert">This Room App is not allowlisted.</div>
+
+  return (
+    <section
+      aria-label={app.label}
+      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-gray-950"
+      data-testid="room-app-host"
+    >
+      <div className="flex flex-none items-center justify-between border-b border-gray-800 px-3 py-2 text-xs text-gray-300">
+        <span>{app.label}</span>
+        <div className="flex items-center gap-2">
+          <span aria-live="polite">
+            {failed ? "unavailable" : ready ? "ready" : "connecting…"}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-1 text-gray-400 hover:bg-gray-800 hover:text-white"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+      {failed ? (
+        <div className="flex flex-1 items-center justify-center p-6 text-sm text-gray-400">
+          This Room App is unavailable. The Room is still usable.
+        </div>
+      ) : (
+        <iframe
+          ref={iframeRef}
+          title={app.label}
+          src={app.url}
+          sandbox="allow-scripts"
+          referrerPolicy="no-referrer"
+          allow=""
+          onLoad={sendBootstrap}
+          onError={() => setFailed(true)}
+          className="min-h-0 flex-1 border-0"
+          data-testid="room-app-iframe"
+        />
+      )}
+    </section>
+  )
+}

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -138,6 +138,7 @@ export default function RoomAppHost({
       post({
         type: message.lane,
         appInstanceId,
+        sourceParticipantId: message.sourceParticipantId,
         payload: message.payload,
       })
     })

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -89,6 +89,9 @@ const baseHookReturn = {
   connectLocalRuntime: vi.fn(),
   runtimeConnectionStatus: "idle" as const,
   leaveRoom: vi.fn(),
+  roomAppsEnabled: false,
+  sendRoomAppMessage: vi.fn(() => false),
+  subscribeRoomAppMessages: vi.fn(() => () => undefined),
 }
 
 const LATE_JOIN_EXPIRY = Date.now() + 365 * 24 * 60 * 60 * 1000
@@ -1083,6 +1086,34 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       screen.queryByText("Connection command copied")
     ).not.toBeInTheDocument()
     expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
+  })
+
+  it("keeps a selected Room App tab mounted instead of treating it as a stale Task", async () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      roomAppsEnabled: true,
+      participants: [
+        {
+          peerId: "local-peer",
+          name: "Alice",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+        },
+      ],
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+    )
+
+    const appTab = screen.getByTestId("interaction-tab-app-shared-canvas")
+    fireEvent.click(appTab)
+    expect(appTab).toHaveAttribute("aria-selected", "true")
+    await waitFor(() =>
+      expect(screen.getByTestId("room-app-host")).toBeInTheDocument()
+    )
   })
 
   it("uses the intentional two-row mobile header layout with a truncating Room id", () => {

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -330,12 +330,16 @@ export default function RoomContent({
   }, [activeInteraction, effectiveLocalParticipantId, taskProjections])
 
   useEffect(() => {
+    const isRoomAppInteraction =
+      activeInteraction.startsWith("app:") &&
+      roomApps.some((app) => activeInteraction === `app:${app.id}`)
     if (
       activeInteraction !== "room" &&
-      !taskProjections.some((task) => task.requestId === activeInteraction)
+      !taskProjections.some((task) => task.requestId === activeInteraction) &&
+      !isRoomAppInteraction
     )
       setActiveInteraction("room")
-  }, [activeInteraction, taskProjections])
+  }, [activeInteraction, roomApps, taskProjections])
 
   useEffect(() => {
     if (

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -7,12 +7,21 @@ import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
 import AgentInviteControl from "./AgentInviteControl"
 import { LiveTranscriptControl, LiveTranscriptSegments } from "./LiveTranscript"
+import RoomAppHost from "./RoomAppHost"
 import TaskLiveView from "./TaskLiveView"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { agentActivityLabel } from "../common/agentActivity"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
+import {
+  experimentalRoomAppCatalog,
+  isRoomAppAllowlisted,
+  ROOM_APP_MAX_INSTANCES,
+  projectRoomAppParticipants,
+  roomAppInstanceId,
+  validateRoomAppDefinition,
+} from "../common/roomApp"
 import {
   buildTaskProjections,
   isTaskTerminal,
@@ -117,6 +126,7 @@ export default function RoomContent({
   const [taskInstruction, setTaskInstruction] = useState("")
   const [taskError, setTaskError] = useState("")
   const [activeInteraction, setActiveInteraction] = useState("room")
+  const [activeRoomAppId, setActiveRoomAppId] = useState<string | null>(null)
   const [stageView, setStageView] = useState<"screen" | "live-view">("screen")
   const taskLiveViewState = useRef(new Map())
   const observedLiveViewKeys = useRef(new Set<string>())
@@ -187,6 +197,9 @@ export default function RoomContent({
     leaveRoom,
     localParticipantId,
     agentActivities,
+    roomAppsEnabled,
+    sendRoomAppMessage,
+    subscribeRoomAppMessages,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
   })
@@ -197,6 +210,34 @@ export default function RoomContent({
   )
   const effectiveLocalParticipantId =
     localParticipantId ?? getLocalRoomAuth()?.participantId
+  const roomApps = useMemo(
+    () =>
+      roomAppsEnabled
+        ? experimentalRoomAppCatalog()
+            .filter(
+              (app) =>
+                validateRoomAppDefinition(app) && isRoomAppAllowlisted(app)
+            )
+            .slice(0, ROOM_APP_MAX_INSTANCES)
+        : [],
+    [roomAppsEnabled]
+  )
+  const activeRoomApp = roomApps.find(
+    (app) => activeRoomAppId === app.id && activeInteraction === `app:${app.id}`
+  )
+  const roomAppParticipants = projectRoomAppParticipants(
+    participants.map((participant) => ({
+      participantId:
+        participant.peerId === LOCAL_PEER_ID
+          ? effectiveLocalParticipantId ?? ""
+          : participant.peerId,
+      name: participant.name,
+      kind: participant.kind,
+    }))
+  )
+  const roomAppSelf = roomAppParticipants.find(
+    (participant) => participant.participantId === effectiveLocalParticipantId
+  )
   const activeTask = taskProjections.find(
     (task) => task.requestId === activeInteraction
   )
@@ -295,6 +336,17 @@ export default function RoomContent({
     )
       setActiveInteraction("room")
   }, [activeInteraction, taskProjections])
+
+  useEffect(() => {
+    if (
+      activeRoomAppId &&
+      (!roomApps.some((app) => app.id === activeRoomAppId) ||
+        activeInteraction !== `app:${activeRoomAppId}`)
+    ) {
+      setActiveRoomAppId(null)
+      if (activeInteraction.startsWith("app:")) setActiveInteraction("room")
+    }
+  }, [activeInteraction, activeRoomAppId, roomApps])
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
@@ -1061,6 +1113,26 @@ export default function RoomContent({
                 )}
               </button>
             ))}
+            {roomApps.map((app) => (
+              <button
+                key={app.id}
+                type="button"
+                role="tab"
+                aria-selected={activeInteraction === `app:${app.id}`}
+                data-testid={`interaction-tab-app-${app.id}`}
+                onClick={() => {
+                  setActiveRoomAppId(app.id)
+                  setActiveInteraction(`app:${app.id}`)
+                }}
+                className={`flex max-w-52 shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition ${
+                  activeInteraction === `app:${app.id}`
+                    ? "bg-blue-600 text-white"
+                    : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                }`}
+              >
+                <span className="truncate">{app.label}</span>
+              </button>
+            ))}
           </div>
           <div
             data-testid="interaction-content"
@@ -1086,25 +1158,40 @@ export default function RoomContent({
               </div>
             )}
             <div data-testid="interaction-chat" className="min-h-0 flex-1">
-              <TextChatCard
-                key={activeInteraction}
-                room={roomName}
-                nickName={nickName}
-                messages={interactionMessages}
-                attachments={interactionAttachments}
-                participants={participants}
-                pendingFiles={activeTask ? [] : pendingFiles}
-                onSendText={wrappedSendText}
-                onSendFile={wrappedSendFile}
-                onSendAction={sendActionMessage}
-                localParticipantId={effectiveLocalParticipantId}
-                onCollabRespond={handleCollabRespond}
-                onReadArtifact={handleReadArtifact}
-                onCollabResult={handleCollabResult}
-                onPermissionRespond={handlePermissionResponse}
-                taskAvailable={!activeTaskUnavailable}
-                taskRequestId={activeTask?.requestId}
-              />
+              {activeRoomApp && roomAppSelf ? (
+                <RoomAppHost
+                  app={activeRoomApp}
+                  appInstanceId={roomAppInstanceId(roomName, activeRoomApp.id)}
+                  self={roomAppSelf}
+                  participants={roomAppParticipants}
+                  subscribe={subscribeRoomAppMessages}
+                  send={sendRoomAppMessage}
+                  onClose={() => {
+                    setActiveRoomAppId(null)
+                    setActiveInteraction("room")
+                  }}
+                />
+              ) : (
+                <TextChatCard
+                  key={activeInteraction}
+                  room={roomName}
+                  nickName={nickName}
+                  messages={interactionMessages}
+                  attachments={interactionAttachments}
+                  participants={participants}
+                  pendingFiles={activeTask ? [] : pendingFiles}
+                  onSendText={wrappedSendText}
+                  onSendFile={wrappedSendFile}
+                  onSendAction={sendActionMessage}
+                  localParticipantId={effectiveLocalParticipantId}
+                  onCollabRespond={handleCollabRespond}
+                  onReadArtifact={handleReadArtifact}
+                  onCollabResult={handleCollabResult}
+                  onPermissionRespond={handlePermissionResponse}
+                  taskAvailable={!activeTaskUnavailable}
+                  taskRequestId={activeTask?.requestId}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -256,6 +256,7 @@ export interface RoomSessionEnv {
   SFU_APP_ID?: string
   SFU_APP_SECRET?: string
   AGENT_MEDIA_ENABLED?: string
+  ROOM_APPS_ENABLED?: string
   // #228: preconfigured production Worker secret for Room-authoritative
   // collaboration analytics (direct Mixpanel /import). Absent in
   // local/test environments: analytics safely no-ops.
@@ -279,6 +280,7 @@ interface StoredParticipant extends RoomParticipant {
   sessionId?: string
   muted?: boolean
   fileChannelReady?: boolean
+  appDataChannelReady?: boolean
   tracks?: RoomMediaTrack[]
 }
 
@@ -684,7 +686,7 @@ type ClientMessage =
     }
   | { type: "mute"; muted: boolean }
   | { type: "unpublish"; trackName: string }
-  | { type: "datachannel-ready" }
+  | { type: "datachannel-ready"; appDataChannelReady?: boolean }
   | { type: "resync" }
   | { type: "leave" }
   | { type: "meeting-notes-start"; agentParticipantId: string }
@@ -931,6 +933,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           "sessionId",
           "muted",
           "fileChannelReady",
+          "appDataChannelReady",
           "tracks",
         ] as const) {
           if (key in participant) {
@@ -959,6 +962,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           sessionId: participant.sessionId,
           muted: participant.muted === true,
           fileChannelReady: participant.fileChannelReady === true,
+          appDataChannelReady: participant.appDataChannelReady === true,
           tracks: participant.tracks ?? [],
         }
         delete participant.sessionId
@@ -1452,6 +1456,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       meetingNotesMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
       agentVoice: room.agentVoice,
       agentVoiceMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+      ...(this.env.ROOM_APPS_ENABLED !== undefined
+        ? { roomAppsEnabled: this.env.ROOM_APPS_ENABLED === "true" }
+        : {}),
       agentActivities: [...this.transientAgentActivities.values()].filter(
         (activity) => room.participants[activity.agentParticipantId]?.connected
       ),
@@ -5219,6 +5226,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
     if (message.type === "datachannel-ready") {
       participant.media.fileChannelReady = true
+      participant.media.appDataChannelReady =
+        message.appDataChannelReady === true
       await this.saveRoom(room)
       await this.broadcastState(room)
       return

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -11,6 +11,7 @@ class FakeTrack {
 }
 
 class FakeDataChannel {
+  constructor(public label = "") {}
   binaryType = ""
   bufferedAmountLowThreshold = 0
   bufferedAmount = 0
@@ -29,6 +30,7 @@ class FakeDataChannel {
 
 class FakePeerConnection {
   static instances: FakePeerConnection[] = []
+  static dataChannels: FakeDataChannel[] = []
   connectionState = "connected"
   ontrack: ((event: unknown) => void) | null = null
   onconnectionstatechange: (() => void) | null = null
@@ -67,8 +69,10 @@ class FakePeerConnection {
   setRemoteDescription() {
     return Promise.resolve()
   }
-  createDataChannel() {
-    return new FakeDataChannel()
+  createDataChannel(label: string) {
+    const channel = new FakeDataChannel(label)
+    FakePeerConnection.dataChannels.push(channel)
+    return channel
   }
   removeTrack() {}
   close() {}
@@ -101,6 +105,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
 
   beforeEach(() => {
     FakePeerConnection.instances.length = 0
+    FakePeerConnection.dataChannels.length = 0
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       FakePeerConnection
     class FakeMediaStream {
@@ -246,6 +251,77 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
     expect(sessionStorage.getItem("ts_token")).toBeNull()
     expect(localStorage.getItem("ts_token")).toBeNull()
 
+    unmount()
+  })
+
+  it("dispatches reliable and realtime Room App messages on the shared transport", async () => {
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            roomAppsEnabled: true,
+          })
+        if (url.endsWith("/api/sfu/datachannels/establish"))
+          return jsonResponse({})
+        if (url.endsWith("/api/sfu/datachannels/new")) {
+          const body = JSON.parse(String(init?.body ?? "{}")) as {
+            dataChannels?: Array<{ dataChannelName?: string }>
+          }
+          const appChannels = body.dataChannels?.filter((channel) =>
+            channel.dataChannelName?.startsWith("room-app-")
+          )
+          if (appChannels?.length)
+            return jsonResponse({
+              dataChannels: appChannels.map((_, index) => ({ id: index + 2 })),
+            })
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        }
+        if (url.endsWith("/api/sfu/tracks"))
+          return localTrackResponse(init) ?? jsonResponse({})
+        return jsonResponse({})
+      }
+    )
+
+    const { result, unmount } = renderHook(() =>
+      useSfuChatRoom("room-app", "alice", "audio", {})
+    )
+
+    await waitFor(() => expect(result.current.roomAppsEnabled).toBe(true))
+    await waitFor(() =>
+      expect(
+        FakePeerConnection.dataChannels.filter((channel) =>
+          channel.label.startsWith("room-app-")
+        )
+      ).toHaveLength(2)
+    )
+
+    act(() => {
+      expect(
+        result.current.sendRoomAppMessage("reliable", "shared-canvas:room", {
+          type: "stroke",
+        })
+      ).toBe(true)
+      expect(
+        result.current.sendRoomAppMessage("realtime", "shared-canvas:room", {
+          type: "cursor",
+        })
+      ).toBe(true)
+    })
+
+    const channels = FakePeerConnection.dataChannels.filter((channel) =>
+      channel.label.startsWith("room-app-")
+    )
+    expect(
+      JSON.parse(String(channels[0]!.send.mock.calls[0]![0]))
+    ).toMatchObject({ lane: "reliable", appInstanceId: "shared-canvas:room" })
+    expect(
+      JSON.parse(String(channels[1]!.send.mock.calls[0]![0]))
+    ).toMatchObject({ lane: "realtime", appInstanceId: "shared-canvas:room" })
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -380,6 +380,29 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
         channel.label.startsWith("files-")
       )
     ).toBe(true)
+    await waitFor(() => expect(lastFakeWebSocket).not.toBeNull())
+    act(() =>
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            participants: [],
+            messages: [],
+            attachments: [],
+            liveTranscript: { active: false },
+            liveTranscriptSegments: [],
+            agentVoice: {},
+            agentVoiceMediaAvailable: false,
+            meetingNotesMediaAvailable: false,
+            runtimeHosts: {},
+            runtimeHostProviders: {},
+            roomAppsEnabled: true,
+          },
+        }),
+      })
+    )
+    expect(result.current.roomAppsEnabled).toBe(false)
+    expect(result.current.error).toBe("")
     unmount()
   })
 

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSfuChatRoom } from "./useSfuChatRoom"
+import { roomAppInstanceId } from "../common/roomApp"
 
 class FakeTrack {
   kind: "audio" | "video" = "audio"
@@ -11,7 +12,10 @@ class FakeTrack {
 }
 
 class FakeDataChannel {
-  constructor(public label = "") {}
+  constructor(
+    public label = "",
+    public options: Record<string, unknown> = {}
+  ) {}
   binaryType = ""
   bufferedAmountLowThreshold = 0
   bufferedAmount = 0
@@ -25,6 +29,9 @@ class FakeDataChannel {
   }
   removeEventListener(type: string, handler: (event: unknown) => void) {
     this.listeners.get(type)?.delete(handler)
+  }
+  emit(type: string, event: unknown) {
+    for (const handler of this.listeners.get(type) ?? []) handler(event)
   }
 }
 
@@ -69,8 +76,8 @@ class FakePeerConnection {
   setRemoteDescription() {
     return Promise.resolve()
   }
-  createDataChannel(label: string) {
-    const channel = new FakeDataChannel(label)
+  createDataChannel(label: string, options: Record<string, unknown> = {}) {
+    const channel = new FakeDataChannel(label, options)
     FakePeerConnection.dataChannels.push(channel)
     return channel
   }
@@ -98,6 +105,11 @@ function localTrackResponse(init?: RequestInit) {
     tracks: [{ mid: track.mid ?? "0", trackName: track.trackName }],
   })
 }
+
+let lastFakeWebSocket: {
+  onopen: (() => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+} | null = null
 
 describe("useSfuChatRoom — Turnstile boundary", () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -129,7 +141,9 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
       onmessage: ((event: { data: string }) => void) | null = null
       onerror: (() => void) | null = null
       onclose: (() => void) | null = null
-      constructor(public url: string) {}
+      constructor(public url: string) {
+        lastFakeWebSocket = this
+      }
       send() {}
       close() {}
     }
@@ -168,6 +182,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
   })
 
   afterEach(() => {
+    lastFakeWebSocket = null
     vi.restoreAllMocks()
   })
 
@@ -255,6 +270,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
   })
 
   it("dispatches reliable and realtime Room App messages on the shared transport", async () => {
+    const appInstanceId = roomAppInstanceId("room-app", "shared-canvas")
     fetchMock.mockImplementation(
       (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === "string" ? input : input.toString()
@@ -302,12 +318,12 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
 
     act(() => {
       expect(
-        result.current.sendRoomAppMessage("reliable", "shared-canvas:room", {
+        result.current.sendRoomAppMessage("reliable", appInstanceId, {
           type: "stroke",
         })
       ).toBe(true)
       expect(
-        result.current.sendRoomAppMessage("realtime", "shared-canvas:room", {
+        result.current.sendRoomAppMessage("realtime", appInstanceId, {
           type: "cursor",
         })
       ).toBe(true)
@@ -318,11 +334,290 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
     )
     expect(
       JSON.parse(String(channels[0]!.send.mock.calls[0]![0]))
-    ).toMatchObject({ lane: "reliable", appInstanceId: "shared-canvas:room" })
+    ).toMatchObject({ lane: "reliable", appInstanceId })
     expect(
       JSON.parse(String(channels[1]!.send.mock.calls[0]![0]))
-    ).toMatchObject({ lane: "realtime", appInstanceId: "shared-canvas:room" })
+    ).toMatchObject({ lane: "realtime", appInstanceId })
     unmount()
+  })
+
+  it("isolates optional Room App channel setup failures from the Room connection", async () => {
+    let dataChannelNewCalls = 0
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            roomAppsEnabled: true,
+          })
+        if (url.endsWith("/api/sfu/datachannels/establish"))
+          return jsonResponse({})
+        if (url.endsWith("/api/sfu/datachannels/new")) {
+          dataChannelNewCalls += 1
+          if (dataChannelNewCalls === 2)
+            return Promise.reject(new Error("room_app_channels_unavailable"))
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        }
+        if (url.endsWith("/api/sfu/tracks"))
+          return localTrackResponse(init) ?? jsonResponse({})
+        return jsonResponse({})
+      }
+    )
+
+    const { result, unmount } = renderHook(() =>
+      useSfuChatRoom("room-app-failure", "alice", "audio", {})
+    )
+
+    await waitFor(() => expect(dataChannelNewCalls).toBe(2))
+    expect(result.current.roomAppsEnabled).toBe(false)
+    expect(result.current.error).toBe("")
+    expect(
+      FakePeerConnection.dataChannels.some((channel) =>
+        channel.label.startsWith("files-")
+      )
+    ).toBe(true)
+    unmount()
+  })
+
+  it("subscribes to remote Room App lanes, tags the bound sender, retries, and cleans up", async () => {
+    const appInstanceId = roomAppInstanceId("remote-app-room", "shared-canvas")
+    let dataChannelNewCalls = 0
+    let remoteFailureCount = 0
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            roomAppsEnabled: true,
+          })
+        if (url.endsWith("/api/sfu/datachannels/establish"))
+          return jsonResponse({})
+        if (url.endsWith("/api/sfu/datachannels/new")) {
+          dataChannelNewCalls += 1
+          const body = JSON.parse(String(init?.body ?? "{}")) as {
+            publisherSessionId?: string
+            dataChannels?: Array<{ dataChannelName?: string }>
+          }
+          if (body.publisherSessionId && remoteFailureCount === 0) {
+            remoteFailureCount += 1
+            return Promise.reject(new Error("remote_channel_retry"))
+          }
+          const count = body.dataChannels?.length ?? 0
+          return jsonResponse({
+            dataChannels: Array.from({ length: count }, () => ({
+              id: dataChannelNewCalls + 10,
+            })),
+          })
+        }
+        if (url.endsWith("/api/sfu/tracks"))
+          return localTrackResponse(init) ?? jsonResponse({})
+        return jsonResponse({})
+      }
+    )
+
+    const received: unknown[] = []
+    const { result, unmount } = renderHook(() =>
+      useSfuChatRoom("remote-app-room", "alice", "audio", {})
+    )
+    await waitFor(() => expect(lastFakeWebSocket).not.toBeNull())
+    act(() => lastFakeWebSocket?.onopen?.())
+    act(() => {
+      result.current.subscribeRoomAppMessages((message) =>
+        received.push(message)
+      )
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 1,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: [
+              {
+                id: "participant-1",
+                name: "Alice",
+                kind: "human",
+                connected: true,
+                joinedAt: 1,
+                lastSeenAt: 1,
+                media: {
+                  sessionId: "session-1",
+                  muted: false,
+                  fileChannelReady: false,
+                  appDataChannelReady: false,
+                  tracks: [],
+                },
+              },
+              {
+                id: "human-b",
+                name: "Bob",
+                kind: "human",
+                connected: true,
+                joinedAt: 1,
+                lastSeenAt: 1,
+                media: {
+                  sessionId: "session-b",
+                  muted: false,
+                  fileChannelReady: false,
+                  appDataChannelReady: true,
+                  tracks: [],
+                },
+              },
+            ],
+            messages: [],
+            liveTranscript: { active: false },
+            liveTranscriptSegments: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: false,
+            agentVoice: {},
+            agentVoiceMediaAvailable: false,
+            roomAppsEnabled: true,
+          },
+        }),
+      })
+    })
+
+    await waitFor(() =>
+      expect(
+        FakePeerConnection.dataChannels.filter((channel) =>
+          channel.label.endsWith("-subscriber")
+        )
+      ).toHaveLength(2)
+    )
+    expect(dataChannelNewCalls).toBeGreaterThanOrEqual(5)
+    const remoteChannels = FakePeerConnection.dataChannels.filter((channel) =>
+      channel.label.endsWith("-subscriber")
+    )
+    expect(
+      remoteChannels.find((channel) => channel.label.includes("reliable"))
+        ?.options
+    ).toMatchObject({ ordered: true })
+    expect(
+      remoteChannels.find((channel) => channel.label.includes("realtime"))
+        ?.options
+    ).toMatchObject({ ordered: false, maxRetransmits: 0 })
+
+    const reliable = remoteChannels.find((channel) =>
+      channel.label.includes("reliable")
+    )!
+    const realtime = remoteChannels.find((channel) =>
+      channel.label.includes("realtime")
+    )!
+    act(() => {
+      reliable.emit("message", {
+        data: JSON.stringify({
+          protocolVersion: 1,
+          appInstanceId,
+          lane: "reliable",
+          payload: { type: "cursor", sourceParticipantId: "spoofed" },
+        }),
+      })
+      realtime.emit("message", {
+        data: JSON.stringify({
+          protocolVersion: 1,
+          appInstanceId: "shared-canvas:deadbeef",
+          lane: "realtime",
+          payload: { type: "cursor" },
+        }),
+      })
+    })
+    expect(received).toEqual([])
+
+    act(() =>
+      reliable.emit("message", {
+        data: JSON.stringify({
+          protocolVersion: 1,
+          appInstanceId,
+          lane: "reliable",
+          payload: { type: "cursor", x: 1 },
+        }),
+      })
+    )
+    expect(received).toMatchObject([
+      {
+        appInstanceId,
+        lane: "reliable",
+        sourceParticipantId: "human-b",
+        payload: { type: "cursor", x: 1 },
+      },
+    ])
+
+    const oldRemoteChannels = [...remoteChannels]
+    act(() =>
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 1,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: [
+              {
+                id: "participant-1",
+                name: "Alice",
+                kind: "human",
+                connected: true,
+                joinedAt: 1,
+                lastSeenAt: 1,
+                media: {
+                  sessionId: "session-1",
+                  muted: false,
+                  fileChannelReady: false,
+                  appDataChannelReady: false,
+                  tracks: [],
+                },
+              },
+              {
+                id: "human-b",
+                name: "Bob",
+                kind: "human",
+                connected: true,
+                joinedAt: 1,
+                lastSeenAt: 1,
+                media: {
+                  sessionId: "session-b2",
+                  muted: false,
+                  fileChannelReady: false,
+                  appDataChannelReady: true,
+                  tracks: [],
+                },
+              },
+            ],
+            messages: [],
+            liveTranscript: { active: false },
+            liveTranscriptSegments: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: false,
+            agentVoice: {},
+            agentVoiceMediaAvailable: false,
+            roomAppsEnabled: true,
+          },
+        }),
+      })
+    )
+    await waitFor(() =>
+      expect(
+        FakePeerConnection.dataChannels.filter((channel) =>
+          channel.label.endsWith("-subscriber")
+        )
+      ).toHaveLength(4)
+    )
+    expect(
+      oldRemoteChannels.every((channel) => channel.close.mock.calls.length)
+    ).toBeTruthy()
+    const currentRemoteChannels = FakePeerConnection.dataChannels.filter(
+      (channel) => channel.label.endsWith("-subscriber")
+    )
+    unmount()
+    expect(
+      currentRemoteChannels.every((channel) => channel.close.mock.calls.length)
+    ).toBeTruthy()
   })
 
   it("does not request a Turnstile token at all when the caller provides no getTurnstileToken", async () => {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -8,6 +8,7 @@ import {
 import {
   decodeRoomAppEnvelope,
   encodeRoomAppEnvelope,
+  isRoomAppInstanceForRoom,
   roomAppRateGuard,
   type RoomAppLane,
   type RoomAppTransportEnvelope,
@@ -1406,9 +1407,13 @@ export function useSfuChatRoom(
   )
 
   const handleRoomAppChannelMessage = useCallback(
-    (lane: RoomAppLane, event: MessageEvent) => {
+    (sourceParticipantId: string, lane: RoomAppLane, event: MessageEvent) => {
       const envelope = decodeRoomAppEnvelope(event.data)
-      if (!envelope || envelope.lane !== lane) {
+      if (
+        !envelope ||
+        envelope.lane !== lane ||
+        !isRoomAppInstanceForRoom(roomName, envelope.appInstanceId)
+      ) {
         roomAppStatsRef.current.droppedMessages += 1
         return
       }
@@ -1422,9 +1427,10 @@ export function useSfuChatRoom(
       roomAppStatsRef.current.bytesReceived += bytes
       if (lane === "reliable") roomAppStatsRef.current.reliableMessages += 1
       else roomAppStatsRef.current.realtimeMessages += 1
-      for (const listener of roomAppListenersRef.current) listener(envelope)
+      const received = { ...envelope, sourceParticipantId }
+      for (const listener of roomAppListenersRef.current) listener(received)
     },
-    []
+    [roomName]
   )
 
   const cleanupRemoteRoomAppChannel = useCallback(
@@ -1585,7 +1591,7 @@ export function useSfuChatRoom(
         dataChannelsRef.current.add(channel)
         dataChannelIdsRef.current.add(channelId)
         channel.addEventListener("message", (event) =>
-          handleRoomAppChannelMessage(lane, event)
+          handleRoomAppChannelMessage(participant.id, lane, event)
         )
         const cleanup = () =>
           cleanupRemoteRoomAppChannel(key, channelAttempt, "closed")
@@ -1698,40 +1704,59 @@ export function useSfuChatRoom(
           dataChannelName: roomAppChannelName(session.participantId, lane),
         })
       )
-      const appResponse = await apiRequest("datachannels/new", {
-        room: roomName,
-        participantId: session.participantId,
-        token: session.participantToken,
-        sessionId: session.sessionId,
-        dataChannels: appChannelNames.map(({ lane, dataChannelName }) => ({
-          location: "local",
-          dataChannelName,
-          ordered: lane === "reliable",
-          ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
-        })),
-      })
-      const channelIds = appResponse.dataChannels ?? []
-      if (
-        channelIds.length !== appChannelNames.length ||
-        channelIds.some((entry) => typeof entry.id !== "number")
-      )
-        throw new Error("SFU Room App data channels were not created")
-      for (const [
-        index,
-        { lane, dataChannelName },
-      ] of appChannelNames.entries()) {
-        const channelId = channelIds[index].id as number
-        const channel = pc.createDataChannel(dataChannelName, {
-          negotiated: true,
-          id: channelId,
-          ordered: lane === "reliable",
-          ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+      const appChannelIds: number[] = []
+      try {
+        const appResponse = await apiRequest("datachannels/new", {
+          room: roomName,
+          participantId: session.participantId,
+          token: session.participantToken,
+          sessionId: session.sessionId,
+          dataChannels: appChannelNames.map(({ lane, dataChannelName }) => ({
+            location: "local",
+            dataChannelName,
+            ordered: lane === "reliable",
+            ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+          })),
         })
-        dataChannelsRef.current.add(channel)
-        dataChannelIdsRef.current.add(channelId)
-        localRoomAppChannelsRef.current.set(lane, channel)
+        const channelIds = appResponse.dataChannels ?? []
+        appChannelIds.push(
+          ...channelIds.flatMap((entry) =>
+            typeof entry.id === "number" ? [entry.id] : []
+          )
+        )
+        if (
+          channelIds.length !== appChannelNames.length ||
+          channelIds.some((entry) => typeof entry.id !== "number")
+        )
+          throw new Error("SFU Room App data channels were not created")
+        for (const [
+          index,
+          { lane, dataChannelName },
+        ] of appChannelNames.entries()) {
+          const channelId = channelIds[index].id as number
+          const channel = pc.createDataChannel(dataChannelName, {
+            negotiated: true,
+            id: channelId,
+            ordered: lane === "reliable",
+            ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+          })
+          dataChannelsRef.current.add(channel)
+          dataChannelIdsRef.current.add(channelId)
+          localRoomAppChannelsRef.current.set(lane, channel)
+        }
+        roomAppChannelsReadyRef.current = true
+      } catch {
+        for (const channel of localRoomAppChannelsRef.current.values()) {
+          dataChannelsRef.current.delete(channel)
+          channel.close()
+        }
+        localRoomAppChannelsRef.current.clear()
+        for (const appChannelId of appChannelIds)
+          dataChannelIdsRef.current.delete(appChannelId)
+        roomAppChannelsReadyRef.current = false
+        roomAppsEnabledRef.current = false
+        setRoomAppsEnabled(false)
       }
-      roomAppChannelsReadyRef.current = true
     }
   }, [apiRequest, roomAppChannelName, roomName])
 
@@ -3429,7 +3454,11 @@ export function useSfuChatRoom(
       appInstanceId: string,
       payload: Record<string, unknown>
     ): boolean => {
-      if (!roomAppsEnabledRef.current || !roomAppChannelsReadyRef.current)
+      if (
+        !roomAppsEnabledRef.current ||
+        !roomAppChannelsReadyRef.current ||
+        !isRoomAppInstanceForRoom(roomName, appInstanceId)
+      )
         return false
       const encoded = encodeRoomAppEnvelope({
         appInstanceId,
@@ -3450,7 +3479,7 @@ export function useSfuChatRoom(
       else roomAppStatsRef.current.realtimeMessages += 1
       return true
     },
-    []
+    [roomName]
   )
 
   const subscribeRoomAppMessages = useCallback(

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -618,6 +618,7 @@ export function useSfuChatRoom(
     bytesReceived: 0,
     droppedMessages: 0,
   })
+  const roomAppsServerEnabledRef = useRef(false)
   const roomAppsEnabledRef = useRef(false)
   const roomAppChannelsReadyRef = useRef(false)
   const dataChannelsRef = useRef(new Set<RTCDataChannel>())
@@ -1697,7 +1698,7 @@ export function useSfuChatRoom(
     localFileChannelRef.current = channel
     localFileChannelIdRef.current = channelId
     dataChannelReadyRef.current = true
-    if (roomAppsEnabledRef.current) {
+    if (roomAppsServerEnabledRef.current) {
       const appChannelNames = (["reliable", "realtime"] as const).map(
         (lane) => ({
           lane,
@@ -1745,6 +1746,8 @@ export function useSfuChatRoom(
           localRoomAppChannelsRef.current.set(lane, channel)
         }
         roomAppChannelsReadyRef.current = true
+        roomAppsEnabledRef.current = roomAppsServerEnabledRef.current
+        setRoomAppsEnabled(roomAppsEnabledRef.current)
       } catch {
         for (const channel of localRoomAppChannelsRef.current.values()) {
           dataChannelsRef.current.delete(channel)
@@ -2610,7 +2613,10 @@ export function useSfuChatRoom(
       setLiveTranscriptMediaAvailable(state.meetingNotesMediaAvailable)
       setAgentVoiceState(state.agentVoice)
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
-      setRoomAppsEnabled(state.roomAppsEnabled === true)
+      roomAppsServerEnabledRef.current = state.roomAppsEnabled === true
+      roomAppsEnabledRef.current =
+        roomAppsServerEnabledRef.current && roomAppChannelsReadyRef.current
+      setRoomAppsEnabled(roomAppsEnabledRef.current)
       const nextActivities = state.agentActivities ?? []
       agentActivitiesRef.current = nextActivities
       setAgentActivities(nextActivities)
@@ -3103,6 +3109,7 @@ export function useSfuChatRoom(
         localFileChannelRef.current = null
         localFileChannelIdRef.current = null
         localRoomAppChannelsRef.current.clear()
+        roomAppsServerEnabledRef.current = false
         roomAppChannelsReadyRef.current = false
         const oldPeerConnection = peerConnectionRef.current
         if (oldPeerConnection) {
@@ -3191,8 +3198,9 @@ export function useSfuChatRoom(
       }
       const session = (await response.json()) as SfuSessionResponse
       sessionRef.current = { ...session, room: roomName }
-      roomAppsEnabledRef.current = session.roomAppsEnabled === true
-      setRoomAppsEnabled(roomAppsEnabledRef.current)
+      roomAppsServerEnabledRef.current = session.roomAppsEnabled === true
+      roomAppsEnabledRef.current = false
+      setRoomAppsEnabled(false)
       await establishDataChannelTransport()
       await publishTrack(audioTrack, "audio", `audio-${session.participantId}`)
       if (screenTrack && screenTrack.readyState === "live") {
@@ -3323,6 +3331,7 @@ export function useSfuChatRoom(
       localFileChannelRef.current = null
       for (const channel of localRoomAppChannels.values()) channel.close()
       localRoomAppChannels.clear()
+      roomAppsServerEnabledRef.current = false
       roomAppChannelsReadyRef.current = false
       roomAppsEnabledRef.current = false
       for (const channel of dataChannels) channel.close()

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -5,6 +5,13 @@ import {
   mergeRoomAndEphemeralMessages,
   reconcileCanonicalRoomMessages,
 } from "@common/messageReconciliation"
+import {
+  decodeRoomAppEnvelope,
+  encodeRoomAppEnvelope,
+  roomAppRateGuard,
+  type RoomAppLane,
+  type RoomAppTransportEnvelope,
+} from "@common/roomApp"
 import { validateRoomAttachmentRead } from "@common/roomAttachments"
 import {
   createRuntimeProviderClaim as createRuntimeProviderCredential,
@@ -95,6 +102,8 @@ const REMOTE_TRACK_SUBSCRIPTION_RETRY_DELAYS_MS = [
 ] as const
 const REMOTE_TRACK_READY_TIMEOUT_MS = 5000
 const REMOTE_FILE_CHANNEL_OPEN_TIMEOUT_MS = 5000
+const ROOM_APP_CHANNEL_OPEN_TIMEOUT_MS = 5000
+const ROOM_APP_RETRY_DELAYS_MS = [100, 500, 2000] as const
 
 const runtimeReattachStorageKey = (room: string) =>
   `free4chat:runtime-reattach:${room}`
@@ -194,6 +203,25 @@ interface RemoteFileChannelAttempt {
   attempt: number
   channel: RTCDataChannel | null
   channelId: number | null
+}
+
+interface RemoteRoomAppChannelAttempt {
+  peerConnection: RTCPeerConnection
+  subscriberSessionId: string
+  publisherSessionId: string
+  participantKind: "human" | "agent"
+  lane: RoomAppLane
+  attempt: number
+  channel: RTCDataChannel | null
+  channelId: number | null
+}
+
+export interface RoomAppTransportStats {
+  reliableMessages: number
+  realtimeMessages: number
+  bytesSent: number
+  bytesReceived: number
+  droppedMessages: number
 }
 
 function hasUsableSessionDescription(response: SfuApiResponse): boolean {
@@ -417,6 +445,7 @@ interface SfuServerMessage {
     sessionId?: string
     muted?: boolean
     fileChannelReady?: boolean
+    appDataChannelReady?: boolean
   }
   message?: SfuMessage
   error?: string
@@ -475,6 +504,7 @@ export function useSfuChatRoom(
   const [error, setError] = useState("")
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("verifying")
+  const [roomAppsEnabled, setRoomAppsEnabled] = useState(false)
   const [resolvedRoomType] = useState<"audio" | "screenshare">(roomType)
   const [liveTranscript, setLiveTranscript] = useState<LiveTranscriptState>({
     active: false,
@@ -568,6 +598,27 @@ export function useSfuChatRoom(
   )
   const remoteFileChannelAttemptCountsRef = useRef(new Map<string, number>())
   const remoteFileChannelIdsRef = useRef(new Map<string, number>())
+  const localRoomAppChannelsRef = useRef(new Map<RoomAppLane, RTCDataChannel>())
+  const remoteRoomAppChannelsRef = useRef(new Map<string, RTCDataChannel>())
+  const remoteRoomAppChannelIdsRef = useRef(new Map<string, number>())
+  const remoteRoomAppChannelAttemptsRef = useRef(
+    new Map<string, RemoteRoomAppChannelAttempt>()
+  )
+  const remoteRoomAppChannelAttemptCountsRef = useRef(new Map<string, number>())
+  const roomAppListenersRef = useRef(
+    new Set<(message: RoomAppTransportEnvelope) => void>()
+  )
+  const roomAppOutboundRateRef = useRef(roomAppRateGuard())
+  const roomAppInboundRateRef = useRef(roomAppRateGuard())
+  const roomAppStatsRef = useRef<RoomAppTransportStats>({
+    reliableMessages: 0,
+    realtimeMessages: 0,
+    bytesSent: 0,
+    bytesReceived: 0,
+    droppedMessages: 0,
+  })
+  const roomAppsEnabledRef = useRef(false)
+  const roomAppChannelsReadyRef = useRef(false)
   const dataChannelsRef = useRef(new Set<RTCDataChannel>())
   const dataChannelIdsRef = useRef(new Set<number>())
   const localFileChannelIdRef = useRef<number | null>(null)
@@ -1017,7 +1068,10 @@ export function useSfuChatRoom(
 
   const closeDataChannels = useCallback(
     async (session: SfuSession | null = sessionRef.current) => {
-      if (!session || dataChannelIdsRef.current.size === 0) return
+      if (!session || dataChannelIdsRef.current.size === 0) {
+        remoteRoomAppChannelIdsRef.current.clear()
+        return
+      }
       const dataChannels = [...dataChannelIdsRef.current].map((id) => ({ id }))
       try {
         await apiRequest("datachannels/close", {
@@ -1033,6 +1087,9 @@ export function useSfuChatRoom(
         dataChannelIdsRef.current.clear()
         localFileChannelIdRef.current = null
         remoteFileChannelIdsRef.current.clear()
+        remoteRoomAppChannelIdsRef.current.clear()
+        localRoomAppChannelsRef.current.clear()
+        roomAppChannelsReadyRef.current = false
       }
     },
     [apiRequest, roomName]
@@ -1337,6 +1394,235 @@ export function useSfuChatRoom(
     [addReceivedFileMessage]
   )
 
+  const roomAppChannelName = useCallback(
+    (participantId: string, lane: RoomAppLane) =>
+      `room-app-${lane}-${participantId}`,
+    []
+  )
+
+  const roomAppChannelKey = useCallback(
+    (participantId: string, lane: RoomAppLane) => `${participantId}:${lane}`,
+    []
+  )
+
+  const handleRoomAppChannelMessage = useCallback(
+    (lane: RoomAppLane, event: MessageEvent) => {
+      const envelope = decodeRoomAppEnvelope(event.data)
+      if (!envelope || envelope.lane !== lane) {
+        roomAppStatsRef.current.droppedMessages += 1
+        return
+      }
+      const bytes = new TextEncoder().encode(
+        JSON.stringify(envelope)
+      ).byteLength
+      if (!roomAppInboundRateRef.current.allow(lane, bytes)) {
+        roomAppStatsRef.current.droppedMessages += 1
+        return
+      }
+      roomAppStatsRef.current.bytesReceived += bytes
+      if (lane === "reliable") roomAppStatsRef.current.reliableMessages += 1
+      else roomAppStatsRef.current.realtimeMessages += 1
+      for (const listener of roomAppListenersRef.current) listener(envelope)
+    },
+    []
+  )
+
+  const cleanupRemoteRoomAppChannel = useCallback(
+    (key: string, attempt: RemoteRoomAppChannelAttempt, reason: string) => {
+      const activeAttempt = remoteRoomAppChannelAttemptsRef.current.get(key)
+      const readyChannel = remoteRoomAppChannelsRef.current.get(key)
+      const ownsAttempt = activeAttempt === attempt
+      const ownsReadyChannel = readyChannel === attempt.channel
+      if (!ownsAttempt && !ownsReadyChannel) return false
+      if (ownsAttempt) remoteRoomAppChannelAttemptsRef.current.delete(key)
+      if (ownsReadyChannel) remoteRoomAppChannelsRef.current.delete(key)
+      if (attempt.channel) {
+        dataChannelsRef.current.delete(attempt.channel)
+        attempt.channel.close()
+      }
+      const channelId =
+        attempt.channelId ?? remoteRoomAppChannelIdsRef.current.get(key) ?? null
+      if (channelId !== null) dataChannelIdsRef.current.delete(channelId)
+      if (ownsReadyChannel || ownsAttempt)
+        remoteRoomAppChannelIdsRef.current.delete(key)
+      sfuClientDiagnostic("room_app_channel_cleanup", { reason })
+      return true
+    },
+    []
+  )
+
+  const clearAllRemoteRoomAppChannels = useCallback(
+    (reason: string) => {
+      const keys = new Set([
+        ...remoteRoomAppChannelAttemptsRef.current.keys(),
+        ...remoteRoomAppChannelsRef.current.keys(),
+      ])
+      for (const key of keys) {
+        const attempt =
+          remoteRoomAppChannelAttemptsRef.current.get(key) ??
+          (() => {
+            const channel = remoteRoomAppChannelsRef.current.get(key)
+            if (!channel) return null
+            const lane = key.split(":")[1] as RoomAppLane
+            return {
+              peerConnection: peerConnectionRef.current!,
+              subscriberSessionId: sessionRef.current?.sessionId ?? "",
+              publisherSessionId: "",
+              participantKind: "human" as const,
+              lane,
+              attempt: 0,
+              channel,
+              channelId: remoteRoomAppChannelIdsRef.current.get(key) ?? null,
+            }
+          })()
+        if (attempt) cleanupRemoteRoomAppChannel(key, attempt, reason)
+      }
+      remoteRoomAppChannelAttemptCountsRef.current.clear()
+    },
+    [cleanupRemoteRoomAppChannel]
+  )
+
+  const resetRemoteRoomAppParticipant = useCallback(
+    (participantId: string, reason: string) => {
+      for (const lane of ["reliable", "realtime"] as const) {
+        const key = roomAppChannelKey(participantId, lane)
+        const attempt =
+          remoteRoomAppChannelAttemptsRef.current.get(key) ??
+          (() => {
+            const channel = remoteRoomAppChannelsRef.current.get(key)
+            if (!channel) return null
+            return {
+              peerConnection: peerConnectionRef.current!,
+              subscriberSessionId: sessionRef.current?.sessionId ?? "",
+              publisherSessionId: "",
+              participantKind: "human" as const,
+              lane,
+              attempt: 0,
+              channel,
+              channelId: remoteRoomAppChannelIdsRef.current.get(key) ?? null,
+            }
+          })()
+        if (attempt) cleanupRemoteRoomAppChannel(key, attempt, reason)
+        remoteRoomAppChannelAttemptCountsRef.current.delete(key)
+      }
+    },
+    [cleanupRemoteRoomAppChannel, roomAppChannelKey]
+  )
+
+  const subscribeRoomAppChannel = useCallback(
+    async (participant: SfuParticipant, lane: RoomAppLane, attempt = 1) => {
+      const pc = peerConnectionRef.current
+      const session = sessionRef.current
+      const media = participant.media
+      const key = roomAppChannelKey(participant.id, lane)
+      if (
+        !roomAppsEnabledRef.current ||
+        !pc ||
+        !session ||
+        participant.id === session.participantId ||
+        participant.kind !== "human" ||
+        !media?.appDataChannelReady ||
+        remoteRoomAppChannelsRef.current.has(key) ||
+        remoteRoomAppChannelAttemptsRef.current.has(key) ||
+        pc.connectionState !== "connected"
+      )
+        return
+      const attemptKey =
+        (remoteRoomAppChannelAttemptCountsRef.current.get(key) ?? 0) + 1
+      remoteRoomAppChannelAttemptCountsRef.current.set(key, attemptKey)
+      const channelAttempt: RemoteRoomAppChannelAttempt = {
+        peerConnection: pc,
+        subscriberSessionId: session.sessionId,
+        publisherSessionId: media.sessionId,
+        participantKind: participant.kind,
+        lane,
+        attempt: attemptKey,
+        channel: null,
+        channelId: null,
+      }
+      remoteRoomAppChannelAttemptsRef.current.set(key, channelAttempt)
+      try {
+        const response = await apiRequest("datachannels/new", {
+          room: roomName,
+          participantId: session.participantId,
+          token: session.participantToken,
+          sessionId: session.sessionId,
+          publisherSessionId: media.sessionId,
+          dataChannels: [
+            {
+              location: "remote",
+              sessionId: media.sessionId,
+              dataChannelName: roomAppChannelName(participant.id, lane),
+              ordered: lane === "reliable",
+              ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+              waitForAck: true,
+            },
+          ],
+        })
+        const channelId = response.dataChannels?.[0]?.id
+        if (typeof channelId !== "number")
+          throw new Error("SFU Room App data channel was not created")
+        if (
+          remoteRoomAppChannelAttemptsRef.current.get(key) !== channelAttempt ||
+          peerConnectionRef.current !== pc ||
+          sessionRef.current?.sessionId !== session.sessionId ||
+          participantMapRef.current.get(participant.id)?.media?.sessionId !==
+            media.sessionId
+        )
+          throw new Error("SFU Room App data channel became stale")
+        const channel = pc.createDataChannel(
+          `${roomAppChannelName(participant.id, lane)}-subscriber`,
+          {
+            negotiated: true,
+            id: channelId,
+            ordered: lane === "reliable",
+            ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+          }
+        )
+        channelAttempt.channel = channel
+        channelAttempt.channelId = channelId
+        remoteRoomAppChannelIdsRef.current.set(key, channelId)
+        dataChannelsRef.current.add(channel)
+        dataChannelIdsRef.current.add(channelId)
+        channel.addEventListener("message", (event) =>
+          handleRoomAppChannelMessage(lane, event)
+        )
+        const cleanup = () =>
+          cleanupRemoteRoomAppChannel(key, channelAttempt, "closed")
+        channel.addEventListener("close", cleanup)
+        channel.addEventListener("error", cleanup)
+        await waitForDataChannelOpen(channel, ROOM_APP_CHANNEL_OPEN_TIMEOUT_MS)
+        if (
+          remoteRoomAppChannelAttemptsRef.current.get(key) !== channelAttempt ||
+          channel.readyState !== "open"
+        )
+          throw new Error("SFU Room App data channel became stale")
+        channel.send("ack")
+        remoteRoomAppChannelAttemptsRef.current.delete(key)
+        remoteRoomAppChannelsRef.current.set(key, channel)
+      } catch {
+        cleanupRemoteRoomAppChannel(key, channelAttempt, "establishment_failed")
+        const delay = ROOM_APP_RETRY_DELAYS_MS[attempt - 1]
+        if (delay !== undefined && roomAppsEnabledRef.current) {
+          window.setTimeout(() => {
+            const current = participantMapRef.current.get(participant.id)
+            if (current)
+              void subscribeRoomAppChannel(current, lane, attempt + 1)
+          }, delay)
+        }
+      }
+    },
+    [
+      apiRequest,
+      cleanupRemoteRoomAppChannel,
+      handleRoomAppChannelMessage,
+      roomAppChannelKey,
+      roomAppChannelName,
+      roomName,
+      waitForDataChannelOpen,
+    ]
+  )
+
   const establishDataChannelTransport = useCallback(async () => {
     const pc = peerConnectionRef.current
     const session = sessionRef.current
@@ -1405,7 +1691,49 @@ export function useSfuChatRoom(
     localFileChannelRef.current = channel
     localFileChannelIdRef.current = channelId
     dataChannelReadyRef.current = true
-  }, [apiRequest, roomName])
+    if (roomAppsEnabledRef.current) {
+      const appChannelNames = (["reliable", "realtime"] as const).map(
+        (lane) => ({
+          lane,
+          dataChannelName: roomAppChannelName(session.participantId, lane),
+        })
+      )
+      const appResponse = await apiRequest("datachannels/new", {
+        room: roomName,
+        participantId: session.participantId,
+        token: session.participantToken,
+        sessionId: session.sessionId,
+        dataChannels: appChannelNames.map(({ lane, dataChannelName }) => ({
+          location: "local",
+          dataChannelName,
+          ordered: lane === "reliable",
+          ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+        })),
+      })
+      const channelIds = appResponse.dataChannels ?? []
+      if (
+        channelIds.length !== appChannelNames.length ||
+        channelIds.some((entry) => typeof entry.id !== "number")
+      )
+        throw new Error("SFU Room App data channels were not created")
+      for (const [
+        index,
+        { lane, dataChannelName },
+      ] of appChannelNames.entries()) {
+        const channelId = channelIds[index].id as number
+        const channel = pc.createDataChannel(dataChannelName, {
+          negotiated: true,
+          id: channelId,
+          ordered: lane === "reliable",
+          ...(lane === "realtime" ? { maxRetransmits: 0 } : {}),
+        })
+        dataChannelsRef.current.add(channel)
+        dataChannelIdsRef.current.add(channelId)
+        localRoomAppChannelsRef.current.set(lane, channel)
+      }
+      roomAppChannelsReadyRef.current = true
+    }
+  }, [apiRequest, roomAppChannelName, roomName])
 
   const subscribeFileChannel = useCallback(
     async (participant: SfuParticipant) => {
@@ -2211,8 +2539,12 @@ export function useSfuChatRoom(
         void subscribeTrack(participant, track)
       if (participant.media?.fileChannelReady)
         void subscribeFileChannel(participant)
+      if (participant.media?.appDataChannelReady) {
+        void subscribeRoomAppChannel(participant, "reliable")
+        void subscribeRoomAppChannel(participant, "realtime")
+      }
     }
-  }, [subscribeFileChannel, subscribeTrack])
+  }, [subscribeFileChannel, subscribeRoomAppChannel, subscribeTrack])
 
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
@@ -2253,6 +2585,7 @@ export function useSfuChatRoom(
       setLiveTranscriptMediaAvailable(state.meetingNotesMediaAvailable)
       setAgentVoiceState(state.agentVoice)
       setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
+      setRoomAppsEnabled(state.roomAppsEnabled === true)
       const nextActivities = state.agentActivities ?? []
       agentActivitiesRef.current = nextActivities
       setAgentActivities(nextActivities)
@@ -2264,8 +2597,13 @@ export function useSfuChatRoom(
         if (
           previousParticipantId !== localParticipantId &&
           !currentParticipantIds.has(previousParticipantId)
-        )
+        ) {
           resetRemoteParticipant(previousParticipantId)
+          resetRemoteRoomAppParticipant(
+            previousParticipantId,
+            "participant_left"
+          )
+        }
       }
       for (const participant of state.participants) {
         const previous = participantMapRef.current.get(participant.id)
@@ -2289,6 +2627,7 @@ export function useSfuChatRoom(
         )
         if (mediaSessionChanged || agentAudioTrackRemoved) {
           resetRemoteParticipant(participant.id)
+          resetRemoteRoomAppParticipant(participant.id, "session_changed")
         } else if (previous?.media) {
           for (const previousTrack of previousTracks) {
             if (
@@ -2325,6 +2664,7 @@ export function useSfuChatRoom(
       rebuildParticipants,
       resetRemoteParticipant,
       resetRemoteTrackSubscription,
+      resetRemoteRoomAppParticipant,
       replaceRoomMessages,
       resubscribeRemoteMedia,
     ]
@@ -2334,6 +2674,7 @@ export function useSfuChatRoom(
     clearAllRemoteTrackSubscriptionRetries("peer_connection_replaced")
     clearRemoteTrackBindings()
     clearAllRemoteFileChannels("peer_connection_replaced")
+    clearAllRemoteRoomAppChannels("peer_connection_replaced")
     const pc = new RTCPeerConnection({
       iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
     })
@@ -2429,6 +2770,7 @@ export function useSfuChatRoom(
     return pc
   }, [
     clearAllRemoteFileChannels,
+    clearAllRemoteRoomAppChannels,
     clearAllRemoteTrackSubscriptionRetries,
     clearRemoteTrackBindings,
     rebuildParticipants,
@@ -2453,7 +2795,10 @@ export function useSfuChatRoom(
       setError("")
       sendSocketMessage({ type: "resync" })
       if (dataChannelReadyRef.current)
-        sendSocketMessage({ type: "datachannel-ready" })
+        sendSocketMessage({
+          type: "datachannel-ready",
+          appDataChannelReady: roomAppChannelsReadyRef.current,
+        })
     }
     socket.onmessage = (event) => {
       const message = JSON.parse(event.data) as SfuServerMessage
@@ -2616,6 +2961,15 @@ export function useSfuChatRoom(
           void subscribeFileChannel(participant)
           rebuildParticipants()
         }
+        if (
+          participant?.media &&
+          message.participant.appDataChannelReady === true
+        ) {
+          participant.media.appDataChannelReady = true
+          void subscribeRoomAppChannel(participant, "reliable")
+          void subscribeRoomAppChannel(participant, "realtime")
+          rebuildParticipants()
+        }
       } else if (message.type === "message" && message.message) {
         const localParticipantId = sessionRef.current?.participantId
         appendRoomMessage(
@@ -2691,6 +3045,7 @@ export function useSfuChatRoom(
     resetRemoteTrackSubscription,
     sendSocketMessage,
     subscribeFileChannel,
+    subscribeRoomAppChannel,
     subscribeTrack,
   ])
 
@@ -2714,6 +3069,7 @@ export function useSfuChatRoom(
         }
         await closeDataChannels(previousSession)
         clearAllRemoteFileChannels("media_reconnect")
+        clearAllRemoteRoomAppChannels("media_reconnect")
         clearRemoteTrackBindings()
         for (const channel of dataChannelsRef.current) channel.close()
         dataChannelsRef.current.clear()
@@ -2721,6 +3077,8 @@ export function useSfuChatRoom(
         incomingFilesRef.current.clear()
         localFileChannelRef.current = null
         localFileChannelIdRef.current = null
+        localRoomAppChannelsRef.current.clear()
+        roomAppChannelsReadyRef.current = false
         const oldPeerConnection = peerConnectionRef.current
         if (oldPeerConnection) {
           sampleSfuEgress("disconnect", oldPeerConnection)
@@ -2728,6 +3086,7 @@ export function useSfuChatRoom(
         }
         peerConnectionRef.current = null
         dataChannelReadyRef.current = false
+        roomAppsEnabledRef.current = false
         localTrackMidsRef.current.clear()
         clearAllAgentAudioSubscriptionRetries("media_reconnect")
         clearAllRemoteTrackSubscriptionRetries("media_reconnect")
@@ -2807,6 +3166,8 @@ export function useSfuChatRoom(
       }
       const session = (await response.json()) as SfuSessionResponse
       sessionRef.current = { ...session, room: roomName }
+      roomAppsEnabledRef.current = session.roomAppsEnabled === true
+      setRoomAppsEnabled(roomAppsEnabledRef.current)
       await establishDataChannelTransport()
       await publishTrack(audioTrack, "audio", `audio-${session.participantId}`)
       if (screenTrack && screenTrack.readyState === "live") {
@@ -2823,6 +3184,7 @@ export function useSfuChatRoom(
       clearAllAgentAudioSubscriptionRetries,
       clearAllRemoteTrackSubscriptionRetries,
       clearAllRemoteFileChannels,
+      clearAllRemoteRoomAppChannels,
       clearRemoteTrackBindings,
       connectWebSocket,
       createPeerConnection,
@@ -2910,6 +3272,7 @@ export function useSfuChatRoom(
     const objectUrls = objectUrlsRef.current
     const dataChannels = dataChannelsRef.current
     const localTrackMids = localTrackMidsRef.current
+    const localRoomAppChannels = localRoomAppChannelsRef.current
 
     return () => {
       closingRef.current = true
@@ -2926,12 +3289,17 @@ export function useSfuChatRoom(
       window.removeEventListener("pagehide", handlePageHide)
       void closeDataChannels(sessionRef.current)
       clearAllRemoteFileChannels("unmount")
+      clearAllRemoteRoomAppChannels("unmount")
       clearRemoteTrackBindings()
       websocketRef.current?.close()
       localAudioTrackRef.current?.stop()
       localScreenTrackRef.current?.stop()
       localFileChannelRef.current?.close()
       localFileChannelRef.current = null
+      for (const channel of localRoomAppChannels.values()) channel.close()
+      localRoomAppChannels.clear()
+      roomAppChannelsReadyRef.current = false
+      roomAppsEnabledRef.current = false
       for (const channel of dataChannels) channel.close()
       dataChannels.clear()
       for (const channel of remoteFileChannels.values()) channel.close()
@@ -2956,6 +3324,7 @@ export function useSfuChatRoom(
     clearAllAgentAudioSubscriptionRetries,
     clearAllRemoteTrackSubscriptionRetries,
     clearAllRemoteFileChannels,
+    clearAllRemoteRoomAppChannels,
     connectMediaSession,
     clearRemoteTrackBindings,
     enabled,
@@ -3052,6 +3421,49 @@ export function useSfuChatRoom(
       })
     },
     [sendSocketMessage]
+  )
+
+  const sendRoomAppMessage = useCallback(
+    (
+      lane: RoomAppLane,
+      appInstanceId: string,
+      payload: Record<string, unknown>
+    ): boolean => {
+      if (!roomAppsEnabledRef.current || !roomAppChannelsReadyRef.current)
+        return false
+      const encoded = encodeRoomAppEnvelope({
+        appInstanceId,
+        lane,
+        payload,
+      })
+      if (!encoded) return false
+      const bytes = new TextEncoder().encode(encoded).byteLength
+      if (!roomAppOutboundRateRef.current.allow(lane, bytes)) {
+        roomAppStatsRef.current.droppedMessages += 1
+        return false
+      }
+      const channel = localRoomAppChannelsRef.current.get(lane)
+      if (!channel || channel.readyState !== "open") return false
+      channel.send(encoded)
+      roomAppStatsRef.current.bytesSent += bytes
+      if (lane === "reliable") roomAppStatsRef.current.reliableMessages += 1
+      else roomAppStatsRef.current.realtimeMessages += 1
+      return true
+    },
+    []
+  )
+
+  const subscribeRoomAppMessages = useCallback(
+    (listener: (message: RoomAppTransportEnvelope) => void) => {
+      roomAppListenersRef.current.add(listener)
+      return () => roomAppListenersRef.current.delete(listener)
+    },
+    []
+  )
+
+  const getRoomAppStats = useCallback(
+    (): RoomAppTransportStats => ({ ...roomAppStatsRef.current }),
+    []
   )
 
   const sendActionMessage = useCallback(
@@ -3426,6 +3838,10 @@ export function useSfuChatRoom(
     messages,
     attachments,
     taskLiveViews,
+    roomAppsEnabled,
+    sendRoomAppMessage,
+    subscribeRoomAppMessages,
+    getRoomAppStats,
     sendTextMessage,
     sendFileMessage,
     sendActionMessage,

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -32,6 +32,10 @@ export interface RoomMediaState {
   sessionId: string
   muted: boolean
   fileChannelReady: boolean
+  // Phase 0 Room App transport readiness. This is only a public transport
+  // hint; App payloads still cross the sandbox MessagePort boundary and never
+  // use this field as authorization.
+  appDataChannelReady?: boolean
   tracks: RoomMediaTrack[]
   // Cloudflare-assigned `mid`s for an agent's active *remote* (subscribe)
   // track negotiations on this sessionId — never set for a human. Exists
@@ -459,6 +463,9 @@ export interface RoomState {
   // Coarse Worker media admission switch. Per-Agent UI availability still
   // comes from the Runtime Host's TTS readiness, never from this field.
   agentVoiceMediaAvailable: boolean
+  // Experimental Room App kill switch. The catalog remains curated in the
+  // browser; this flag only enables the host/transport seam in an environment.
+  roomAppsEnabled?: boolean
 }
 
 // A Cloudflare Realtime track-close attempt that hasn't been confirmed

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -38,6 +38,8 @@ export interface SfuEnv {
   // itself give any Agent audio access. The production deploy workflow
   // (deploy-web.yml) sets it to "true".
   AGENT_MEDIA_ENABLED?: string
+  // Experimental Room App host/transport kill switch. Defaults to off.
+  ROOM_APPS_ENABLED?: string
 }
 
 function json(data: unknown, status = 200): Response {
@@ -519,6 +521,7 @@ export async function handleSfuRequest(
               sessionId: session.sessionId,
               muted: false,
               fileChannelReady: false,
+              appDataChannelReady: false,
               tracks: [],
             },
             joinedAt: Date.now(),
@@ -540,6 +543,9 @@ export async function handleSfuRequest(
       // RoomSession's empty-room expiry); this is only a defensive fallback
       // for the (should-never-happen) case where the DO's response omits it.
       expiresAt: registered.expiresAt ?? Date.now() + 365 * 24 * 60 * 60 * 1000,
+      ...(env.ROOM_APPS_ENABLED !== undefined
+        ? { roomAppsEnabled: env.ROOM_APPS_ENABLED === "true" }
+        : {}),
     }
     return json(result)
   }

--- a/app/src/sfu/types.ts
+++ b/app/src/sfu/types.ts
@@ -24,4 +24,5 @@ export interface SfuSessionResponse {
   participantToken: string
   sessionId: string
   expiresAt: number
+  roomAppsEnabled?: boolean
 }

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -22,7 +22,10 @@
   "triggers": { "crons": [] },
   "vars": {
     // The production App ID is injected by GitHub Actions at deploy time.
-    "SFU_APP_ID": "set-during-deployment"
+    "SFU_APP_ID": "set-during-deployment",
+    // Phase 0 Room Apps stay disabled until the curated Lab fixtures are
+    // deliberately deployed and enabled.
+    "ROOM_APPS_ENABLED": "false"
   },
   "kv_namespaces": [
     {

--- a/docs/room-app-phase0-contract.md
+++ b/docs/room-app-phase0-contract.md
@@ -1,0 +1,69 @@
+# Room App Phase 0 internal contract
+
+This is an experimental Lab-facing seam, not a public SDK or extension
+registry. The Room App catalog is compiled into Free4Chat and is disabled by
+the `ROOM_APPS_ENABLED` Worker flag until the fixture deployment is ready.
+
+## Bootstrap
+
+The Room renders only a curated App definition in a sandboxed iframe:
+
+- production origin: `https://room-apps.free4.chat`;
+- local development origin: `http://localhost:8787`;
+- sandbox: `allow-scripts` only;
+- no `allow-same-origin`, camera, microphone, cookies, Room history, SFU
+  credentials, participant tokens, Agent credentials, PeerConnection, or raw
+  DataChannel is passed to the App.
+
+On iframe load, the host sends a bootstrap `postMessage` carrying one
+dedicated `MessagePort`, a bounded `appInstanceId`, and a one-time handshake
+token. The App must answer on that port with `ready` and the token. The host
+then sends only the bounded `self` and `participants` projection.
+
+## Messages
+
+All transport messages contain:
+
+```text
+protocolVersion
+appInstanceId
+lane: reliable | realtime
+payload: bounded JSON object
+```
+
+The iframe may request `sendReliable` or `sendRealtime`. The host validates
+the current instance, payload shape, UTF-8 size, and local rate budget before
+sending. Join/leave notifications are host-generated from the current Room
+participant projection. The App cannot choose a relay destination.
+
+The App receives no Room message ring or persistent App state. A closed or
+failed iframe only removes its MessagePort; ordinary Room chat, media, Tasks,
+attachments, and Live View remain independent.
+
+## Transport
+
+Free4Chat reuses the existing Human PeerConnection and Cloudflare Realtime
+SFU DataChannel substrate. Each Human publishes one named channel per lane;
+the `appInstanceId` multiplexes the bounded App messages over those channels.
+
+- reliable lane: ordered, fully reliable DataChannel;
+- realtime lane: unordered, `maxRetransmits: 0` DataChannel;
+- no Durable Object message/storage write is created for App traffic;
+- no PeerConnection is created per App.
+
+The realtime lane is therefore genuinely stale-droppable for this fixture.
+The host keeps coarse in-memory counters for messages, bytes, and drops only.
+
+## Bounds and lifecycle
+
+- payload: at most 16 KiB serialized UTF-8;
+- reliable: at most 20 messages/sec;
+- realtime: at most 60 messages/sec;
+- combined transport budget: at most 256 KiB/sec;
+- at most two App tabs are admitted by the Phase 0 UI (one is mounted at a
+  time in the current Room shell).
+
+App instances are browser/Room scoped and deterministic for the curated App
+id. There is no Room persistence, history, alarm, or recovery protocol. Room
+participant changes update the projection; closing/unmounting the App closes
+the port and leaves the Room untouched.

--- a/docs/room-app-phase0-contract.md
+++ b/docs/room-app-phase0-contract.md
@@ -31,10 +31,17 @@ lane: reliable | realtime
 payload: bounded JSON object
 ```
 
+Messages delivered from the host to the App also contain the host-derived
+`sourceParticipantId`. It is bound to the remote SFU channel owner; an App
+payload cannot set or override it, and payloads using that reserved field are
+rejected.
+
 The iframe may request `sendReliable` or `sendRealtime`. The host validates
-the current instance, payload shape, UTF-8 size, and local rate budget before
-sending. Join/leave notifications are host-generated from the current Room
-participant projection. The App cannot choose a relay destination.
+the current curated Room instance, payload shape, UTF-8 size, and local rate
+budget before sending. Unknown instances are rejected before rate accounting
+or listener dispatch. Join/leave notifications are host-generated from the
+current Room participant projection. The App cannot choose a relay
+destination.
 
 The App receives no Room message ring or persistent App state. A closed or
 failed iframe only removes its MessagePort; ordinary Room chat, media, Tasks,


### PR DESCRIPTION
## Summary

Refs #344
Closes #354

Adds the narrow Phase 0A experimental Room App seam for the Shared Canvas and Tiny Arena fixtures:

- curated, exact allowlisted App catalog with a sandbox="allow-scripts" iframe;
- dedicated MessagePort bootstrap with one-time handshake token and bounded `self`/`participants` projection;
- generic `reliable` and `realtime` logical lanes multiplexed by `appInstanceId`;
- reuses the existing Human PeerConnection/SFU DataChannel transport: ordered reliable lane and unordered `maxRetransmits: 0` realtime lane;
- simple UTF-8 payload/rate/instance caps, kill switch, in-memory coarse counters, participant join/leave projection, and cleanup/failure isolation;
- short internal Lab-facing contract at `docs/room-app-phase0-contract.md`.

No Room App traffic enters Room messages, Durable Object storage, alarms, analytics, or a per-App PeerConnection. No credentials, tokens, SFU objects, Room history, or Agent state cross into the iframe.

## Validation

- `yarn test`: 83 files / 742 tests passed
- `yarn type-check`: passed
- `yarn eslint src --no-fix`: passed
- `yarn prettier --check .`: passed
- `yarn docs:check`: passed
- `git diff --check`: passed
- focused Room App host/common/hook tests: passed
- `yarn cf-build`: OpenNext reaches the existing repository baseline strict-null type error in `src/common/utils.tsx:34`; no Room App build error was observed.

This PR is intentionally host/bridge only. Canvas and Arena domain implementations remain in extension-lab and must consume this same seam after review. It is not merged.
