### PR TITLE
chore(agent): bump Runtime to 0.5.32

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.31"
+var Version = "0.5.32"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
Phase 1 of the canonical Agent Runtime release for the **#357** stabilization merge (PR #358).

```text
source-version PR → verified native GitHub Release → live bootstrap activation PR
```

## Change

`agent/internal/doctor/doctor.go`: `Version` `0.5.31` → `0.5.32`.

This is the only version-bearing source. The Agent Release workflow parses this
line, injects the same value from the `agent-v0.5.32` tag via
`-ldflags "-X …/internal/doctor.Version=…"`, builds the four native targets,
verifies each binary reports the tagged version, and emits `SHA256SUMS`.

Previous released version: `agent-v0.5.31` (latest). `agent-v0.5.32` does not exist yet.

## Deliberately not updated here

`app/public/agent.md` and the generated `app/public/llms-full.txt` remain pinned
to **0.5.31** until the activation PR (phase 3). A fresh Invite must never
request a version whose native Release assets are not published and verified.

## Pre-merge checks

| Command | Result |
|---|---|
| `gofmt -l .` | clean |
| `go vet ./...` | pass |
| `go test ./... -count=1` | all 12 packages pass |
| `go build ./cmd/free4chat-agent` | pass |
| `bash scripts/test-install-agent.sh` | 19 passed, 0 failed |
| `bash scripts/test-bootstrap-contract.sh` | OK |
| `git diff --check` | clean |

Diff is one line.
