### PR TITLE
docs(agent): activate runtime version 0.5.32

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -328,7 +328,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.31` (release tag `agent-v0.5.31`).
+`0.5.32` (release tag `agent-v0.5.32`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -389,7 +389,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.31"
+expected_version="0.5.32"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -2299,7 +2299,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.31` (release tag `agent-v0.5.31`).
+`0.5.32` (release tag `agent-v0.5.32`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -2360,7 +2360,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.31"
+expected_version="0.5.32"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 


### PR DESCRIPTION
Phase 3 (activation) of the canonical Agent Runtime release.

```text
source-version PR → verified native GitHub Release → live bootstrap activation PR
```

## Evidence gate satisfied

Phase 2 is complete and verified before this PR:

- Release: **https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.32** (published, not draft, not prerelease)
- Tag `agent-v0.5.32` → commit `9738b2b120f213d76696ecf1d5c47c7f7f38b7f6`
- Assets: `free4chat-agent-darwin-arm64`, `free4chat-agent-darwin-amd64`, `free4chat-agent-linux-arm64`, `free4chat-agent-linux-amd64`, `SHA256SUMS`
- `shasum -a 256 -c SHA256SUMS` → all four `OK`
- Published `free4chat-agent-darwin-arm64 version --json` → `{"version": "0.5.32"}`
- Agent Release workflow run: `success`

## Change

`app/public/agent.md` — both version occurrences:

- line 331: `` `0.5.32` (release tag `agent-v0.5.32`). ``
- line 392: `expected_version="0.5.32"`

`app/public/llms-full.txt` — regenerated with `yarn docs:generate`; the diff is
exactly the two matching pins. `llms.txt` and `sitemap.xml` carry no version and
are unchanged.

## Validation

| Command | Result |
|---|---|
| `cd agent && bash scripts/test-bootstrap-contract.sh` | OK |
| `yarn docs:check` | docs assets OK (×3), no drift |
| `yarn test` | 83 files / 751 tests passed |
| `yarn type-check` | pass |
| `yarn eslint src --no-fix` | pass |
| `yarn prettier --check .` | pass |
| `yarn cf-build` | exit 0, `.open-next/worker.js` produced |
| `git diff --check` | clean |

After merge the `cf-sfu` Build & Deploy workflow must complete before the
deployed `/agent.md` is verified to serve the release version, tag, and
installer pin.
