### PR TITLE
ux(room): make attachments compose-first and available in Tasks (#363)

### DIFF
--- a/app/src/common/taskAttachmentWake.test.ts
+++ b/app/src/common/taskAttachmentWake.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  encodeTaskAttachmentWake,
+  parseTaskAttachmentWake,
+  TASK_ATTACHMENT_WAKE_HEADER,
+} from "./taskAttachmentWake"
+
+/**
+ * #363 second review: the Task attachment wake intent is a bounded boolean
+ * carried on the existing Task-correlated upload and persisted with the
+ * attachment. The transport contract is exactly two one-character tokens so
+ * no client string can smuggle a second wake intent.
+ */
+describe("Task attachment wake intent transport", () => {
+  it("keeps the wire header stable", () => {
+    expect(TASK_ATTACHMENT_WAKE_HEADER).toBe("X-Task-Attachment-Wake")
+  })
+
+  it("round-trips both explicit intents", () => {
+    for (const intent of [true, false]) {
+      expect(parseTaskAttachmentWake(encodeTaskAttachmentWake(intent))).toBe(
+        intent
+      )
+    }
+    expect(encodeTaskAttachmentWake(true)).toBe("1")
+    expect(encodeTaskAttachmentWake(false)).toBe("0")
+  })
+
+  it("never interprets an unknown or absent value as a wake", () => {
+    for (const value of [undefined, null, "", "true", "false", "yes", "2"]) {
+      expect(parseTaskAttachmentWake(value)).toBeUndefined()
+    }
+  })
+})

--- a/app/src/common/taskAttachmentWake.ts
+++ b/app/src/common/taskAttachmentWake.ts
@@ -1,0 +1,31 @@
+// #363 (second review): the ACTIVE-Task composer is compose-first, so one
+// Human Send can carry an attachment and text together. A Task-correlated
+// Human attachment therefore must NOT derive its Agent wake from
+// `senderKind === human && taskRequestId` alone: the composer decides whether
+// this upload is the whole submission and sends that decision as one bounded
+// token on the existing Task-correlated attachment upload. The Room persists
+// it with the attachment record, so a reconnect/replay rebuilds the same
+// `addressed` value — an immediate-only broadcast would not survive replay.
+//
+//   "1" => attachment-only submission: the persisted attachment addresses the
+//          canonical participating Task Agent(s) and wakes an idle Harness.
+//   "0" => attachment + text submission: the attachment is Task context only,
+//          and the following addressed Task text is the single wake boundary.
+//
+// Anything else — including an absent header — is "no explicit wake intent"
+// and never wakes an Agent on its own.
+export const TASK_ATTACHMENT_WAKE_HEADER = "X-Task-Attachment-Wake"
+
+export function encodeTaskAttachmentWake(wakeAgent: boolean): "1" | "0" {
+  return wakeAgent ? "1" : "0"
+}
+
+/** Strict, bounded parse: only the two exact one-character tokens are
+ * accepted, so no client string can smuggle a second wake intent. */
+export function parseTaskAttachmentWake(
+  value: string | null | undefined
+): boolean | undefined {
+  if (value === "1") return true
+  if (value === "0") return false
+  return undefined
+}

--- a/app/src/components/RoomContent.composeAttachment.test.tsx
+++ b/app/src/components/RoomContent.composeAttachment.test.tsx
@@ -349,12 +349,37 @@ describe("Active Task attachment path (#363 A2)", () => {
     fireEvent.click(screen.getByLabelText("Send message"))
 
     await waitFor(() =>
-      expect(sendTaskAttachment).toHaveBeenCalledWith(file, "T")
+      expect(sendTaskAttachment).toHaveBeenCalledWith(file, "T", false)
     )
     expect(sendFileMessage).not.toHaveBeenCalled()
     await waitFor(() =>
       expect(sendTextMessage).toHaveBeenCalledWith("use this", [], "T")
     )
+  })
+
+  it("asks the Room to wake the Task Agent for an attachment-only submission", async () => {
+    const sendFileMessage = vi.fn()
+    const sendTaskAttachment = vi.fn().mockResolvedValue(undefined)
+    const sendTextMessage = vi.fn()
+    const { container } = renderRoom({
+      messages: [taskRequest("T", 1)],
+      sendFileMessage,
+      sendTaskAttachment,
+      sendTextMessage,
+    })
+    const file = fileFixture("task-note.md", "text/markdown")
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    pickFile(container, file)
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    // No text: the attachment is the whole submission and must wake the
+    // participating Task Agent on its own.
+    await waitFor(() =>
+      expect(sendTaskAttachment).toHaveBeenCalledWith(file, "T", true)
+    )
+    expect(sendFileMessage).not.toHaveBeenCalled()
+    expect(sendTextMessage).not.toHaveBeenCalled()
   })
 
   it("never falls back to Room scope when the Task correlation fails", async () => {

--- a/app/src/components/RoomContent.composeAttachment.test.tsx
+++ b/app/src/components/RoomContent.composeAttachment.test.tsx
@@ -1,0 +1,347 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+// Observe the long-lived analytics calls without allowing the browser
+// analytics fallback timer to outlive jsdom teardown.
+vi.mock("@common/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@common/utils")>()
+  return { ...actual, trackAnalyticsEvent: vi.fn(), umamiEvent: vi.fn() }
+})
+
+const mockUseSfuChatRoom = vi.fn()
+vi.mock("../hooks/useSfuChatRoom", () => ({
+  useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
+}))
+
+import type { Message } from "@common/types"
+
+import RoomContent from "./RoomContent"
+import type { RoomAttachmentProjection } from "../room/types"
+
+/**
+ * #363: Room/active-Task attachment wiring. The Room composer keeps the
+ * existing 20 MB DataChannel transfer, the active Task composer uses the
+ * bounded task-correlated attachment API instead, and a Human Task
+ * attachment is visible only inside its own Task interaction.
+ */
+
+const baseHookReturn = {
+  participants: [] as unknown[],
+  messages: [] as unknown[],
+  attachments: [] as unknown[],
+  taskLiveViews: {},
+  agentActivities: [],
+  sendTextMessage: vi.fn(),
+  sendFileMessage: vi.fn(),
+  sendTaskAttachment: vi.fn(),
+  sendActionMessage: vi.fn(),
+  getLocalRoomAuth: vi.fn(() => null),
+  sendCollabResponse: vi.fn(() => true),
+  sendCollabResult: vi.fn(() => true),
+  sendPermissionResponse: vi.fn(() => true),
+  readRoomAttachment: vi.fn(),
+  localParticipantId: "human-local",
+  muteSelf: vi.fn(),
+  toggleScreenShare: vi.fn(),
+  retryVerification: vi.fn(),
+  error: "",
+  connectionStatus: "connected" as string,
+  resolvedRoomType: "audio" as const,
+  liveTranscript: { active: false },
+  liveTranscriptSegments: [],
+  runtimeHosts: {},
+  runtimeHostProviders: {},
+  liveTranscriptMediaAvailable: false,
+  startLiveTranscript: vi.fn(),
+  stopLiveTranscript: vi.fn(),
+  connectLocalRuntime: vi.fn(),
+  runtimeConnectionStatus: "idle" as const,
+  leaveRoom: vi.fn(),
+  roomAppsEnabled: false,
+  sendRoomAppMessage: vi.fn(() => false),
+  subscribeRoomAppMessages: vi.fn(() => () => undefined),
+}
+
+const ROOM_PARTICIPANTS = [
+  {
+    peerId: "human-local",
+    name: "Hannah",
+    kind: "human",
+    room: "test-room",
+  },
+  {
+    peerId: "agent-x",
+    name: "Agent X",
+    kind: "agent",
+    room: "test-room",
+  },
+]
+
+function taskRequest(requestId: string, sequence: number): Message {
+  return {
+    peerId: "human-local",
+    name: "Hannah",
+    kind: "human",
+    type: "action",
+    actionType: "collab",
+    sequence,
+    collab: {
+      requestId,
+      kind: "request",
+      fromParticipantId: "human-local",
+      targetParticipantId: "agent-x",
+      summary: requestId,
+    },
+  }
+}
+
+function attachment(
+  id: string,
+  fileName: string,
+  taskRequestId?: string
+): RoomAttachmentProjection {
+  return {
+    id,
+    senderId: "human-local",
+    senderName: "Hannah",
+    senderKind: "human",
+    fileName,
+    mimeType: "text/plain",
+    size: 6,
+    sequence: 10,
+    createdAt: 10,
+    ...(taskRequestId ? { taskRequestId } : {}),
+  }
+}
+
+function renderRoom(hookReturn: Record<string, unknown> = {}) {
+  mockUseSfuChatRoom.mockReturnValue({
+    ...baseHookReturn,
+    participants: ROOM_PARTICIPANTS,
+    localParticipantId: "human-local",
+    getLocalRoomAuth: vi.fn(() => ({ participantId: "human-local" })),
+    ...hookReturn,
+  })
+  return render(
+    <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
+  )
+}
+
+function pickFile(container: HTMLElement, file: File) {
+  const input = container.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    value: [file],
+  })
+  fireEvent.change(input)
+}
+
+function fileFixture(name = "notes.txt", type = "text/plain"): File {
+  return new File([new Uint8Array(6)], name, { type })
+}
+
+beforeEach(() => {
+  mockUseSfuChatRoom.mockReset()
+  // jsdom doesn't implement scrollIntoView; TextChatCard calls it on every
+  // message-list update.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("Room composer attachment transfer (#363 A1)", () => {
+  it("sends a Room file only on Send, through the existing DataChannel path", async () => {
+    let release: (() => void) | undefined
+    const sendFileMessage = vi.fn(
+      (_file: File, onInitiated?: () => void) =>
+        new Promise<void>((resolve) => {
+          onInitiated?.()
+          release = resolve
+        })
+    )
+    const { container } = renderRoom({ sendFileMessage })
+    const file = fileFixture("room-note.txt")
+
+    pickFile(container, file)
+
+    // The pick is a composer draft only.
+    expect(sendFileMessage).not.toHaveBeenCalled()
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() => expect(sendFileMessage).toHaveBeenCalledTimes(1))
+    expect(sendFileMessage.mock.calls[0][0]).toBe(file)
+    expect(typeof sendFileMessage.mock.calls[0][1]).toBe("function")
+    // The composer releases the draft as soon as the local transfer begins.
+    await waitFor(() =>
+      expect(screen.queryByTestId("composer-attachment")).toBeNull()
+    )
+    await act(async () => {
+      release?.()
+    })
+  })
+
+  it("keeps the draft and reports the 20 MB bound without starting a transfer", async () => {
+    const sendFileMessage = vi.fn()
+    const { container } = renderRoom({ sendFileMessage })
+    const oversized = {
+      name: "huge.bin",
+      type: "application/octet-stream",
+      size: 21 * 1024 * 1024,
+    } as unknown as File
+
+    pickFile(container, oversized)
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("20 MB")
+    )
+    expect(sendFileMessage).not.toHaveBeenCalled()
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+  })
+
+  it("keeps a truthful draft when the local transfer cannot begin", async () => {
+    const sendFileMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("SFU file data channel is unavailable"))
+    const { container } = renderRoom({ sendFileMessage })
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, "look at this")
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+
+    pickFile(container, fileFixture())
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "SFU file data channel is unavailable"
+      )
+    )
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    expect(composer.value).toBe("look at this")
+    expect(baseHookReturn.sendTextMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe("Active Task attachment path (#363 A2)", () => {
+  it("uses the task-correlated bounded attachment API, never the DataChannel transfer", async () => {
+    const sendFileMessage = vi.fn()
+    const sendTaskAttachment = vi.fn().mockResolvedValue(undefined)
+    const sendTextMessage = vi.fn()
+    const { container } = renderRoom({
+      messages: [taskRequest("T", 1)],
+      sendFileMessage,
+      sendTaskAttachment,
+      sendTextMessage,
+    })
+    const file = fileFixture("task-note.md", "text/markdown")
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, "use this")
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+
+    pickFile(container, file)
+    expect(sendTaskAttachment).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() =>
+      expect(sendTaskAttachment).toHaveBeenCalledWith(file, "T")
+    )
+    expect(sendFileMessage).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(sendTextMessage).toHaveBeenCalledWith("use this", [], "T")
+    )
+  })
+
+  it("never falls back to Room scope when the Task correlation fails", async () => {
+    const sendFileMessage = vi.fn()
+    const sendTaskAttachment = vi
+      .fn()
+      .mockRejectedValue(new Error("This task is no longer active"))
+    const sendTextMessage = vi.fn()
+    const { container } = renderRoom({
+      messages: [taskRequest("T", 1)],
+      sendFileMessage,
+      sendTaskAttachment,
+      sendTextMessage,
+    })
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    pickFile(container, fileFixture())
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "This task is no longer active"
+      )
+    )
+    expect(sendFileMessage).not.toHaveBeenCalled()
+    expect(sendTextMessage).not.toHaveBeenCalled()
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+  })
+})
+
+describe("Human Task attachment presentation (#363 A2)", () => {
+  const attachments = [
+    attachment("human-task-t", "task-t.txt", "T"),
+    attachment("human-task-u", "task-u.txt", "U"),
+    attachment("human-room-copy", "room-copy.txt"),
+  ]
+
+  function renderScoped() {
+    renderRoom({
+      messages: [taskRequest("T", 1), taskRequest("U", 2)],
+      attachments,
+    })
+  }
+
+  it("renders a Human Task attachment inside its own Task and never in the Room", () => {
+    renderScoped()
+
+    // Ordinary Room presentation stays free of Task attachments, and the
+    // existing Human Room file copy still has no standalone timeline item.
+    expect(screen.queryByText("task-t.txt")).toBeNull()
+    expect(screen.queryByText("task-u.txt")).toBeNull()
+    expect(screen.queryByText("room-copy.txt")).toBeNull()
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    expect(screen.getByText("task-t.txt")).toBeInTheDocument()
+    expect(screen.queryByText("task-u.txt")).toBeNull()
+    expect(screen.queryByText("room-copy.txt")).toBeNull()
+  })
+
+  it("never leaks Task T's attachment into Task U", () => {
+    renderScoped()
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-U"))
+    expect(screen.getByText("task-u.txt")).toBeInTheDocument()
+    expect(screen.queryByText("task-t.txt")).toBeNull()
+
+    fireEvent.click(screen.getByTestId("interaction-tab-task-T"))
+    expect(screen.getByText("task-t.txt")).toBeInTheDocument()
+    expect(screen.queryByText("task-u.txt")).toBeNull()
+  })
+})

--- a/app/src/components/RoomContent.composeAttachment.test.tsx
+++ b/app/src/components/RoomContent.composeAttachment.test.tsx
@@ -161,9 +161,11 @@ describe("Room composer attachment transfer (#363 A1)", () => {
   it("sends a Room file only on Send, through the existing DataChannel path", async () => {
     let release: (() => void) | undefined
     const sendFileMessage = vi.fn(
-      (_file: File, onInitiated?: () => void) =>
+      (_file: File, hooks?: { onReadiness?: (error?: unknown) => void }) =>
         new Promise<void>((resolve) => {
-          onInitiated?.()
+          // #363 review (point 1): a file with no applicable bounded
+          // Agent-readable copy keeps today's initiation release edge.
+          hooks?.onReadiness?.()
           release = resolve
         })
     )
@@ -180,14 +182,93 @@ describe("Room composer attachment transfer (#363 A1)", () => {
 
     await waitFor(() => expect(sendFileMessage).toHaveBeenCalledTimes(1))
     expect(sendFileMessage.mock.calls[0][0]).toBe(file)
-    expect(typeof sendFileMessage.mock.calls[0][1]).toBe("function")
-    // The composer releases the draft as soon as the local transfer begins.
+    expect(
+      typeof (sendFileMessage.mock.calls[0][1] as { onReadiness?: unknown })
+        ?.onReadiness
+    ).toBe("function")
+    // The composer releases the draft as soon as the readiness edge fires —
+    // the whole DataChannel transfer is still pending here.
     await waitFor(() =>
       expect(screen.queryByTestId("composer-attachment")).toBeNull()
     )
     await act(async () => {
       release?.()
     })
+  })
+
+  it("withholds the text half until the readiness edge fires", async () => {
+    let releaseReadiness: (() => void) | undefined
+    const sendFileMessage = vi.fn(
+      (_file: File, hooks?: { onReadiness?: (error?: unknown) => void }) =>
+        new Promise<void>(() => {
+          // The Human transfer never settles in this test; only the bounded
+          // Agent-readable copy readiness edge releases the text.
+          releaseReadiness = () => hooks?.onReadiness?.()
+        })
+    )
+    const sendTextMessage = vi.fn()
+    const { container } = renderRoom({ sendFileMessage, sendTextMessage })
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, "@Agent B please inspect this screenshot")
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+
+    pickFile(container, fileFixture("screenshot.png", "image/png"))
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() => expect(sendFileMessage).toHaveBeenCalledTimes(1))
+    // The file transfer has begun but the bounded copy is not published yet,
+    // so the @Agent instruction is deliberately not released.
+    expect(sendTextMessage).not.toHaveBeenCalled()
+    expect(composer.value).toBe("@Agent B please inspect this screenshot")
+
+    await act(async () => {
+      releaseReadiness?.()
+    })
+    await waitFor(() => expect(sendTextMessage).toHaveBeenCalledTimes(1))
+    expect(sendTextMessage.mock.calls[0][0]).toContain(
+      "inspect this screenshot"
+    )
+    expect(composer.value).toBe("")
+  })
+
+  it("keeps a truthful draft when the bounded Agent-readable copy fails", async () => {
+    const sendFileMessage = vi.fn(
+      (_file: File, hooks?: { onReadiness?: (error?: unknown) => void }) => {
+        hooks?.onReadiness?.(
+          new Error("Couldn't publish the Agent-readable copy of this file")
+        )
+        return Promise.resolve()
+      }
+    )
+    const sendTextMessage = vi.fn()
+    const { container } = renderRoom({ sendFileMessage, sendTextMessage })
+    const composer = screen.getByLabelText(
+      "Message the room or @ an Agent"
+    ) as HTMLTextAreaElement
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set
+    setter!.call(composer, "@Agent B please inspect this screenshot")
+    composer.dispatchEvent(new Event("input", { bubbles: true }))
+
+    pickFile(container, fileFixture("screenshot.png", "image/png"))
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Agent-readable copy")
+    )
+    // The draft and its error stay visible, and no partial text-only
+    // submission is released as if the Agent context were complete.
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    expect(composer.value).toBe("@Agent B please inspect this screenshot")
+    expect(sendTextMessage).not.toHaveBeenCalled()
   })
 
   it("keeps the draft and reports the 20 MB bound without starting a transfer", async () => {

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -171,6 +171,7 @@ export default function RoomContent({
     taskLiveViews,
     sendTextMessage,
     sendFileMessage,
+    sendTaskAttachment,
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
@@ -556,53 +557,66 @@ export default function RoomContent({
     [roomName, sendTextMessage]
   )
 
+  // #363 A1: compose-first Room attachment. The composer awaits this promise
+  // only until the local DataChannel transfer has genuinely begun (or failed
+  // before it could begin); the existing ephemeral "Sending…" timeline bubble
+  // keeps tracking the rest of the transfer exactly as before.
   const wrappedSendFile = useCallback(
-    async (file: File) => {
+    async (file: File): Promise<void> => {
       const id = `${Date.now()}-${file.name}`
-      if (file.size > MAX_FILE_SIZE) {
-        setPendingFiles((prev) => [
-          ...prev,
-          {
-            id,
-            fileName: file.name,
-            isImage: file.type.startsWith("image/"),
-            error: true,
-            errorMessage: `File too large (max 20 MB)`,
-          },
-        ])
-        setTimeout(
-          () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
-          3000
-        )
-        return
-      }
+      if (file.size > MAX_FILE_SIZE)
+        throw new Error("File exceeds the 20 MB limit")
       umamiEvent("ChatActivity", {
         type: file.type.startsWith("image/") ? "image" : "file",
         roomHash: hashRoom(roomName),
       })
+      let markInitiated: (() => void) | undefined
+      let markFailed: ((error: unknown) => void) | undefined
+      const initiated = new Promise<void>((resolve, reject) => {
+        markInitiated = resolve
+        markFailed = reject
+      })
+      // The composer owns the pre-Send draft; this derived promise is not
+      // always awaited by its caller, so keep the rejection handled.
+      void initiated.catch(() => undefined)
       setPendingFiles((prev) => [
         ...prev,
         { id, fileName: file.name, isImage: file.type.startsWith("image/") },
       ])
-      try {
-        await sendFileMessage(file)
-      } catch {
-        setPendingFiles((prev) =>
-          prev.map((f) =>
-            f.id === id
-              ? { ...f, error: true, errorMessage: "Failed to send" }
-              : f
+      void sendFileMessage(file, () => markInitiated?.())
+        .then(() => {
+          setPendingFiles((prev) => prev.filter((f) => f.id !== id))
+        })
+        .catch((error) => {
+          markFailed?.(error)
+          setPendingFiles((prev) =>
+            prev.map((f) =>
+              f.id === id
+                ? { ...f, error: true, errorMessage: "Failed to send" }
+                : f
+            )
           )
-        )
-        setTimeout(
-          () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
-          3000
-        )
-        return
-      }
-      setPendingFiles((prev) => prev.filter((f) => f.id !== id))
+          setTimeout(
+            () => setPendingFiles((prev) => prev.filter((f) => f.id !== id)),
+            3000
+          )
+        })
+      return initiated
     },
     [roomName, sendFileMessage]
+  )
+
+  // #363 A2: a Human attachment inside the ACTIVE Task rides the existing
+  // bounded, task-correlated Room attachment API — never the 20 MB Room
+  // DataChannel transfer — and never falls back to Room scope.
+  const activeTaskRequestId = activeTask?.requestId
+  const wrappedSendTaskFile = useCallback(
+    async (file: File, taskRequestId: string): Promise<void> => {
+      if (!activeTaskRequestId || activeTaskRequestId !== taskRequestId)
+        throw new Error("This task is no longer active")
+      await sendTaskAttachment(file, taskRequestId)
+    },
+    [activeTaskRequestId, sendTaskAttachment]
   )
 
   const selfScreenShareRef = useRef(false)
@@ -1186,6 +1200,7 @@ export default function RoomContent({
                   pendingFiles={activeTask ? [] : pendingFiles}
                   onSendText={wrappedSendText}
                   onSendFile={wrappedSendFile}
+                  onSendTaskFile={wrappedSendTaskFile}
                   onSendAction={sendActionMessage}
                   localParticipantId={effectiveLocalParticipantId}
                   onCollabRespond={handleCollabRespond}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -616,13 +616,20 @@ export default function RoomContent({
 
   // #363 A2: a Human attachment inside the ACTIVE Task rides the existing
   // bounded, task-correlated Room attachment API — never the 20 MB Room
-  // DataChannel transfer — and never falls back to Room scope.
+  // DataChannel transfer — and never falls back to Room scope. The composer
+  // owns the wake intent: an attachment-only submission wakes the Task Agent,
+  // an attachment + text submission keeps the attachment as Task context so
+  // the following text is the single addressed wake boundary.
   const activeTaskRequestId = activeTask?.requestId
   const wrappedSendTaskFile = useCallback(
-    async (file: File, taskRequestId: string): Promise<void> => {
+    async (
+      file: File,
+      taskRequestId: string,
+      wakeAgent: boolean
+    ): Promise<void> => {
       if (!activeTaskRequestId || activeTaskRequestId !== taskRequestId)
         throw new Error("This task is no longer active")
-      await sendTaskAttachment(file, taskRequestId)
+      await sendTaskAttachment(file, taskRequestId, wakeAgent)
     },
     [activeTaskRequestId, sendTaskAttachment]
   )

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -557,10 +557,13 @@ export default function RoomContent({
     [roomName, sendTextMessage]
   )
 
-  // #363 A1: compose-first Room attachment. The composer awaits this promise
-  // only until the local DataChannel transfer has genuinely begun (or failed
-  // before it could begin); the existing ephemeral "Sending…" timeline bubble
-  // keeps tracking the rest of the transfer exactly as before.
+  // #363 review (point 1): the composer awaits this promise only until the
+  // submission is ready to be released — the local DataChannel transfer has
+  // genuinely begun and, when a bounded Agent-readable copy applies, that
+  // bounded copy has been published. The full 20 MB transfer is never awaited;
+  // the existing ephemeral "Sending…" timeline bubble keeps tracking it
+  // exactly as before. A failed applicable copy rejects this promise so the
+  // composer keeps a truthful draft instead of releasing the text.
   const wrappedSendFile = useCallback(
     async (file: File): Promise<void> => {
       const id = `${Date.now()}-${file.name}`
@@ -570,20 +573,25 @@ export default function RoomContent({
         type: file.type.startsWith("image/") ? "image" : "file",
         roomHash: hashRoom(roomName),
       })
-      let markInitiated: (() => void) | undefined
+      let markReady: (() => void) | undefined
       let markFailed: ((error: unknown) => void) | undefined
-      const initiated = new Promise<void>((resolve, reject) => {
-        markInitiated = resolve
+      const readiness = new Promise<void>((resolve, reject) => {
+        markReady = resolve
         markFailed = reject
       })
       // The composer owns the pre-Send draft; this derived promise is not
       // always awaited by its caller, so keep the rejection handled.
-      void initiated.catch(() => undefined)
+      void readiness.catch(() => undefined)
       setPendingFiles((prev) => [
         ...prev,
         { id, fileName: file.name, isImage: file.type.startsWith("image/") },
       ])
-      void sendFileMessage(file, () => markInitiated?.())
+      void sendFileMessage(file, {
+        onReadiness: (error) => {
+          if (error === undefined) markReady?.()
+          else markFailed?.(error)
+        },
+      })
         .then(() => {
           setPendingFiles((prev) => prev.filter((f) => f.id !== id))
         })
@@ -601,7 +609,7 @@ export default function RoomContent({
             3000
           )
         })
-      return initiated
+      return readiness
     },
     [roomName, sendFileMessage]
   )

--- a/app/src/components/TextChatCard.composeAttachment.test.tsx
+++ b/app/src/components/TextChatCard.composeAttachment.test.tsx
@@ -308,7 +308,8 @@ describe("Active Task composer attachments (#363 A2)", () => {
     pickFile(fileInput, file)
     await pressSend()
 
-    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42")
+    // Attachment only: the composer asks the Room to wake the Task Agent.
+    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42", true)
     // Never the ordinary 20 MB Room DataChannel transfer.
     expect(onSendFile).not.toHaveBeenCalled()
     expect(screen.queryByTestId("composer-attachment")).toBeNull()
@@ -327,7 +328,33 @@ describe("Active Task composer attachments (#363 A2)", () => {
     await waitFor(() =>
       expect(onSendText).toHaveBeenCalledWith("summarize this", [], "task-42")
     )
-    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42")
+    // Text present: the attachment is Task context only, so the following
+    // addressed Task text stays the single wake boundary.
+    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42", false)
+  })
+
+  it("recomputes the Task wake intent for each submission", async () => {
+    const { composer, fileInput, onSendTaskFile } = renderCard({
+      taskRequestId: "task-42",
+    })
+    const withText = fileFixture("with-text.md", "text/markdown")
+
+    // First submission: attachment + text => context only.
+    typeMessage(composer, "please inspect this")
+    pickFile(fileInput, withText)
+    await pressSend()
+    expect(onSendTaskFile).toHaveBeenNthCalledWith(
+      1,
+      withText,
+      "task-42",
+      false
+    )
+
+    // Second submission from the same composer: attachment only => wakes.
+    const onlyFile = fileFixture("only.md", "text/markdown")
+    pickFile(fileInput, onlyFile)
+    await pressSend()
+    expect(onSendTaskFile).toHaveBeenNthCalledWith(2, onlyFile, "task-42", true)
   })
 
   it("keeps the Task draft when the task correlation fails closed", async () => {

--- a/app/src/components/TextChatCard.composeAttachment.test.tsx
+++ b/app/src/components/TextChatCard.composeAttachment.test.tsx
@@ -1,0 +1,375 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { UserInfo } from "@common/types"
+
+import TextChatCard from "./TextChatCard"
+
+/**
+ * #363 A1/A2: the Room composer is compose-first for attachments. Picking a
+ * file only stages it; one Send initiates the existing file and text
+ * operations together. In an ACTIVE Task the same Send routes the file
+ * through the bounded, task-correlated attachment path instead of the
+ * ordinary Room DataChannel transfer.
+ */
+
+function agentParticipant(): UserInfo {
+  return {
+    peerId: "agent-1",
+    name: "Agent B",
+    kind: "agent",
+    room: "room",
+  }
+}
+
+function fileFixture(name = "notes.txt", type = "text/plain", size = 12): File {
+  return new File([new Uint8Array(size)], name, { type })
+}
+
+function renderCard(
+  props: Partial<React.ComponentProps<typeof TextChatCard>> = {}
+) {
+  const onSendText = vi.fn()
+  const onSendFile = vi.fn().mockResolvedValue(undefined)
+  const onSendTaskFile = vi.fn().mockResolvedValue(undefined)
+  const onSendAction = vi.fn()
+  const view = render(
+    <TextChatCard
+      room="room"
+      nickName="Human"
+      messages={[]}
+      participants={[agentParticipant()]}
+      onSendText={onSendText}
+      onSendFile={onSendFile}
+      onSendTaskFile={onSendTaskFile}
+      onSendAction={onSendAction}
+      {...props}
+    />
+  )
+  const composer = screen.getByLabelText(
+    "Message the room or @ an Agent"
+  ) as HTMLTextAreaElement
+  const fileInput = view.container.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement
+  return {
+    view,
+    onSendText,
+    onSendFile,
+    onSendTaskFile,
+    onSendAction,
+    composer,
+    fileInput,
+  }
+}
+
+function pickFile(fileInput: HTMLInputElement, file: File) {
+  Object.defineProperty(fileInput, "files", {
+    configurable: true,
+    value: [file],
+  })
+  fireEvent.change(fileInput)
+}
+
+/** One Send action, flushed inside act so the awaited local initiation and
+ * the following text half settle inside React's update scope. */
+async function pressSend() {
+  await act(async () => {
+    fireEvent.click(screen.getByLabelText("Send message"))
+  })
+}
+
+async function pressEnter(composer: HTMLTextAreaElement) {
+  await act(async () => {
+    fireEvent.keyDown(composer, { key: "Enter" })
+  })
+}
+
+function typeMessage(composer: HTMLTextAreaElement, value: string) {
+  // React 19's value tracker breaks fireEvent.change's own-property path on
+  // controlled textareas; set through the prototype setter explicitly.
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value"
+  )?.set
+  setter!.call(composer, value)
+  composer.dispatchEvent(new Event("input", { bubbles: true }))
+  composer.selectionStart = value.length
+  composer.selectionEnd = value.length
+}
+
+/** Simulate typing so the caret sits mid-text when React re-renders. */
+function typeAtCaret(
+  composer: HTMLTextAreaElement,
+  value: string,
+  caret: number
+) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value"
+  )?.set
+  setter!.call(composer, value)
+  composer.selectionStart = caret
+  composer.selectionEnd = caret
+  composer.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("Room composer: compose-first attachments (#363 A1)", () => {
+  it("stages a picked file in the composer and does not send it", () => {
+    const { fileInput, onSendFile } = renderCard()
+    const file = fileFixture("diagram.png", "image/png")
+
+    pickFile(fileInput, file)
+
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    expect(screen.getByText("diagram.png")).toBeInTheDocument()
+    expect(onSendFile).not.toHaveBeenCalled()
+  })
+
+  it("removes a pending attachment before Send", () => {
+    const { fileInput, onSendFile } = renderCard()
+
+    pickFile(fileInput, fileFixture())
+    fireEvent.click(screen.getByLabelText("Remove attachment"))
+
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+    expect(onSendFile).not.toHaveBeenCalled()
+  })
+
+  it("still sends text only when nothing is pending", () => {
+    const { composer, onSendText, onSendFile } = renderCard()
+
+    typeMessage(composer, "hello room")
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    expect(onSendText).toHaveBeenCalledWith("hello room", [])
+    expect(onSendFile).not.toHaveBeenCalled()
+    expect(composer.value).toBe("")
+  })
+
+  it("sends an attachment only from the Send action", async () => {
+    const { composer, fileInput, onSendFile, onSendText } = renderCard()
+    const file = fileFixture("notes.txt")
+
+    pickFile(fileInput, file)
+    // An attachment alone is a complete submission: Send is enabled.
+    expect(screen.getByLabelText("Send message")).toBeEnabled()
+    await pressSend()
+
+    expect(onSendFile).toHaveBeenCalledWith(file)
+    expect(onSendText).not.toHaveBeenCalled()
+    expect(composer.value).toBe("")
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+  })
+
+  it("initiates the file and the text as one Send action", async () => {
+    const { composer, fileInput, onSendFile, onSendText } = renderCard()
+    const file = fileFixture("notes.txt")
+
+    typeMessage(composer, "  please review  ")
+    pickFile(fileInput, file)
+    await pressSend()
+
+    expect(onSendText).toHaveBeenCalledWith("please review", [])
+    expect(onSendFile).toHaveBeenCalledWith(file)
+    // The local file initiation is attempted before the text half.
+    expect(onSendFile.mock.invocationCallOrder[0]).toBeLessThan(
+      onSendText.mock.invocationCallOrder[0]
+    )
+    expect(composer.value).toBe("")
+  })
+
+  it("keeps resolved @Agent targets correct with an attachment present", async () => {
+    const { composer, fileInput, onSendFile, onSendText } = renderCard()
+
+    typeAtCaret(composer, "@Age please review", 4)
+    fireEvent.mouseDown(await screen.findByText("Agent B"))
+    await waitFor(() => expect(composer.value).toContain("@Agent B "))
+
+    pickFile(fileInput, fileFixture("context.md", "text/markdown"))
+    await pressEnter(composer)
+
+    expect(onSendText).toHaveBeenCalledWith(
+      expect.stringContaining("@Agent B"),
+      ["agent-1"]
+    )
+    expect(onSendFile).toHaveBeenCalled()
+  })
+
+  it("keeps a truthful retry state when the local attachment cannot begin", async () => {
+    const onSendFile = vi
+      .fn()
+      .mockRejectedValue(new Error("SFU file data channel is unavailable"))
+    const { composer, fileInput, onSendText } = renderCard({ onSendFile })
+    const file = fileFixture("notes.txt")
+
+    typeMessage(composer, "please review")
+    pickFile(fileInput, file)
+    await pressSend()
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "SFU file data channel is unavailable"
+    )
+    // The pending attachment is never silently cleared, and the obviously
+    // partial text-only submission is never sent.
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    expect(composer.value).toBe("please review")
+    expect(onSendText).not.toHaveBeenCalled()
+
+    // Both retry and remove stay available.
+    expect(screen.getByLabelText("Send message")).toBeEnabled()
+    fireEvent.click(screen.getByLabelText("Remove attachment"))
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+  })
+
+  it("retries the same pending attachment after a failed local initiation", async () => {
+    const onSendFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("SFU file data channel is unavailable"))
+      .mockResolvedValueOnce(undefined)
+    const {
+      fileInput,
+      onSendFile: _ignored,
+      onSendText,
+    } = renderCard({
+      onSendFile,
+    })
+    void _ignored
+    const file = fileFixture("notes.txt")
+
+    pickFile(fileInput, file)
+    await pressSend()
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+
+    await pressSend()
+
+    expect(onSendFile).toHaveBeenCalledTimes(2)
+    expect(onSendFile).toHaveBeenNthCalledWith(2, file)
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+    expect(onSendText).not.toHaveBeenCalled()
+  })
+
+  it("does not clear the pending attachment while the send is in flight", async () => {
+    let release: (() => void) | undefined
+    const onSendFile = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+    const { fileInput } = renderCard({ onSendFile })
+
+    pickFile(fileInput, fileFixture())
+    fireEvent.click(screen.getByLabelText("Send message"))
+
+    await waitFor(() => expect(onSendFile).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    // A second Send cannot duplicate the submission.
+    expect(screen.getByLabelText("Send message")).toBeDisabled()
+
+    await act(async () => {
+      release?.()
+    })
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+  })
+})
+
+describe("Active Task composer attachments (#363 A2)", () => {
+  it("exposes a small attach affordance that only stages the file", () => {
+    const { fileInput, onSendTaskFile, onSendFile } = renderCard({
+      taskRequestId: "task-42",
+    })
+
+    // The ordinary Room "+" menu stays hidden inside a Task composer.
+    expect(screen.queryByLabelText("More actions")).not.toBeInTheDocument()
+    const attach = screen.getByLabelText("Attach a file to this task")
+    const clickSpy = vi.spyOn(fileInput, "click")
+    fireEvent.click(attach)
+
+    expect(clickSpy).toHaveBeenCalled()
+    expect(onSendTaskFile).not.toHaveBeenCalled()
+    expect(onSendFile).not.toHaveBeenCalled()
+  })
+
+  it("sends the file through the task-correlated path with the exact taskRequestId", async () => {
+    const { fileInput, onSendFile, onSendTaskFile } = renderCard({
+      taskRequestId: "task-42",
+    })
+    const file = fileFixture("task-notes.md", "text/markdown")
+
+    pickFile(fileInput, file)
+    await pressSend()
+
+    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42")
+    // Never the ordinary 20 MB Room DataChannel transfer.
+    expect(onSendFile).not.toHaveBeenCalled()
+    expect(screen.queryByTestId("composer-attachment")).toBeNull()
+  })
+
+  it("still sends task text and the attachment as one Send action", async () => {
+    const { composer, fileInput, onSendTaskFile, onSendText } = renderCard({
+      taskRequestId: "task-42",
+    })
+    const file = fileFixture("task-notes.md", "text/markdown")
+
+    typeMessage(composer, "summarize this")
+    pickFile(fileInput, file)
+    fireEvent.keyDown(composer, { key: "Enter" })
+
+    await waitFor(() =>
+      expect(onSendText).toHaveBeenCalledWith("summarize this", [], "task-42")
+    )
+    expect(onSendTaskFile).toHaveBeenCalledWith(file, "task-42")
+  })
+
+  it("keeps the Task draft when the task correlation fails closed", async () => {
+    const onSendTaskFile = vi
+      .fn()
+      .mockRejectedValue(new Error("This task is no longer active"))
+    const { composer, fileInput, onSendText } = renderCard({
+      taskRequestId: "task-42",
+      onSendTaskFile,
+    })
+
+    typeMessage(composer, "still relevant?")
+    pickFile(fileInput, fileFixture())
+    await pressSend()
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This task is no longer active"
+    )
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+    expect(composer.value).toBe("still relevant?")
+    // Never silently downgraded to an ordinary Room send.
+    expect(onSendText).not.toHaveBeenCalled()
+  })
+
+  it("never falls back to the Room transfer without a task attachment path", async () => {
+    const { fileInput, onSendFile } = renderCard({
+      taskRequestId: "task-42",
+      onSendTaskFile: undefined,
+    })
+
+    // No Task attachment affordance exists without the task-correlated path.
+    expect(
+      screen.queryByLabelText("Attach a file to this task")
+    ).not.toBeInTheDocument()
+
+    pickFile(fileInput, fileFixture())
+    await pressSend()
+
+    expect(onSendFile).not.toHaveBeenCalled()
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Attachments aren't available in this task"
+    )
+    expect(screen.getByTestId("composer-attachment")).toBeInTheDocument()
+  })
+})

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -1605,11 +1605,12 @@ const TextChatCard = memo(function TextChatCard({
         : resolveAgentTargetIds(text, connectedAgents, selectedAgents)
 
     if (attachment) {
-      // The local file initiation is attempted first and awaited: a Human
-      // submission whose attachment could not even begin must never be
-      // completed as an obviously partial text-only send. Once the transfer
-      // has genuinely begun there is no transactional guarantee claimed for
-      // its remote peers.
+      // #363 review (point 1): the awaited promise is the submission
+      // readiness edge, not the whole file transfer — for a Room file it
+      // means the local transfer has begun and, when a bounded
+      // Agent-readable copy applies, that copy has been published. A
+      // submission whose attachment context never reached that edge must
+      // never be completed as an obviously partial text-only send.
       sendingRef.current = true
       setSendingDraft(true)
       setDraftAttachmentError("")

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -65,8 +65,17 @@ interface TextChatCardProps {
   onSendFile: (file: File) => Promise<void> | void
   /** #363 A2: Human attachment inside the ACTIVE Task. Travels the existing
    * bounded, task-correlated Room attachment path — never the Room
-   * DataChannel transfer. */
-  onSendTaskFile?: (file: File, taskRequestId: string) => Promise<void> | void
+   * DataChannel transfer. `wakeAgent` is the composer's explicit submission
+   * intent (`text === ""`): an attachment-only submission wakes the
+   * participating Task Agent, while an attachment + text submission keeps the
+   * attachment as Task context so the following Task text is the single
+   * addressed wake boundary. The Room persists the choice, so replay rebuilds
+   * the same Agent event. */
+  onSendTaskFile?: (
+    file: File,
+    taskRequestId: string,
+    wakeAgent: boolean
+  ) => Promise<void> | void
   onSendAction: (
     actionType: ActionType,
     actionPayload: Record<string, string>
@@ -1597,6 +1606,11 @@ const TextChatCard = memo(function TextChatCard({
     const text = message.trim()
     const attachment = draftAttachment
     if (text === "" && !attachment) return
+    // #363 second review: one Send can carry an attachment and text together.
+    // The composer — not the Room — decides whether the attachment is a whole
+    // Task submission that wakes the Task Agent, or context that must be
+    // persisted before the single addressed Task text turn.
+    const wakeAgent = text === ""
     const targets =
       text === ""
         ? []
@@ -1621,7 +1635,7 @@ const TextChatCard = memo(function TextChatCard({
           // closed instead.
           if (!onSendTaskFile || !taskRequestId)
             throw new Error("Attachments aren't available in this task")
-          await onSendTaskFile(attachment, taskRequestId)
+          await onSendTaskFile(attachment, taskRequestId, wakeAgent)
         } else {
           await onSendFile(attachment)
         }

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -58,7 +58,15 @@ interface TextChatCardProps {
   participants: UserInfo[]
   pendingFiles?: PendingFile[]
   onSendText: (text: string, targets?: string[], taskRequestId?: string) => void
-  onSendFile: (file: File) => void
+  /** #363 A1: ordinary Human Room file send (DataChannel, 20 MB). Called only
+   * when the Human presses Send for a pending composer attachment, never on
+   * pick. The returned promise settles once the local transfer has been
+   * initiated, or rejects when it could not even begin. */
+  onSendFile: (file: File) => Promise<void> | void
+  /** #363 A2: Human attachment inside the ACTIVE Task. Travels the existing
+   * bounded, task-correlated Room attachment path — never the Room
+   * DataChannel transfer. */
+  onSendTaskFile?: (file: File, taskRequestId: string) => Promise<void> | void
   onSendAction: (
     actionType: ActionType,
     actionPayload: Record<string, string>
@@ -335,8 +343,12 @@ export function buildRoomTimeline(
   // stay out: Human browser files already render through the DataChannel
   // file bubble (their Agent-consumption Room copies must not appear twice),
   // and an unknown sender (departed participant) is never mislabeled.
+  // #363 A2: the one exception is a Task-correlated attachment, because a
+  // Human Task attachment travels the bounded Room attachment path and has no
+  // DataChannel bubble at all. RoomContent already scopes the list to one
+  // Task, so this can never leak into ordinary Room presentation.
   for (const attachment of attachments) {
-    if (attachment.senderKind !== "agent") continue
+    if (attachment.senderKind !== "agent" && !attachment.taskRequestId) continue
     items.push({ type: "attachment", seq: attachment.sequence, attachment })
   }
   // Stable sort: canonical sequence order; sequence-less ephemeral messages
@@ -348,6 +360,13 @@ export function buildRoomTimeline(
 export function formatAttachmentSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
   return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+/** #363: keep the composer's pending attachment visible with the real reason
+ * the local send could not even begin. */
+function attachmentErrorMessage(error: unknown): string {
+  const detail = error instanceof Error ? error.message.trim() : ""
+  return detail || "Couldn't send this attachment. Try again or remove it."
 }
 
 function getOrCreateWhiteboardUrl(room: string): string {
@@ -1121,7 +1140,9 @@ const TimelineAttachmentRow = memo(function TimelineAttachmentRow({
       <div className="min-w-0 flex-1">
         <p className="mb-1 ml-1 text-xs text-gray-400">
           {attachment.senderName}
-          <span className="ml-1 text-[10px] text-blue-300">🤖 Agent</span>
+          {attachment.senderKind === "agent" && (
+            <span className="ml-1 text-[10px] text-blue-300">🤖 Agent</span>
+          )}
         </p>
         <AgentAttachmentCard attachment={attachment} onPreview={onPreview} />
       </div>
@@ -1496,10 +1517,18 @@ const TextChatCard = memo(function TextChatCard({
   onPermissionRespond,
   taskRequestId,
   taskAvailable = true,
+  onSendTaskFile,
 }: TextChatCardProps) {
   const taskScoped = Boolean(taskRequestId)
   const taskUnavailable = taskScoped && !taskAvailable
   const [message, setMessage] = useState<string>("")
+  // #363 A1: compose-first attachment. The picked file is a composer draft —
+  // picking never sends — and only Send initiates the existing file and text
+  // operations as one user action.
+  const [draftAttachment, setDraftAttachment] = useState<File | null>(null)
+  const [draftAttachmentError, setDraftAttachmentError] = useState<string>("")
+  const [sendingDraft, setSendingDraft] = useState(false)
+  const sendingRef = useRef(false)
   const [submenu, setSubmenu] = useState<"more" | "games" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
   const [pickerIndex, setPickerIndex] = useState(0)
@@ -1563,18 +1592,59 @@ const TextChatCard = memo(function TextChatCard({
     setSubmenu(null)
   }
 
-  const sendCurrentMessage = () => {
-    if (message.trim() === "" || taskUnavailable) return
-    const targets = taskScoped
-      ? resolveSelectedAgentTargetIds(message.trim(), selectedAgents)
-      : resolveAgentTargetIds(message.trim(), connectedAgents, selectedAgents)
-    if (taskRequestId) onSendText(message.trim(), targets, taskRequestId)
-    else onSendText(message.trim(), targets)
+  const sendCurrentMessage = async () => {
+    if (taskUnavailable || sendingRef.current) return
+    const text = message.trim()
+    const attachment = draftAttachment
+    if (text === "" && !attachment) return
+    const targets =
+      text === ""
+        ? []
+        : taskScoped
+        ? resolveSelectedAgentTargetIds(text, selectedAgents)
+        : resolveAgentTargetIds(text, connectedAgents, selectedAgents)
+
+    if (attachment) {
+      // The local file initiation is attempted first and awaited: a Human
+      // submission whose attachment could not even begin must never be
+      // completed as an obviously partial text-only send. Once the transfer
+      // has genuinely begun there is no transactional guarantee claimed for
+      // its remote peers.
+      sendingRef.current = true
+      setSendingDraft(true)
+      setDraftAttachmentError("")
+      try {
+        if (taskScoped) {
+          // A Task-scoped composer must never fall back to the ordinary Room
+          // transfer: without the task-correlated path the submission fails
+          // closed instead.
+          if (!onSendTaskFile || !taskRequestId)
+            throw new Error("Attachments aren't available in this task")
+          await onSendTaskFile(attachment, taskRequestId)
+        } else {
+          await onSendFile(attachment)
+        }
+      } catch (error) {
+        setDraftAttachmentError(attachmentErrorMessage(error))
+        return
+      } finally {
+        sendingRef.current = false
+        setSendingDraft(false)
+      }
+      setDraftAttachment(null)
+      setDraftAttachmentError("")
+    }
+
+    if (text === "") return
+    if (taskRequestId) onSendText(text, targets, taskRequestId)
+    else onSendText(text, targets)
     setMessage("")
     setSelectedAgents([])
   }
 
-  const handleSend = sendCurrentMessage
+  const handleSend = () => {
+    void sendCurrentMessage()
+  }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (pickerVisible) {
@@ -1608,16 +1678,24 @@ const TextChatCard = memo(function TextChatCard({
       // stays a newline and sending happens through the send button.
       if (event.shiftKey || isCoarsePointer) return
       event.preventDefault()
-      sendCurrentMessage()
+      void sendCurrentMessage()
     }
   }
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     if (file) {
-      onSendFile(file)
+      // #363 A1: picking a file only stages it in the composer. Nothing is
+      // sent until the Human presses Send.
+      setDraftAttachment(file)
+      setDraftAttachmentError("")
       event.target.value = ""
     }
+  }
+
+  const handleRemoveDraftAttachment = () => {
+    setDraftAttachment(null)
+    setDraftAttachmentError("")
   }
 
   const handleWhiteboard = () => {
@@ -1808,193 +1886,256 @@ const TextChatCard = memo(function TextChatCard({
             No participating Agent is currently available.
           </p>
         )}
-        <div className="relative flex flex-none items-end gap-2 border-t border-gray-700 p-3">
-          {pickerVisible && (
-            <div className="absolute bottom-full left-3 right-3 mb-1 overflow-hidden rounded-lg border border-gray-600 bg-gray-800 shadow-xl">
-              {(showAgentPicker ? mentionAgents : pickerItems).map(
-                (item, i) => (
-                  <button
-                    key={showAgentPicker ? item.peerId : item.label}
-                    type="button"
-                    onMouseDown={(e) => {
-                      e.preventDefault()
-                      if (showAgentPicker) selectAgent(item as UserInfo)
-                      else commitPicker(i)
-                    }}
-                    onTouchEnd={(e) => {
-                      e.preventDefault()
-                      if (showAgentPicker) selectAgent(item as UserInfo)
-                      else commitPicker(i)
-                    }}
-                    className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors ${
-                      i === pickerIndex
-                        ? "bg-gray-700 text-white"
-                        : "text-gray-300 hover:bg-gray-700"
-                    }`}
-                  >
-                    {showAgentPicker ? (
-                      <>
-                        <span className="text-base">🤖</span>
-                        <span className="font-medium">{item.name}</span>
-                        <span className="text-xs text-gray-500">Agent</span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="text-base">{item.icon}</span>
-                        <span className="font-medium">{item.label}</span>
-                        <span className="text-xs text-gray-500">
-                          {item.desc}
-                        </span>
-                      </>
-                    )}
-                  </button>
-                )
+        <div className="relative flex flex-none flex-col border-t border-gray-700 p-3">
+          {draftAttachment && (
+            <div
+              data-testid="composer-attachment"
+              className="mb-2 flex flex-wrap items-center gap-2 rounded-lg border border-gray-600 bg-gray-800 px-2.5 py-1.5 text-xs text-gray-200"
+            >
+              <span aria-hidden="true">📎</span>
+              <span
+                className="min-w-0 flex-1 truncate"
+                title={draftAttachment.name}
+              >
+                {draftAttachment.name}
+              </span>
+              <span className="flex-none text-gray-500">
+                {formatAttachmentSize(draftAttachment.size)}
+              </span>
+              <button
+                type="button"
+                onClick={handleRemoveDraftAttachment}
+                disabled={sendingDraft}
+                className="flex-none rounded px-1 text-gray-400 hover:text-white disabled:opacity-30"
+                title="Remove attachment"
+                aria-label="Remove attachment"
+              >
+                ×
+              </button>
+              {draftAttachmentError && (
+                <span role="alert" className="w-full text-rose-300">
+                  {draftAttachmentError}
+                </span>
               )}
             </div>
           )}
-          {!taskScoped && (
-            <div ref={moreBtnRef} className="relative">
+          <div className="flex items-end gap-2">
+            {pickerVisible && (
+              <div className="absolute bottom-full left-3 right-3 mb-1 overflow-hidden rounded-lg border border-gray-600 bg-gray-800 shadow-xl">
+                {(showAgentPicker ? mentionAgents : pickerItems).map(
+                  (item, i) => (
+                    <button
+                      key={showAgentPicker ? item.peerId : item.label}
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        if (showAgentPicker) selectAgent(item as UserInfo)
+                        else commitPicker(i)
+                      }}
+                      onTouchEnd={(e) => {
+                        e.preventDefault()
+                        if (showAgentPicker) selectAgent(item as UserInfo)
+                        else commitPicker(i)
+                      }}
+                      className={`flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors ${
+                        i === pickerIndex
+                          ? "bg-gray-700 text-white"
+                          : "text-gray-300 hover:bg-gray-700"
+                      }`}
+                    >
+                      {showAgentPicker ? (
+                        <>
+                          <span className="text-base">🤖</span>
+                          <span className="font-medium">{item.name}</span>
+                          <span className="text-xs text-gray-500">Agent</span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="text-base">{item.icon}</span>
+                          <span className="font-medium">{item.label}</span>
+                          <span className="text-xs text-gray-500">
+                            {item.desc}
+                          </span>
+                        </>
+                      )}
+                    </button>
+                  )
+                )}
+              </div>
+            )}
+            {!taskScoped && (
+              <div ref={moreBtnRef} className="relative">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setSubmenu((v) => (v === "more" ? null : "more"))
+                  }
+                  className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white"
+                  title="More actions"
+                  aria-label="More actions"
+                  aria-expanded={submenu === "more" || submenu === "games"}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                    className="h-4 w-4"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 4.5v15m7.5-7.5h-15"
+                    />
+                  </svg>
+                </button>
+                {submenu === "more" && (
+                  <>
+                    <div
+                      className="fixed inset-0 z-20 md:hidden"
+                      onClick={closeMenu}
+                    />
+                    <div
+                      ref={moreMenuRef}
+                      className="fixed bottom-0 left-0 right-0 z-30 rounded-t-xl border-t border-gray-600 bg-gray-800 py-1 shadow-xl md:absolute md:bottom-full md:left-0 md:right-auto md:mb-1 md:w-48 md:rounded-lg md:border md:border-gray-600"
+                    >
+                      <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
+                        Room actions
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          // Close before opening the native picker so the menu
+                          // (mobile bottom sheet) is gone when the picker returns.
+                          closeMenu()
+                          fileInputRef.current?.click()
+                        }}
+                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                      >
+                        <span>📎</span> Attach file
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleWhiteboard}
+                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                      >
+                        <span>🎨</span> Whiteboard
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handlePoll}
+                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                      >
+                        <span>📊</span> Poll
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setSubmenu("games")}
+                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
+                      >
+                        <span>🎮</span> Games
+                      </button>
+                    </div>
+                  </>
+                )}
+                {submenu === "games" && (
+                  <GamesMenu
+                    onSelect={handleGameSelect}
+                    onBack={() => setSubmenu(null)}
+                    menuRef={gamesMenuRef}
+                  />
+                )}
+              </div>
+            )}
+            {taskScoped && onSendTaskFile && (
               <button
                 type="button"
-                onClick={() =>
-                  setSubmenu((v) => (v === "more" ? null : "more"))
-                }
-                className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white"
-                title="More actions"
-                aria-label="More actions"
-                aria-expanded={submenu === "more" || submenu === "games"}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={taskUnavailable || sendingDraft}
+                className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white disabled:opacity-30"
+                title="Attach a file to this task"
+                aria-label="Attach a file to this task"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
-                  strokeWidth={2}
+                  strokeWidth={1.5}
                   stroke="currentColor"
                   className="h-4 w-4"
                 >
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    d="M12 4.5v15m7.5-7.5h-15"
+                    d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13"
                   />
                 </svg>
               </button>
-              {submenu === "more" && (
-                <>
-                  <div
-                    className="fixed inset-0 z-20 md:hidden"
-                    onClick={closeMenu}
-                  />
-                  <div
-                    ref={moreMenuRef}
-                    className="fixed bottom-0 left-0 right-0 z-30 rounded-t-xl border-t border-gray-600 bg-gray-800 py-1 shadow-xl md:absolute md:bottom-full md:left-0 md:right-auto md:mb-1 md:w-48 md:rounded-lg md:border md:border-gray-600"
-                  >
-                    <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
-                      Room actions
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        // Close before opening the native picker so the menu
-                        // (mobile bottom sheet) is gone when the picker returns.
-                        closeMenu()
-                        fileInputRef.current?.click()
-                      }}
-                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                    >
-                      <span>📎</span> Attach file
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handleWhiteboard}
-                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                    >
-                      <span>🎨</span> Whiteboard
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handlePoll}
-                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                    >
-                      <span>📊</span> Poll
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setSubmenu("games")}
-                      className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                    >
-                      <span>🎮</span> Games
-                    </button>
-                  </div>
-                </>
-              )}
-              {submenu === "games" && (
-                <GamesMenu
-                  onSelect={handleGameSelect}
-                  onBack={() => setSubmenu(null)}
-                  menuRef={gamesMenuRef}
-                />
-              )}
-            </div>
-          )}
-          <textarea
-            ref={textRef}
-            rows={1}
-            className="scrollbar-thin max-h-40 flex-1 resize-none overflow-y-auto rounded-xl bg-gray-900 px-3 py-2 text-sm leading-relaxed text-white placeholder-gray-500 focus:outline-none"
-            value={message}
-            disabled={taskUnavailable}
-            onKeyDown={handleKeyDown}
-            onChange={(e) => {
-              const nextMessage = e.target.value
-              setMessage(nextMessage)
-              setSelectedAgents((current) =>
-                current.filter((agent) =>
-                  resolveAgentTargetIds(nextMessage, connectedAgents, [
-                    agent,
-                  ]).includes(agent.id)
+            )}
+            <textarea
+              ref={textRef}
+              rows={1}
+              className="scrollbar-thin max-h-40 flex-1 resize-none overflow-y-auto rounded-xl bg-gray-900 px-3 py-2 text-sm leading-relaxed text-white placeholder-gray-500 focus:outline-none"
+              value={message}
+              disabled={taskUnavailable}
+              onKeyDown={handleKeyDown}
+              onChange={(e) => {
+                const nextMessage = e.target.value
+                setMessage(nextMessage)
+                setSelectedAgents((current) =>
+                  current.filter((agent) =>
+                    resolveAgentTargetIds(nextMessage, connectedAgents, [
+                      agent,
+                    ]).includes(agent.id)
+                  )
                 )
-              )
-              setPickerDismissed(false)
-              setPickerIndex(0)
-            }}
-            onCompositionStart={() => {
-              isComposingRef.current = true
-            }}
-            onCompositionEnd={() => {
-              isComposingRef.current = false
-            }}
-            placeholder="Message the room or @ an Agent…"
-            aria-label="Message the room or @ an Agent"
-          />
-          <button
-            type="button"
-            onClick={handleSend}
-            disabled={message.trim() === "" || taskUnavailable}
-            className="rounded-lg bg-blue-600 p-2 transition hover:bg-blue-500 disabled:opacity-30"
-            title="Send"
-            aria-label="Send message"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-5 w-5 text-white"
+                setPickerDismissed(false)
+                setPickerIndex(0)
+              }}
+              onCompositionStart={() => {
+                isComposingRef.current = true
+              }}
+              onCompositionEnd={() => {
+                isComposingRef.current = false
+              }}
+              placeholder="Message the room or @ an Agent…"
+              aria-label="Message the room or @ an Agent"
+            />
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={
+                (message.trim() === "" && !draftAttachment) ||
+                taskUnavailable ||
+                sendingDraft
+              }
+              className="rounded-lg bg-blue-600 p-2 transition hover:bg-blue-500 disabled:opacity-30"
+              title="Send"
+              aria-label="Send message"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
-              />
-            </svg>
-          </button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            className="hidden"
-            onChange={handleFileChange}
-          />
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-5 w-5 text-white"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+                />
+              </svg>
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+          </div>
         </div>
       </div>
 

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -129,6 +129,10 @@ import {
   isRuntimeProviderClaimHash,
 } from "../common/runtimeProviderCredential"
 import {
+  parseTaskAttachmentWake,
+  TASK_ATTACHMENT_WAKE_HEADER,
+} from "../common/taskAttachmentWake"
+import {
   validateTaskLiveViewDraft,
   validateTaskLiveViewSnapshot,
   type TaskLiveViewSnapshot,
@@ -1350,7 +1354,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       (attachment.taskRequestId === undefined ||
         (typeof attachment.taskRequestId === "string" &&
           attachment.taskRequestId.length > 0 &&
-          attachment.taskRequestId.length <= 64))
+          attachment.taskRequestId.length <= 64)) &&
+      // #363 second review: the persisted wake intent is a bounded boolean (or
+      // absent). It has to survive normalization for replay to stay truthful;
+      // a malformed value invalidates the record exactly like a malformed
+      // Task correlation, and `toAttachmentEvent` additionally fails closed on
+      // anything that is not literally `true`.
+      (attachment.taskWake === undefined ||
+        typeof attachment.taskWake === "boolean")
     )
   }
 
@@ -2039,15 +2050,23 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
     )
       return undefined
-    // #363 review (point 3): a Human attachment correlated with an ACTIVE
-    // Task is new Task input, so it addresses the canonical participating
-    // Task Agent(s) and wakes an idle Harness exactly like Task text does.
-    // The correlation is resolved from the retained canonical Task log and
-    // fails closed; an Agent-authored Task artifact and every ordinary
+    // #363 second review: a Human attachment correlated with an ACTIVE Task
+    // is new Task input, but whether it INDEPENDENTLY addresses the canonical
+    // participating Task Agent(s) is the composer's PERSISTED wake intent,
+    // never the correlation alone. An attachment-only Task submission
+    // persists `taskWake: true` and wakes an idle Harness exactly like Task
+    // text; an attachment + text submission persists `taskWake: false`, so
+    // the attachment is Task context inside the turn and the following
+    // addressed Task text remains the single wake boundary. Because the
+    // intent lives on the record, a reconnect/replay rebuilds the same
+    // `addressed` value instead of depending on an immediate broadcast.
+    // The correlation is still resolved from the retained canonical Task log
+    // and fails closed; an Agent-authored Task artifact and every ordinary
     // Room-scope attachment stay unaddressed.
     const taskResolution =
       attachment.taskRequestId !== undefined &&
-      attachment.senderKind === "human"
+      attachment.senderKind === "human" &&
+      attachment.taskWake === true
         ? resolveTaskRequest(
             taskProjection,
             attachment.taskRequestId,
@@ -5844,6 +5863,18 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         return this.json({ error: "task_attachment_not_participant" }, 403)
       }
     }
+    // #363 second review: the composer's wake intent for this Task
+    // submission. It is bounded to the two exact transport tokens, is only
+    // meaningful together with a validated Task correlation, and is only
+    // honored for an authenticated Human: an Agent-authored Task artifact is
+    // always context, never addressing. An absent/unknown intent fails closed
+    // to "context only" so the attachment can never wake an Agent by itself.
+    const requestedTaskWake =
+      requestedTaskRequestId !== undefined &&
+      participant.kind === "human" &&
+      parseTaskAttachmentWake(
+        request.headers.get(TASK_ATTACHMENT_WAKE_HEADER)
+      ) === true
     // #106: agents as well as humans may contribute to the room's bounded
     // ephemeral attachment set — a collaborating agent's screenshot/log/JSON
     // artifact rides the exact same store, limits, and eviction rules as
@@ -5888,7 +5919,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       createdAt: Date.now(),
       sequence: room.nextMessageSequence + 1,
       ...(requestedTaskRequestId
-        ? { taskRequestId: requestedTaskRequestId }
+        ? {
+            taskRequestId: requestedTaskRequestId,
+            // Persisted so replay/reconnect rebuilds the same `addressed`
+            // value (see toAttachmentEvent). Room-scope uploads never carry a
+            // wake intent at all.
+            taskWake: requestedTaskWake,
+          }
         : {}),
     }
     try {

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -5796,8 +5796,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     const requestedTaskRequestId =
       request.headers.get("X-Task-Request-Id")?.trim() || undefined
     if (requestedTaskRequestId !== undefined) {
-      if (participant.kind !== "agent")
-        return this.json({ error: "task_attachment_agent_only" }, 403)
+      // #363 A2: a Human may attach into an ACTIVE Task through this same
+      // bounded Room attachment store. The correlation is resolved against
+      // the retained canonical Task log and fails closed — an unknown/expired
+      // Task, or one with no participating Agent currently in the Room, is
+      // rejected before any bytes are stored and is never silently downgraded
+      // to ordinary Room scope.
       const taskResolution = resolveTaskRequest(
         buildTaskProjectionIndex(room.messages, room.participants),
         requestedTaskRequestId,
@@ -5808,8 +5812,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           { error: taskResolution.error },
           taskResolution.error === "unknown_task_request" ? 409 : 403
         )
-      if (!taskResolution.agentParticipantIds.includes(participant.id))
+      if (participant.kind === "agent") {
+        if (!taskResolution.agentParticipantIds.includes(participant.id))
+          return this.json({ error: "task_attachment_not_participant" }, 403)
+      } else if (participant.kind !== "human") {
         return this.json({ error: "task_attachment_not_participant" }, 403)
+      }
     }
     // #106: agents as well as humans may contribute to the room's bounded
     // ephemeral attachment set — a collaborating agent's screenshot/log/JSON

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -2027,7 +2027,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   private toAttachmentEvent(
     attachment: RoomAttachment,
     participantId: string,
-    taskProjection: TaskProjectionIndex
+    taskProjection: TaskProjectionIndex,
+    participants: Record<string, RoomParticipant>
   ): AgentEvent | undefined {
     if (
       attachment.taskRequestId !== undefined &&
@@ -2038,6 +2039,24 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
     )
       return undefined
+    // #363 review (point 3): a Human attachment correlated with an ACTIVE
+    // Task is new Task input, so it addresses the canonical participating
+    // Task Agent(s) and wakes an idle Harness exactly like Task text does.
+    // The correlation is resolved from the retained canonical Task log and
+    // fails closed; an Agent-authored Task artifact and every ordinary
+    // Room-scope attachment stay unaddressed.
+    const taskResolution =
+      attachment.taskRequestId !== undefined &&
+      attachment.senderKind === "human"
+        ? resolveTaskRequest(
+            taskProjection,
+            attachment.taskRequestId,
+            participants
+          )
+        : undefined
+    const addressed =
+      taskResolution?.ok === true &&
+      taskResolution.agentParticipantIds.includes(participantId)
     return {
       sequence: attachment.sequence,
       type: "image",
@@ -2058,7 +2077,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           ? { taskRequestId: attachment.taskRequestId }
           : {}),
       },
-      addressed: false,
+      addressed,
       createdAt: attachment.createdAt,
     }
   }
@@ -2098,7 +2117,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         const event = this.toAttachmentEvent(
           attachment,
           participantId,
-          taskProjection
+          taskProjection,
+          room.participants
         )
         // Keep an invisible attachment as a sequence placeholder. The
         // cursor coverage calculation runs over the shared Room sequence
@@ -2158,7 +2178,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         .filter((event): event is AgentEvent => event !== undefined),
       ...room.attachments
         .map((attachment) =>
-          this.toAttachmentEvent(attachment, participantId, taskProjection)
+          this.toAttachmentEvent(
+            attachment,
+            participantId,
+            taskProjection,
+            room.participants
+          )
         )
         .filter((event): event is AgentEvent => event !== undefined),
     ].sort((left, right) => left.sequence - right.sequence)

--- a/app/src/do/roomSessionHumanTaskAttachment.test.ts
+++ b/app/src/do/roomSessionHumanTaskAttachment.test.ts
@@ -146,8 +146,47 @@ function makeRoom() {
     )
     return { status: response.status, json: await response.json() }
   }
+  const agentWait = async (
+    participantId: string,
+    cursor = 0,
+    timeoutSeconds = 0
+  ) =>
+    (
+      await control({
+        action: "agent-wait",
+        participantId,
+        token: `tok-${participantId}`,
+        cursor,
+        timeoutSeconds,
+      })
+    ).json as { events: AgentEventProjection[] }
+  const readContext = async (participantId: string) =>
+    (
+      await control({
+        action: "agent-read-context",
+        participantId,
+        token: `tok-${participantId}`,
+        afterSequence: 0,
+      })
+    ).json as { events: AgentEventProjection[] }
   const room = () => store.get("room") as RoomRecord
-  return { session, upload, control, room, broadcasts, store }
+  return {
+    session,
+    upload,
+    control,
+    agentWait,
+    readContext,
+    room,
+    broadcasts,
+    store,
+  }
+}
+
+type AgentEventProjection = {
+  type?: string
+  addressed?: boolean
+  scopeId?: string
+  attachment?: { id: string; taskRequestId?: string }
 }
 
 async function readAttachment(
@@ -329,5 +368,114 @@ describe("Human Task attachments (#363 A2)", () => {
     expect(await response.json()).toMatchObject({
       error: "unsupported_attachment_type",
     })
+  })
+})
+
+/**
+ * #363 review (point 3): a Human attachment correlated with an ACTIVE Task is
+ * new Task input. It must address the canonical participating Task Agent(s)
+ * so an idle Harness actually runs, stay inside its own Task scope, never
+ * leak to Room scope, and fail closed for an unknown/expired Task.
+ */
+describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
+  async function uploadTaskAttachment(test: ReturnType<typeof makeRoom>) {
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-1" }
+    )
+    const payload = (await response.json()) as { attachment: { id: string } }
+    return { response, attachmentId: payload.attachment.id }
+  }
+
+  function attachmentEvent(
+    events: AgentEventProjection[],
+    attachmentId: string
+  ) {
+    return events.find((event) => event.attachment?.id === attachmentId)
+  }
+
+  it("addresses the canonical participating Task Agent", async () => {
+    const test = makeRoom()
+    const { response, attachmentId } = await uploadTaskAttachment(test)
+    expect(response.status).toBe(200)
+
+    const { events } = await test.agentWait("agent-a", 0)
+    expect(attachmentEvent(events, attachmentId)).toMatchObject({
+      type: "image",
+      addressed: true,
+      scopeId: "task:task-1",
+      attachment: { id: attachmentId, taskRequestId: "task-1" },
+    })
+  })
+
+  it("wakes a parked Harness long poll with the addressed Task attachment", async () => {
+    const test = makeRoom()
+    // Park the long poll beyond the current canonical sequence so it really
+    // waits, exactly like an idle resident Harness.
+    const parked = test.agentWait(
+      "agent-a",
+      test.room().nextMessageSequence,
+      25
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const { attachmentId } = await uploadTaskAttachment(test)
+
+    const { events } = await parked
+    expect(attachmentEvent(events, attachmentId)).toMatchObject({
+      addressed: true,
+      scopeId: "task:task-1",
+    })
+  })
+
+  it("never exposes or addresses the Task attachment to a non-participating Agent", async () => {
+    const test = makeRoom()
+    const { attachmentId } = await uploadTaskAttachment(test)
+
+    const { events } = await test.agentWait("agent-b", 0)
+    expect(attachmentEvent(events, attachmentId)).toBeUndefined()
+  })
+
+  it("keeps an ordinary Room-scope Human attachment unaddressed", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "room copy"
+    )
+    const payload = (await response.json()) as { attachment: { id: string } }
+
+    const { events } = await test.agentWait("agent-a", 0)
+    const event = attachmentEvent(events, payload.attachment.id)
+    expect(event).toMatchObject({ addressed: false })
+    expect(event?.scopeId).toBeUndefined()
+  })
+
+  it("keeps an Agent-authored Task attachment unaddressed", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "agent-a", token: "tok-agent-a" },
+      "agent artifact",
+      { taskRequestId: "task-1" }
+    )
+    const payload = (await response.json()) as { attachment: { id: string } }
+
+    const { events } = await test.readContext("agent-a")
+    expect(attachmentEvent(events, payload.attachment.id)).toMatchObject({
+      addressed: false,
+      scopeId: "task:task-1",
+    })
+  })
+
+  it("produces no addressed event for a rejected Task correlation", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-missing" }
+    )
+    expect(response.status).toBe(409)
+
+    const { events } = await test.agentWait("agent-a", 0)
+    expect(events.some((event) => event.attachment !== undefined)).toBe(false)
   })
 })

--- a/app/src/do/roomSessionHumanTaskAttachment.test.ts
+++ b/app/src/do/roomSessionHumanTaskAttachment.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { RoomSession } from "./RoomSession"
+import { encodeTaskAttachmentWake } from "../common/taskAttachmentWake"
 import type { RoomRecord } from "../room/types"
 
 /**
@@ -9,6 +10,10 @@ import type { RoomRecord } from "../room/types"
  * server-side and fails closed — unknown/expired Tasks or a Task with no
  * participating Agent in the Room are rejected before any bytes are stored,
  * and nothing is ever silently downgraded to ordinary Room scope.
+ *
+ * #363 second review: the composer's explicit wake intent rides the same
+ * upload and is PERSISTED with the attachment, so the Agent event rebuilt from
+ * Room state carries exactly the same `addressed` value as the live one.
  */
 
 const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
@@ -26,6 +31,12 @@ function buildStoredRoom(): RoomRecord {
         joinedAt: 1,
         lastSeenAt: Date.now(),
         token: "tok-human",
+        media: {
+          sessionId: "human-session",
+          muted: false,
+          fileChannelReady: true,
+          tracks: [],
+        },
       },
       "agent-a": {
         id: "agent-a",
@@ -119,7 +130,13 @@ function makeRoom() {
   const upload = (
     sender: { id: string; token: string },
     body = "task context",
-    options: { taskRequestId?: string; contentType?: string } = {}
+    options: {
+      taskRequestId?: string
+      contentType?: string
+      /** The composer's wake intent. Left undefined to exercise an upload
+       * that carries no explicit intent at all. */
+      wakeAgent?: boolean
+    } = {}
   ) =>
     session.fetch(
       new Request("https://room/attachment", {
@@ -133,9 +150,40 @@ function makeRoom() {
           ...(options.taskRequestId
             ? { "X-Task-Request-Id": options.taskRequestId }
             : {}),
+          ...(options.wakeAgent === undefined
+            ? {}
+            : {
+                "X-Task-Attachment-Wake": encodeTaskAttachmentWake(
+                  options.wakeAgent
+                ),
+              }),
         },
         body,
       })
+    )
+  // The browser's human Task text half: the ordinary authenticated Room
+  // WebSocket chat message carrying the canonical task correlation.
+  const humanSocket = {
+    send: () => undefined,
+    close: () => undefined,
+  } as unknown as WebSocket
+  const sendHumanTaskText = (text: string, taskRequestId = "task-1") =>
+    (
+      session as unknown as {
+        handleClientMessage: (
+          socket: WebSocket,
+          attachment: unknown,
+          message: unknown
+        ) => Promise<void>
+      }
+    ).handleClientMessage(
+      humanSocket,
+      {
+        participantId: "human-1",
+        token: "tok-human",
+        connectionNonce: "human-connection",
+      },
+      { type: "chat", text, taskRequestId }
     )
   const control = async (body: Record<string, unknown>) => {
     const response = await session.fetch(
@@ -159,14 +207,14 @@ function makeRoom() {
         cursor,
         timeoutSeconds,
       })
-    ).json as { events: AgentEventProjection[] }
-  const readContext = async (participantId: string) =>
+    ).json as { events: AgentEventProjection[]; cursor: number }
+  const readContext = async (participantId: string, afterSequence = 0) =>
     (
       await control({
         action: "agent-read-context",
         participantId,
         token: `tok-${participantId}`,
-        afterSequence: 0,
+        afterSequence,
       })
     ).json as { events: AgentEventProjection[] }
   const room = () => store.get("room") as RoomRecord
@@ -176,6 +224,7 @@ function makeRoom() {
     control,
     agentWait,
     readContext,
+    sendHumanTaskText,
     room,
     broadcasts,
     store,
@@ -183,9 +232,11 @@ function makeRoom() {
 }
 
 type AgentEventProjection = {
+  sequence?: number
   type?: string
   addressed?: boolean
   scopeId?: string
+  text?: string
   attachment?: { id: string; taskRequestId?: string }
 }
 
@@ -372,17 +423,21 @@ describe("Human Task attachments (#363 A2)", () => {
 })
 
 /**
- * #363 review (point 3): a Human attachment correlated with an ACTIVE Task is
- * new Task input. It must address the canonical participating Task Agent(s)
- * so an idle Harness actually runs, stay inside its own Task scope, never
- * leak to Room scope, and fail closed for an unknown/expired Task.
+ * #363 review (point 3) / second review: a Human attachment correlated with an
+ * ACTIVE Task is new Task input and can address the canonical participating
+ * Task Agent(s) — but only when the composer explicitly said so. The wake
+ * intent is persisted with the attachment, so the live event and the event
+ * rebuilt from Room state agree.
  */
 describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
-  async function uploadTaskAttachment(test: ReturnType<typeof makeRoom>) {
+  async function uploadTaskAttachment(
+    test: ReturnType<typeof makeRoom>,
+    wakeAgent?: boolean
+  ) {
     const response = await test.upload(
       { id: "human-1", token: "tok-human" },
       "task context",
-      { taskRequestId: "task-1" }
+      { taskRequestId: "task-1", wakeAgent }
     )
     const payload = (await response.json()) as { attachment: { id: string } }
     return { response, attachmentId: payload.attachment.id }
@@ -395,9 +450,9 @@ describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
     return events.find((event) => event.attachment?.id === attachmentId)
   }
 
-  it("addresses the canonical participating Task Agent", async () => {
+  it("addresses the canonical participating Task Agent for an attachment-only submission", async () => {
     const test = makeRoom()
-    const { response, attachmentId } = await uploadTaskAttachment(test)
+    const { response, attachmentId } = await uploadTaskAttachment(test, true)
     expect(response.status).toBe(200)
 
     const { events } = await test.agentWait("agent-a", 0)
@@ -419,7 +474,7 @@ describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
       25
     )
     await new Promise((resolve) => setTimeout(resolve, 0))
-    const { attachmentId } = await uploadTaskAttachment(test)
+    const { attachmentId } = await uploadTaskAttachment(test, true)
 
     const { events } = await parked
     expect(attachmentEvent(events, attachmentId)).toMatchObject({
@@ -428,9 +483,23 @@ describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
     })
   })
 
-  it("never exposes or addresses the Task attachment to a non-participating Agent", async () => {
+  it("does not address a Task attachment that carries no explicit wake intent", async () => {
     const test = makeRoom()
     const { attachmentId } = await uploadTaskAttachment(test)
+
+    // Absent intent fails closed: the record is stored with `taskWake: false`
+    // and the event rebuilt from Room state stays unaddressed.
+    expect(test.room().attachments[0].taskWake).toBe(false)
+    const { events } = await test.readContext("agent-a")
+    expect(attachmentEvent(events, attachmentId)).toMatchObject({
+      addressed: false,
+      scopeId: "task:task-1",
+    })
+  })
+
+  it("never exposes or addresses the Task attachment to a non-participating Agent", async () => {
+    const test = makeRoom()
+    const { attachmentId } = await uploadTaskAttachment(test, true)
 
     const { events } = await test.agentWait("agent-b", 0)
     expect(attachmentEvent(events, attachmentId)).toBeUndefined()
@@ -444,21 +513,26 @@ describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
     )
     const payload = (await response.json()) as { attachment: { id: string } }
 
+    // Room scope never even persists a wake intent.
+    expect(test.room().attachments[0].taskWake).toBeUndefined()
     const { events } = await test.agentWait("agent-a", 0)
     const event = attachmentEvent(events, payload.attachment.id)
     expect(event).toMatchObject({ addressed: false })
     expect(event?.scopeId).toBeUndefined()
   })
 
-  it("keeps an Agent-authored Task attachment unaddressed", async () => {
+  it("keeps an Agent-authored Task attachment unaddressed even with a wake intent", async () => {
     const test = makeRoom()
     const response = await test.upload(
       { id: "agent-a", token: "tok-agent-a" },
       "agent artifact",
-      { taskRequestId: "task-1" }
+      { taskRequestId: "task-1", wakeAgent: true }
     )
     const payload = (await response.json()) as { attachment: { id: string } }
 
+    // An Agent can never choose the Human wake intent, and the persisted
+    // record stays unaddressed on replay too.
+    expect(test.room().attachments[0].taskWake).toBe(false)
     const { events } = await test.readContext("agent-a")
     expect(attachmentEvent(events, payload.attachment.id)).toMatchObject({
       addressed: false,
@@ -471,11 +545,147 @@ describe("Human Task attachment Agent addressing (#363 review point 3)", () => {
     const response = await test.upload(
       { id: "human-1", token: "tok-human" },
       "task context",
-      { taskRequestId: "task-missing" }
+      { taskRequestId: "task-missing", wakeAgent: true }
     )
     expect(response.status).toBe(409)
 
     const { events } = await test.agentWait("agent-a", 0)
     expect(events.some((event) => event.attachment !== undefined)).toBe(false)
+  })
+})
+
+/**
+ * #363 second review: one composer Send can carry an attachment and text
+ * together. The Task attachment must be persisted first as Task context
+ * WITHOUT independently waking the Task Agent, and the following addressed
+ * Task text must be the single wake/turn boundary — with the attachment
+ * visible in that first turn. An attachment-only Send still wakes.
+ */
+describe("Single Task wake boundary per composer submission (#363 second review)", () => {
+  function attachmentEvent(
+    events: AgentEventProjection[],
+    attachmentId: string
+  ) {
+    return events.find((event) => event.attachment?.id === attachmentId)
+  }
+
+  function addressedEvents(events: AgentEventProjection[]) {
+    return events.filter((event) => event.addressed === true)
+  }
+
+  async function uploadTaskAttachment(
+    test: ReturnType<typeof makeRoom>,
+    wakeAgent: boolean
+  ) {
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "screenshot bytes",
+      { taskRequestId: "task-1", wakeAgent }
+    )
+    const payload = (await response.json()) as { attachment: { id: string } }
+    return payload.attachment.id
+  }
+
+  it("yields exactly one wake boundary for `attachment + text`, with the attachment inside it", async () => {
+    const test = makeRoom()
+    // Everything already retained (the original Task request) is outside this
+    // composer submission.
+    const submissionStart = test.room().nextMessageSequence
+    // The composer decides: text is present, so the attachment is context.
+    const text: string = "please inspect this"
+    const attachmentId = await uploadTaskAttachment(test, text === "")
+    await test.sendHumanTaskText(text)
+
+    // Live delivery: exactly one addressed event, and it is the Task text.
+    const { events } = await test.agentWait("agent-a", submissionStart)
+    const addressed = addressedEvents(events)
+    expect(addressed).toHaveLength(1)
+    expect(addressed[0]).toMatchObject({
+      type: "text",
+      text,
+      scopeId: "task:task-1",
+    })
+    // The attachment is Task context inside that same turn, not a wake.
+    const attachment = attachmentEvent(events, attachmentId)
+    expect(attachment).toMatchObject({
+      addressed: false,
+      scopeId: "task:task-1",
+    })
+    expect(attachment!.sequence!).toBeLessThan(addressed[0].sequence!)
+    // ...and the Task Agent can still read its bytes in that turn.
+    expect(
+      await readAttachment(test.session, "agent-a", "tok-agent-a", attachmentId)
+    ).toBe(200)
+
+    // Replay/reconstruction from persisted Room state, not the live
+    // broadcast, produces the identical boundary.
+    const retained = (await test.readContext("agent-a", submissionStart)).events
+    const replayed = addressedEvents(retained)
+    expect(replayed).toHaveLength(1)
+    expect(replayed[0]).toMatchObject({ type: "text", text })
+    const replayedAttachment = attachmentEvent(retained, attachmentId)
+    expect(replayedAttachment).toMatchObject({ addressed: false })
+    expect(replayedAttachment!.sequence!).toBeLessThan(replayed[0].sequence!)
+  })
+
+  it("does not resolve an idle Harness on the attachment half of `attachment + text`", async () => {
+    const test = makeRoom()
+    const parked = test.agentWait(
+      "agent-a",
+      test.room().nextMessageSequence,
+      25
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const attachmentId = await uploadTaskAttachment(test, false)
+
+    // The attachment alone produces no addressed event...
+    const first = await parked
+    expect(attachmentEvent(first.events, attachmentId)).toMatchObject({
+      addressed: false,
+    })
+    expect(addressedEvents(first.events)).toHaveLength(0)
+
+    // ...so the following Task text is the single wake boundary, and the
+    // attachment is already persisted inside its context window.
+    await test.sendHumanTaskText("please inspect this")
+    const { events } = await test.agentWait("agent-a", first.cursor)
+    const addressed = addressedEvents(events)
+    expect(addressed).toHaveLength(1)
+    expect(addressed[0]).toMatchObject({ type: "text", scopeId: "task:task-1" })
+    // The retained Room state still shows the unaddressed attachment strictly
+    // before the addressed Task text, inside the same Task scope.
+    const retained = await test.readContext("agent-a")
+    const attachment = attachmentEvent(retained.events, attachmentId)
+    expect(attachment).toMatchObject({
+      addressed: false,
+      scopeId: "task:task-1",
+    })
+    expect(attachment!.sequence!).toBeLessThan(addressed[0].sequence!)
+  })
+
+  it("still wakes an idle Harness for an `attachment only` submission", async () => {
+    const test = makeRoom()
+    const parked = test.agentWait(
+      "agent-a",
+      test.room().nextMessageSequence,
+      25
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const attachmentId = await uploadTaskAttachment(test, true)
+
+    const { events } = await parked
+    const addressed = addressedEvents(events)
+    expect(addressed).toHaveLength(1)
+    expect(addressed[0]).toMatchObject({
+      type: "image",
+      scopeId: "task:task-1",
+      attachment: { id: attachmentId, taskRequestId: "task-1" },
+    })
+
+    // The persisted intent reproduces the same wake on replay.
+    expect(test.room().attachments[0].taskWake).toBe(true)
+    expect(
+      attachmentEvent((await test.readContext("agent-a")).events, attachmentId)
+    ).toMatchObject({ addressed: true })
   })
 })

--- a/app/src/do/roomSessionHumanTaskAttachment.test.ts
+++ b/app/src/do/roomSessionHumanTaskAttachment.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+import type { RoomRecord } from "../room/types"
+
+/**
+ * #363 A2: a Human may attach into an ACTIVE Task through the existing
+ * bounded Room attachment store. The canonical Task correlation is resolved
+ * server-side and fails closed — unknown/expired Tasks or a Task with no
+ * participating Agent in the Room are rejected before any bytes are stored,
+ * and nothing is ever silently downgraded to ordinary Room scope.
+ */
+
+const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
+
+function buildStoredRoom(): RoomRecord {
+  return {
+    createdAt: Date.now(),
+    expiresAt: FAR_FUTURE,
+    participants: {
+      "human-1": {
+        id: "human-1",
+        name: "Hannah",
+        kind: "human",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-human",
+      },
+      "agent-a": {
+        id: "agent-a",
+        name: "Agent A",
+        kind: "agent",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-agent-a",
+        capabilities: { text: true },
+      },
+      "agent-b": {
+        id: "agent-b",
+        name: "Agent B",
+        kind: "agent",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-agent-b",
+        capabilities: { text: true },
+      },
+    },
+    messages: [
+      {
+        id: "task-request-1",
+        peerId: "human-1",
+        name: "Hannah",
+        kind: "human",
+        type: "action",
+        actionType: "collab",
+        sequence: 1,
+        createdAt: 1,
+        collab: {
+          requestId: "task-1",
+          kind: "request",
+          fromParticipantId: "human-1",
+          targetParticipantId: "agent-a",
+          summary: "Review the attached log",
+        },
+        targets: ["agent-a"],
+      },
+    ],
+    nextMessageSequence: 1,
+    attachments: [],
+    meetingNotes: { active: false },
+    agentVoice: {},
+    liveTranscript: { active: false },
+    liveTranscriptSegments: [],
+    nextLiveTranscriptEpoch: 1,
+    nextTranscriptSequence: 1,
+    pendingMediaCleanup: [],
+  }
+}
+
+function makeRoom() {
+  const store = new Map<string, unknown>([["room", buildStoredRoom()]])
+  const broadcasts: Array<Record<string, unknown>> = []
+  const ctx = {
+    storage: {
+      get: async (key: string) => store.get(key),
+      put: async (key: string, value: unknown) => void store.set(key, value),
+      delete: async (key: string | string[]) => {
+        for (const candidate of Array.isArray(key) ? key : [key])
+          store.delete(candidate)
+      },
+      list: async (options?: { prefix?: string }) => {
+        const entries = [...store.entries()].filter(([key]) =>
+          options?.prefix ? key.startsWith(options.prefix) : true
+        )
+        return new Map(entries)
+      },
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+    getWebSockets: () => {
+      const socket = {
+        send: (raw: string) =>
+          broadcasts.push(JSON.parse(raw) as Record<string, unknown>),
+        close: () => undefined,
+      } as unknown as WebSocket
+      return [socket]
+    },
+    waitUntil: (promise: Promise<unknown>) => void promise,
+    id: { name: "test-room", toString: () => "test-room" },
+  }
+  const session = new RoomSession(
+    ctx as never,
+    { SFU_ROOM: {}, AGENT_MEDIA_ENABLED: "true" } as never
+  )
+  const upload = (
+    sender: { id: string; token: string },
+    body = "task context",
+    options: { taskRequestId?: string; contentType?: string } = {}
+  ) =>
+    session.fetch(
+      new Request("https://room/attachment", {
+        method: "POST",
+        headers: {
+          "Content-Type": options.contentType ?? "text/plain",
+          "Content-Length": String(body.length),
+          "X-Room-Participant-Id": sender.id,
+          "X-Room-Participant-Token": sender.token,
+          "X-File-Name": "context.txt",
+          ...(options.taskRequestId
+            ? { "X-Task-Request-Id": options.taskRequestId }
+            : {}),
+        },
+        body,
+      })
+    )
+  const control = async (body: Record<string, unknown>) => {
+    const response = await session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    )
+    return { status: response.status, json: await response.json() }
+  }
+  const room = () => store.get("room") as RoomRecord
+  return { session, upload, control, room, broadcasts, store }
+}
+
+async function readAttachment(
+  session: RoomSession,
+  participantId: string,
+  token: string,
+  attachmentId: string
+) {
+  const response = await session.fetch(
+    new Request("https://room/control", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "agent-read-attachment",
+        participantId,
+        token,
+        attachmentId,
+      }),
+    })
+  )
+  return response.status
+}
+
+describe("Human Task attachments (#363 A2)", () => {
+  it("stores a Human attachment with the exact Task correlation", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-1" }
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as {
+      attachment: {
+        id: string
+        senderKind: string
+        taskRequestId?: string
+        size: number
+      }
+    }
+    expect(payload.attachment.senderKind).toBe("human")
+    expect(payload.attachment.taskRequestId).toBe("task-1")
+    expect(payload.attachment.size).toBe("task context".length)
+
+    const stored = test.room().attachments
+    expect(stored).toHaveLength(1)
+    expect(stored[0].taskRequestId).toBe("task-1")
+    // The browser projection carries the correlation, which is what keeps the
+    // item inside its own Task interaction.
+    expect(test.broadcasts.at(-1)).toMatchObject({
+      type: "attachment",
+      attachment: { taskRequestId: "task-1", senderKind: "human" },
+    })
+  })
+
+  it("keeps the Task attachment readable by the participating Agent through the existing path", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-1" }
+    )
+    const payload = (await response.json()) as { attachment: { id: string } }
+
+    // The participating Agent can consume it; an unrelated Agent cannot.
+    expect(
+      await readAttachment(
+        test.session,
+        "agent-a",
+        "tok-agent-a",
+        payload.attachment.id
+      )
+    ).toBe(200)
+    expect(
+      await readAttachment(
+        test.session,
+        "agent-b",
+        "tok-agent-b",
+        payload.attachment.id
+      )
+    ).toBe(404)
+  })
+
+  it("fails closed for an unknown or expired Task correlation", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-missing" }
+    )
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({
+      error: "unknown_task_request",
+    })
+    // No bytes and no metadata were stored, and it never became Room scope.
+    expect(test.room().attachments).toHaveLength(0)
+    expect(
+      [...test.store.keys()].filter((key) => key.startsWith("attachment:"))
+    ).toHaveLength(0)
+  })
+
+  it("fails closed when the Task has no participating Agent in the Room", async () => {
+    const test = makeRoom()
+    const room = test.room()
+    room.participants["agent-a"] = {
+      ...room.participants["agent-a"],
+      connected: false,
+    }
+    test.store.set("room", room)
+
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "task context",
+      { taskRequestId: "task-1" }
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: "task_target_not_in_room",
+    })
+    expect(test.room().attachments).toHaveLength(0)
+  })
+
+  it("keeps an ordinary Room attachment unscoped when no Task header is present", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "room copy"
+    )
+
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as {
+      attachment: { taskRequestId?: string }
+    }
+    expect(payload.attachment.taskRequestId).toBeUndefined()
+    expect(test.room().attachments[0].taskRequestId).toBeUndefined()
+  })
+
+  it("still rejects an Agent that does not participate in the Task", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "agent-b", token: "tok-agent-b" },
+      "not mine",
+      { taskRequestId: "task-1" }
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: "task_attachment_not_participant",
+    })
+    expect(test.room().attachments).toHaveLength(0)
+  })
+
+  it("keeps the existing bounded Agent-readable size for Human Task attachments", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "x".repeat(768 * 1024 + 1),
+      { taskRequestId: "task-1" }
+    )
+
+    expect(response.status).toBe(413)
+    expect(await response.json()).toMatchObject({
+      error: "attachment_too_large",
+    })
+    expect(test.room().attachments).toHaveLength(0)
+  })
+
+  it("keeps the supported image/text attachment type bound for Human Task attachments", async () => {
+    const test = makeRoom()
+    const response = await test.upload(
+      { id: "human-1", token: "tok-human" },
+      "binary",
+      { taskRequestId: "task-1", contentType: "application/zip" }
+    )
+
+    expect(response.status).toBe(415)
+    expect(await response.json()).toMatchObject({
+      error: "unsupported_attachment_type",
+    })
+  })
+})

--- a/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
@@ -2,14 +2,16 @@ import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSfuChatRoom } from "./useSfuChatRoom"
+import type { SfuRoomState } from "../sfu/types"
 
 /**
  * #363: a Human Task attachment must ride the existing bounded,
  * task-correlated Room attachment API (exact X-Task-Request-Id, 768 KB
  * Agent-readable bound) and never the 20 MB Human browser DataChannel
- * transfer. The compose-first composer also needs an initiation edge from the
+ * transfer. The compose-first composer also needs a readiness edge from the
  * ordinary Room file path so it never completes an obviously partial
- * submission.
+ * submission — and, when a bounded Agent-readable copy applies, that copy is
+ * published before the text half is released (review point 1).
  */
 
 class FakeTrack {
@@ -117,6 +119,110 @@ let lastFakeWebSocket: {
   onmessage: ((event: { data: string }) => void) | null
 } | null = null
 
+type StateParticipant = SfuRoomState["participants"][number]
+
+function humanParticipant(
+  id: string,
+  fileChannelReady = true
+): StateParticipant {
+  return {
+    id,
+    name: id,
+    kind: "human",
+    connected: true,
+    joinedAt: 0,
+    lastSeenAt: 0,
+    media: {
+      sessionId: `publisher-${id}`,
+      muted: false,
+      fileChannelReady,
+      tracks: [],
+    },
+  }
+}
+
+function agentParticipant(id: string): StateParticipant {
+  return {
+    id,
+    name: id,
+    kind: "agent",
+    connected: true,
+    joinedAt: 0,
+    lastSeenAt: 0,
+  }
+}
+
+function roomState(participants: StateParticipant[]): SfuRoomState {
+  return {
+    createdAt: 0,
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    participants,
+    messages: [],
+    meetingNotes: { active: false },
+    meetingNotesMediaAvailable: false,
+    agentVoice: {},
+    agentVoiceMediaAvailable: false,
+  }
+}
+
+/** A minimal File stand-in: jsdom's Blob has no arrayBuffer(), so the
+ * DataChannel chunk loop models slice() exactly like the existing transfer
+ * tests do. */
+function fakeFile(options: { name: string; type: string; size: number }): File {
+  const bytes = new Uint8Array(Math.min(options.size, 4))
+  return {
+    name: options.name,
+    type: options.type,
+    size: options.size,
+    slice: () => ({
+      arrayBuffer: () => Promise.resolve(bytes.buffer),
+    }),
+  } as unknown as File
+}
+
+function stubObjectUrls() {
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: vi.fn(() => "blob:file"),
+  })
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: vi.fn(),
+  })
+}
+
+/** Model the existing Agent vision copy: a large source image is decoded and
+ * re-encoded down to a bounded JPEG copy. */
+function stubVisionCopy(options: {
+  width: number
+  height: number
+  bytes: number
+}) {
+  class FakeImage {
+    naturalWidth = 0
+    naturalHeight = 0
+    src = ""
+    decode = () => {
+      this.naturalWidth = options.width
+      this.naturalHeight = options.height
+      return Promise.resolve()
+    }
+  }
+  vi.stubGlobal("Image", FakeImage)
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+    drawImage: vi.fn(),
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(
+    (callback: BlobCallback) => {
+      callback({
+        size: options.bytes,
+        type: "image/jpeg",
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(options.bytes)),
+      } as unknown as Blob)
+    }
+  )
+}
+
 describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
   let fetchMock: ReturnType<typeof vi.fn>
   let attachmentResponse: () => Promise<Response>
@@ -190,6 +296,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
 
   afterEach(() => {
     lastFakeWebSocket = null
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -216,9 +323,13 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
   }
 
   function taskUploadCall() {
-    return fetchMock.mock.calls.find(([input]) =>
+    return attachmentUploadCalls()[0]
+  }
+
+  function attachmentUploadCalls() {
+    return fetchMock.mock.calls.filter(([input]) =>
       String(input).endsWith("/api/room/attachments")
-    ) as [string, RequestInit] | undefined
+    ) as Array<[string, RequestInit]>
   }
 
   it("uploads a Task attachment through the bounded API with the exact task correlation", async () => {
@@ -287,13 +398,13 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     expect(localFileChannel().send).not.toHaveBeenCalled()
   })
 
-  it("enforces the existing bounded Agent-readable size for Task attachments", async () => {
+  it("keeps the raw 768 KB bound for a text-like Task attachment (#363 point 2)", async () => {
     const { result } = await connect()
-    const oversized = {
+    const oversized = fakeFile({
       name: "large.txt",
       type: "text/plain",
       size: 768 * 1024 + 1,
-    } as unknown as File
+    })
 
     let caught: unknown
     await act(async () => {
@@ -307,34 +418,23 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     expect(localFileChannel().send).not.toHaveBeenCalled()
   })
 
-  it("reports the Room file initiation edge and completes the existing transfer", async () => {
+  it("reports the Room file readiness edge and completes the existing transfer", async () => {
     const { result } = await connect()
     const channel = localFileChannel()
-    const onInitiated = vi.fn()
-    // jsdom's Blob lacks arrayBuffer(); model the file exactly like the
-    // existing DataChannel transfer tests do.
-    Object.defineProperty(URL, "createObjectURL", {
-      configurable: true,
-      value: vi.fn(() => "blob:small-file"),
-    })
-    Object.defineProperty(URL, "revokeObjectURL", {
-      configurable: true,
-      value: vi.fn(),
-    })
-    const file = {
-      name: "small.txt",
-      type: "text/plain",
+    const onReadiness = vi.fn()
+    stubObjectUrls()
+    const file = fakeFile({
+      name: "small.bin",
+      type: "application/zip",
       size: 4,
-      slice: () => ({
-        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3, 4]).buffer),
-      }),
-    } as unknown as File
+    })
 
     await act(async () => {
-      await result.current.sendFileMessage(file, onInitiated)
+      await result.current.sendFileMessage(file, { onReadiness })
     })
 
-    expect(onInitiated).toHaveBeenCalledTimes(1)
+    expect(onReadiness).toHaveBeenCalledTimes(1)
+    expect(onReadiness.mock.calls[0][0]).toBeUndefined()
     expect(channel.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"file-start"')
     )
@@ -343,24 +443,303 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     )
   })
 
-  it("never reports initiation for a Room file that cannot begin", async () => {
+  it("never releases a Room file that cannot begin", async () => {
     const { result } = await connect()
-    const onInitiated = vi.fn()
-    const oversized = {
+    const onReadiness = vi.fn()
+    const oversized = fakeFile({
       name: "huge.bin",
       type: "application/octet-stream",
       size: 21 * 1024 * 1024,
-    } as unknown as File
+    })
 
     let caught: unknown
     await act(async () => {
       caught = await result.current
-        .sendFileMessage(oversized, onInitiated)
+        .sendFileMessage(oversized, { onReadiness })
         .catch((error: unknown) => error)
     })
 
     expect(String(caught)).toContain("20 MB")
-    expect(onInitiated).not.toHaveBeenCalled()
+    expect(onReadiness).not.toHaveBeenCalled()
     expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("accepts a multi-MB Task image and uploads the bounded derived copy", async () => {
+    const { result } = await connect()
+    stubVisionCopy({ width: 4000, height: 3000, bytes: 512 * 1024 })
+    const file = fakeFile({
+      name: "screenshot.png",
+      type: "image/png",
+      size: 4 * 1024 * 1024,
+    })
+
+    await act(async () => {
+      await result.current.sendTaskAttachment(file, "task-1")
+    })
+
+    // The larger-than-768-KB source is accepted, and the DERIVED uploaded
+    // copy — not the source — carries the Agent-readable bound.
+    const upload = taskUploadCall()
+    expect(upload).toBeDefined()
+    const headers = upload[1].headers as Record<string, string>
+    expect(headers["X-Task-Request-Id"]).toBe("task-1")
+    expect(headers["Content-Type"]).toBe("image/jpeg")
+    const uploaded = upload[1].body as ArrayBuffer
+    expect(uploaded.byteLength).toBeLessThanOrEqual(768 * 1024)
+    expect(uploaded.byteLength).toBeLessThan(file.size)
+    // A Task attachment never rides the 20 MB DataChannel transfer.
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when a Task image cannot produce a bounded copy", async () => {
+    const { result } = await connect()
+    // The existing vision path cannot re-encode this source under the
+    // Agent-readable bound, so the derived-copy bound still fails closed.
+    stubVisionCopy({ width: 4000, height: 3000, bytes: 768 * 1024 + 1 })
+    const file = fakeFile({
+      name: "screenshot.png",
+      type: "image/png",
+      size: 9 * 1024 * 1024,
+    })
+
+    let caught: unknown
+    await act(async () => {
+      caught = await result.current
+        .sendTaskAttachment(file, "task-1")
+        .catch((error: unknown) => error)
+    })
+
+    expect(caught).toBeInstanceOf(Error)
+    expect(taskUploadCall()).toBeUndefined()
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+})
+
+describe("Room file release edge (#363 review point 1)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let attachmentResponse: () => Promise<Response>
+
+  beforeEach(() => {
+    FakePeerConnection.instances.length = 0
+    FakePeerConnection.dataChannels.length = 0
+    ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakePeerConnection
+    class FakeMediaStream {
+      constructor(private tracks: FakeTrack[] = []) {}
+      getAudioTracks() {
+        return this.tracks
+      }
+      getTracks() {
+        return this.tracks
+      }
+    }
+    ;(global as unknown as { MediaStream: unknown }).MediaStream =
+      FakeMediaStream
+    class FakeWebSocket {
+      static OPEN = 1
+      readyState = 1
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: (() => void) | null = null
+      constructor(_url: string) {
+        lastFakeWebSocket = this
+      }
+      send() {}
+      close() {}
+    }
+    ;(global as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getAudioTracks: () => [new FakeTrack()],
+        }),
+      },
+      configurable: true,
+    })
+
+    attachmentResponse = () =>
+      jsonResponse({ attachment: { id: "attachment-1" } })
+    fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/establish"))
+        return jsonResponse({})
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return localTrackResponse(init) ?? jsonResponse({})
+      if (url.endsWith("/api/room/attachments")) return attachmentResponse()
+      return jsonResponse({})
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    lastFakeWebSocket = null
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  async function connectWithAgent() {
+    const hook = renderHook(() =>
+      useSfuChatRoom("attachment-room", "Alice", "audio", {})
+    )
+    await waitFor(() => expect(lastFakeWebSocket).not.toBeNull())
+    act(() => lastFakeWebSocket?.onopen?.())
+    await waitFor(() =>
+      expect(
+        FakePeerConnection.dataChannels.some(
+          (channel) => channel.label === "files-participant-1"
+        )
+      ).toBe(true)
+    )
+    act(() =>
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: roomState([
+            humanParticipant("participant-1"),
+            agentParticipant("agent-remote"),
+          ]),
+        }),
+      })
+    )
+    await waitFor(() =>
+      expect(
+        hook.result.current.participants.some(
+          (participant) => participant.kind === "agent"
+        )
+      ).toBe(true)
+    )
+    return hook
+  }
+
+  function localFileChannel() {
+    return FakePeerConnection.dataChannels.find(
+      (channel) => channel.label === "files-participant-1"
+    )!
+  }
+
+  function attachmentUploadCalls() {
+    return fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/api/room/attachments")
+    ) as Array<[string, RequestInit]>
+  }
+
+  it("holds the release edge until the bounded Agent-readable copy is published", async () => {
+    const { result } = await connectWithAgent()
+    const channel = localFileChannel()
+    stubObjectUrls()
+    let settleCopy: ((response: Response) => void) | undefined
+    attachmentResponse = () =>
+      new Promise<Response>((resolve) => {
+        settleCopy = resolve
+      })
+    const onReadiness = vi.fn()
+    const file = fakeFile({ name: "notes.txt", type: "text/plain", size: 32 })
+
+    await act(async () => {
+      await result.current.sendFileMessage(file, { onReadiness })
+    })
+
+    // The whole Human DataChannel transfer already ran...
+    expect(channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"file-end"')
+    )
+    // ...and the bounded copy is still unpublished, so the text half of the
+    // submission is deliberately NOT released yet.
+    expect(onReadiness).not.toHaveBeenCalled()
+    const uploads = attachmentUploadCalls()
+    expect(uploads).toHaveLength(1)
+
+    await act(async () => {
+      settleCopy?.(await jsonResponse({ attachment: { id: "copy-1" } }))
+    })
+    await waitFor(() => expect(onReadiness).toHaveBeenCalledTimes(1))
+    expect(onReadiness.mock.calls[0][0]).toBeUndefined()
+  })
+
+  it("does not gate a file with no bounded Agent-readable copy", async () => {
+    const { result } = await connectWithAgent()
+    const channel = localFileChannel()
+    stubObjectUrls()
+    const onReadiness = vi.fn()
+    // The file is unsupported for Agent vision and too large for the bounded
+    // text copy, so today's initiation edge is preserved.
+    const file = fakeFile({
+      name: "archive.zip",
+      type: "application/zip",
+      size: 2 * 1024 * 1024,
+    })
+
+    await act(async () => {
+      await result.current.sendFileMessage(file, { onReadiness })
+    })
+
+    expect(onReadiness).toHaveBeenCalledTimes(1)
+    expect(onReadiness.mock.calls[0][0]).toBeUndefined()
+    // Released at local initiation, strictly before the transfer finished.
+    const endIndex = channel.send.mock.calls.findIndex(
+      ([data]) => typeof data === "string" && data.includes('"type":"file-end"')
+    )
+    expect(onReadiness.mock.invocationCallOrder[0]).toBeLessThan(
+      channel.send.mock.invocationCallOrder[endIndex]
+    )
+    expect(attachmentUploadCalls()).toHaveLength(0)
+  })
+
+  it("reports a failed bounded copy instead of releasing the submission", async () => {
+    const { result } = await connectWithAgent()
+    const channel = localFileChannel()
+    stubObjectUrls()
+    attachmentResponse = () =>
+      jsonResponse({ error: "attachment_too_large" }, 413)
+    const onReadiness = vi.fn()
+    const file = fakeFile({ name: "notes.txt", type: "text/plain", size: 32 })
+
+    await act(async () => {
+      await result.current.sendFileMessage(file, { onReadiness })
+    })
+
+    expect(onReadiness).toHaveBeenCalledTimes(1)
+    expect(onReadiness.mock.calls[0][0]).toBeInstanceOf(Error)
+    // The non-transactional Human transfer is never aborted by the secondary
+    // Agent-readable copy failure.
+    expect(channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"file-end"')
+    )
+  })
+
+  it("keeps the Room image path on the same bounded vision copy", async () => {
+    const { result } = await connectWithAgent()
+    stubObjectUrls()
+    stubVisionCopy({ width: 4000, height: 3000, bytes: 320 * 1024 })
+    const onReadiness = vi.fn()
+    const file = fakeFile({
+      name: "shot.png",
+      type: "image/png",
+      size: 3 * 1024 * 1024,
+    })
+
+    await act(async () => {
+      await result.current.sendFileMessage(file, { onReadiness })
+    })
+    await waitFor(() => expect(onReadiness).toHaveBeenCalledTimes(1))
+    expect(onReadiness.mock.calls[0][0]).toBeUndefined()
+
+    const uploads = attachmentUploadCalls()
+    expect(uploads).toHaveLength(1)
+    const headers = uploads[0][1].headers as Record<string, string>
+    expect(headers["Content-Type"]).toBe("image/jpeg")
+    const uploaded = uploads[0][1].body as ArrayBuffer
+    expect(uploaded.byteLength).toBeLessThanOrEqual(768 * 1024)
+    expect(uploaded.byteLength).toBeLessThan(file.size)
   })
 })

--- a/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
@@ -1,0 +1,366 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useSfuChatRoom } from "./useSfuChatRoom"
+
+/**
+ * #363: a Human Task attachment must ride the existing bounded,
+ * task-correlated Room attachment API (exact X-Task-Request-Id, 768 KB
+ * Agent-readable bound) and never the 20 MB Human browser DataChannel
+ * transfer. The compose-first composer also needs an initiation edge from the
+ * ordinary Room file path so it never completes an obviously partial
+ * submission.
+ */
+
+class FakeTrack {
+  kind: "audio" | "video" = "audio"
+  enabled = true
+  readyState = "live"
+  stop = vi.fn()
+}
+
+class FakeDataChannel {
+  binaryType = ""
+  bufferedAmountLowThreshold = 0
+  bufferedAmount = 0
+  readyState = "open"
+  listeners = new Map<string, Set<(event: unknown) => void>>()
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(
+    public label = "",
+    public options: Record<string, unknown> = {}
+  ) {}
+
+  addEventListener(type: string, handler: (event: unknown) => void) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
+    this.listeners.get(type)!.add(handler)
+  }
+  removeEventListener(type: string, handler: (event: unknown) => void) {
+    this.listeners.get(type)?.delete(handler)
+  }
+  emit(type: string, event: unknown) {
+    for (const handler of this.listeners.get(type) ?? []) handler(event)
+  }
+}
+
+class FakePeerConnection {
+  static instances: FakePeerConnection[] = []
+  static dataChannels: FakeDataChannel[] = []
+  connectionState = "connected"
+  ontrack: ((event: unknown) => void) | null = null
+  onconnectionstatechange: (() => void) | null = null
+  private mids = 0
+  private transceivers: { sender: { track: FakeTrack }; mid: string }[] = []
+
+  constructor() {
+    FakePeerConnection.instances.push(this)
+  }
+  addTrack(track: FakeTrack) {
+    const mid = String(this.mids++)
+    this.transceivers.push({ sender: { track }, mid })
+    return { track }
+  }
+  addTransceiver(track: FakeTrack) {
+    const transceiver = { sender: { track }, mid: String(this.mids++) }
+    this.transceivers.push(transceiver)
+    return transceiver
+  }
+  getTransceivers() {
+    return this.transceivers
+  }
+  createOffer() {
+    return Promise.resolve({ type: "offer", sdp: "fake-offer" })
+  }
+  createAnswer() {
+    return Promise.resolve({ type: "answer", sdp: "fake-answer" })
+  }
+  setLocalDescription() {
+    return Promise.resolve()
+  }
+  setRemoteDescription() {
+    return Promise.resolve()
+  }
+  createDataChannel(label: string, options: Record<string, unknown> = {}) {
+    const channel = new FakeDataChannel(label, options)
+    FakePeerConnection.dataChannels.push(channel)
+    return channel
+  }
+  removeTrack() {}
+  close() {}
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response)
+}
+
+function localTrackResponse(init?: RequestInit) {
+  const body = JSON.parse(String(init?.body ?? "{}")) as {
+    tracks?: Array<{ location?: string; mid?: string; trackName?: string }>
+  }
+  const track = body.tracks?.find((entry) => entry.location === "local")
+  if (!track) return null
+  return jsonResponse({
+    sessionDescription: { type: "answer", sdp: "fake-local-answer" },
+    tracks: [{ mid: track.mid ?? "0", trackName: track.trackName }],
+  })
+}
+
+let lastFakeWebSocket: {
+  onopen: (() => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+} | null = null
+
+describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let attachmentResponse: () => Promise<Response>
+
+  beforeEach(() => {
+    FakePeerConnection.instances.length = 0
+    FakePeerConnection.dataChannels.length = 0
+    ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakePeerConnection
+    class FakeMediaStream {
+      constructor(private tracks: FakeTrack[] = []) {}
+      getAudioTracks() {
+        return this.tracks
+      }
+      getTracks() {
+        return this.tracks
+      }
+    }
+    ;(global as unknown as { MediaStream: unknown }).MediaStream =
+      FakeMediaStream
+    class FakeWebSocket {
+      static OPEN = 1
+      readyState = 1
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: (() => void) | null = null
+      constructor(_url: string) {
+        lastFakeWebSocket = this
+      }
+      send() {}
+      close() {}
+    }
+    ;(global as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getAudioTracks: () => [new FakeTrack()],
+        }),
+      },
+      configurable: true,
+    })
+
+    attachmentResponse = () =>
+      jsonResponse({
+        attachment: {
+          id: "attachment-1",
+          taskRequestId: "task-1",
+        },
+      })
+    fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/establish"))
+        return jsonResponse({})
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return localTrackResponse(init) ?? jsonResponse({})
+      if (url.endsWith("/api/room/attachments")) return attachmentResponse()
+      return jsonResponse({})
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    lastFakeWebSocket = null
+    vi.restoreAllMocks()
+  })
+
+  async function connect() {
+    const hook = renderHook(() =>
+      useSfuChatRoom("attachment-room", "Alice", "audio", {})
+    )
+    await waitFor(() => expect(lastFakeWebSocket).not.toBeNull())
+    act(() => lastFakeWebSocket?.onopen?.())
+    await waitFor(() =>
+      expect(
+        FakePeerConnection.dataChannels.some(
+          (channel) => channel.label === "files-participant-1"
+        )
+      ).toBe(true)
+    )
+    return hook
+  }
+
+  function localFileChannel() {
+    return FakePeerConnection.dataChannels.find(
+      (channel) => channel.label === "files-participant-1"
+    )!
+  }
+
+  function taskUploadCall() {
+    return fetchMock.mock.calls.find(([input]) =>
+      String(input).endsWith("/api/room/attachments")
+    ) as [string, RequestInit] | undefined
+  }
+
+  it("uploads a Task attachment through the bounded API with the exact task correlation", async () => {
+    const { result } = await connect()
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "notes.md", {
+      type: "text/markdown",
+    })
+
+    await act(async () => {
+      await result.current.sendTaskAttachment(file, "task-1")
+    })
+
+    const upload = taskUploadCall()
+    expect(upload).toBeDefined()
+    const headers = upload![1].headers as Record<string, string>
+    expect(headers["X-Task-Request-Id"]).toBe("task-1")
+    expect(headers["X-Room-Id"]).toBe("attachment-room")
+    expect(headers["X-Room-Participant-Id"]).toBe("participant-1")
+    expect(headers["X-Room-Participant-Token"]).toBe("participant-token")
+    expect(headers["Content-Type"]).toBe("text/markdown")
+    expect(headers["X-File-Name"]).toBe(encodeURIComponent("notes.md"))
+    expect(upload![1].method).toBe("POST")
+
+    // The 20 MB Human browser transfer is never used for a Task attachment.
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("keeps the exact active Task id when the Task is no longer valid (fail closed)", async () => {
+    const { result } = await connect()
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "notes.md", {
+      type: "text/markdown",
+    })
+    attachmentResponse = () =>
+      jsonResponse({ error: "unknown_task_request" }, 409)
+
+    let caught: unknown
+    await act(async () => {
+      caught = await result.current
+        .sendTaskAttachment(file, "task-stale")
+        .catch((error: unknown) => error)
+    })
+
+    expect(String(caught)).toContain("no longer active")
+    const upload = taskUploadCall()
+    expect(
+      (upload![1].headers as Record<string, string>)["X-Task-Request-Id"]
+    ).toBe("task-stale")
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("never falls back to Room scope for a missing Task correlation", async () => {
+    const { result } = await connect()
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "notes.md", {
+      type: "text/markdown",
+    })
+
+    let caught: unknown
+    await act(async () => {
+      caught = await result.current
+        .sendTaskAttachment(file, "   ")
+        .catch((error: unknown) => error)
+    })
+
+    expect(String(caught)).toContain("no longer active")
+    expect(taskUploadCall()).toBeUndefined()
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("enforces the existing bounded Agent-readable size for Task attachments", async () => {
+    const { result } = await connect()
+    const oversized = {
+      name: "large.txt",
+      type: "text/plain",
+      size: 768 * 1024 + 1,
+    } as unknown as File
+
+    let caught: unknown
+    await act(async () => {
+      caught = await result.current
+        .sendTaskAttachment(oversized, "task-1")
+        .catch((error: unknown) => error)
+    })
+
+    expect(String(caught)).toContain("768 KB")
+    expect(taskUploadCall()).toBeUndefined()
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("reports the Room file initiation edge and completes the existing transfer", async () => {
+    const { result } = await connect()
+    const channel = localFileChannel()
+    const onInitiated = vi.fn()
+    // jsdom's Blob lacks arrayBuffer(); model the file exactly like the
+    // existing DataChannel transfer tests do.
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:small-file"),
+    })
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    })
+    const file = {
+      name: "small.txt",
+      type: "text/plain",
+      size: 4,
+      slice: () => ({
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1, 2, 3, 4]).buffer),
+      }),
+    } as unknown as File
+
+    await act(async () => {
+      await result.current.sendFileMessage(file, onInitiated)
+    })
+
+    expect(onInitiated).toHaveBeenCalledTimes(1)
+    expect(channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"file-start"')
+    )
+    expect(channel.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"file-end"')
+    )
+  })
+
+  it("never reports initiation for a Room file that cannot begin", async () => {
+    const { result } = await connect()
+    const onInitiated = vi.fn()
+    const oversized = {
+      name: "huge.bin",
+      type: "application/octet-stream",
+      size: 21 * 1024 * 1024,
+    } as unknown as File
+
+    let caught: unknown
+    await act(async () => {
+      caught = await result.current
+        .sendFileMessage(oversized, onInitiated)
+        .catch((error: unknown) => error)
+    })
+
+    expect(String(caught)).toContain("20 MB")
+    expect(onInitiated).not.toHaveBeenCalled()
+    expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.taskAttachment.test.tsx
@@ -339,7 +339,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     })
 
     await act(async () => {
-      await result.current.sendTaskAttachment(file, "task-1")
+      await result.current.sendTaskAttachment(file, "task-1", true)
     })
 
     const upload = taskUploadCall()
@@ -351,10 +351,30 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     expect(headers["X-Room-Participant-Token"]).toBe("participant-token")
     expect(headers["Content-Type"]).toBe("text/markdown")
     expect(headers["X-File-Name"]).toBe(encodeURIComponent("notes.md"))
+    // Attachment-only Task submission: the persisted wake intent addresses
+    // the participating Task Agent.
+    expect(headers["X-Task-Attachment-Wake"]).toBe("1")
     expect(upload![1].method).toBe("POST")
 
     // The 20 MB Human browser transfer is never used for a Task attachment.
     expect(localFileChannel().send).not.toHaveBeenCalled()
+  })
+
+  it("carries the composer's context-only intent for an attachment + text submission", async () => {
+    const { result } = await connect()
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "notes.md", {
+      type: "text/markdown",
+    })
+
+    await act(async () => {
+      await result.current.sendTaskAttachment(file, "task-1", false)
+    })
+
+    // The following Task text is the single wake boundary; the attachment is
+    // persisted as Task context and must not wake the Agent on its own.
+    const headers = taskUploadCall()![1].headers as Record<string, string>
+    expect(headers["X-Task-Request-Id"]).toBe("task-1")
+    expect(headers["X-Task-Attachment-Wake"]).toBe("0")
   })
 
   it("keeps the exact active Task id when the Task is no longer valid (fail closed)", async () => {
@@ -368,7 +388,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     let caught: unknown
     await act(async () => {
       caught = await result.current
-        .sendTaskAttachment(file, "task-stale")
+        .sendTaskAttachment(file, "task-stale", false)
         .catch((error: unknown) => error)
     })
 
@@ -389,7 +409,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     let caught: unknown
     await act(async () => {
       caught = await result.current
-        .sendTaskAttachment(file, "   ")
+        .sendTaskAttachment(file, "   ", false)
         .catch((error: unknown) => error)
     })
 
@@ -409,7 +429,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     let caught: unknown
     await act(async () => {
       caught = await result.current
-        .sendTaskAttachment(oversized, "task-1")
+        .sendTaskAttachment(oversized, "task-1", false)
         .catch((error: unknown) => error)
     })
 
@@ -474,7 +494,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     })
 
     await act(async () => {
-      await result.current.sendTaskAttachment(file, "task-1")
+      await result.current.sendTaskAttachment(file, "task-1", false)
     })
 
     // The larger-than-768-KB source is accepted, and the DERIVED uploaded
@@ -505,7 +525,7 @@ describe("useSfuChatRoom task + compose-first attachments (#363)", () => {
     let caught: unknown
     await act(async () => {
       caught = await result.current
-        .sendTaskAttachment(file, "task-1")
+        .sendTaskAttachment(file, "task-1", true)
         .catch((error: unknown) => error)
     })
 

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -24,6 +24,10 @@ import {
   SFU_EGRESS_SAMPLE_INTERVAL_MS,
   type SfuEgressSampleReason,
 } from "@common/sfuEgress"
+import {
+  encodeTaskAttachmentWake,
+  TASK_ATTACHMENT_WAKE_HEADER,
+} from "@common/taskAttachmentWake"
 import { ActionType, Message, UserInfo } from "@common/types"
 import {
   hashRoom,
@@ -3922,8 +3926,20 @@ export function useSfuChatRoom(
   // Agent-readable bound, same ephemeral Room store) instead of the 20 MB
   // Human DataChannel transfer, and it always carries the exact active
   // taskRequestId so the Room can fail closed on a stale or unknown Task.
+  //
+  // #363 second review: `wakeAgent` is the composer's explicit submission
+  // intent. It is persisted with the attachment so the Agent event can be
+  // rebuilt identically after a reconnect/replay: an attachment-only Task
+  // submission wakes the participating Task Agent(s), while an attachment +
+  // text submission keeps the attachment as Task context and leaves the
+  // following Task text as the single addressed wake boundary. The Room never
+  // derives this from the Task correlation alone.
   const sendTaskAttachment = useCallback(
-    async (file: File, taskRequestId: string): Promise<void> => {
+    async (
+      file: File,
+      taskRequestId: string,
+      wakeAgent: boolean
+    ): Promise<void> => {
       const requestId = taskRequestId.trim()
       if (!requestId) throw new Error("This task is no longer active")
       const session = sessionRef.current
@@ -3957,6 +3973,7 @@ export function useSfuChatRoom(
           "X-Room-Participant-Token": session.participantToken,
           "X-File-Name": encodeURIComponent(file.name.slice(0, 256)),
           "X-Task-Request-Id": requestId,
+          [TASK_ATTACHMENT_WAKE_HEADER]: encodeTaskAttachmentWake(wakeAgent),
         },
         body: uploadBody,
       })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -445,6 +445,20 @@ async function createAgentVisionCopy(file: File): Promise<Blob> {
   }
 }
 
+/**
+ * #363 review (point 1): the composer's release edge for one Room file
+ * submission. `onReadiness` fires exactly once — after the Human DataChannel
+ * transfer has genuinely begun and, when a bounded Agent-readable copy applies
+ * to this file, after that bounded copy has been published. It receives an
+ * error instead when an applicable bounded copy could not be published, so the
+ * composer keeps its draft truthful rather than releasing text into an Agent
+ * context that is missing the attachment. The full 20 MB transfer is
+ * deliberately never awaited here.
+ */
+interface RoomFileSendHooks {
+  onReadiness?: (error?: unknown) => void
+}
+
 interface SfuSession extends SfuSessionResponse {
   room: string
 }
@@ -3771,8 +3785,50 @@ export function useSfuChatRoom(
     }
   }, [createRuntimeProviderClaim, roomName])
 
+  /** #363 review (point 1): a bounded Agent-readable copy applies to a
+   * supported image/text-like file while at least one Agent is connected. */
+  const agentReadableCopyApplies = useCallback((file: File): boolean => {
+    if (!sessionRef.current) return false
+    const hasConnectedAgent = [...participantMapRef.current.values()].some(
+      (participant) => participant.kind === "agent" && participant.connected
+    )
+    return hasConnectedAgent && (isAgentImage(file) || isAgentTextFile(file))
+  }, [])
+
+  /** #363 review (point 1): publish the bounded Agent-readable copy of one
+   * Human Room file. This resolves only once the Room has accepted it, which
+   * is what the composer's release edge waits for — never the whole 20 MB
+   * DataChannel transfer. */
+  const publishAgentReadableCopy = useCallback(
+    async (session: SfuSession, file: File): Promise<void> => {
+      let uploadType = file.type
+      let uploadBody: ArrayBuffer | Blob = file
+      if (isAgentImage(file)) {
+        const visionCopy = await createAgentVisionCopy(file)
+        uploadType = visionCopy.type || file.type
+        uploadBody = await visionCopy.arrayBuffer()
+      } else {
+        uploadType = agentTextMime(file) ?? file.type
+      }
+      const response = await fetch("/api/room/attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": uploadType,
+          "X-Room-Id": roomName,
+          "X-Room-Participant-Id": session.participantId,
+          "X-Room-Participant-Token": session.participantToken,
+          "X-File-Name": encodeURIComponent(file.name.slice(0, 256)),
+        },
+        body: uploadBody,
+      })
+      if (!response.ok)
+        throw new Error("Couldn't publish the Agent-readable copy of this file")
+    },
+    [roomName]
+  )
+
   const sendFileMessage = useCallback(
-    async (file: File, onInitiated?: () => void) => {
+    async (file: File, hooks?: RoomFileSendHooks) => {
       // Allocate the transfer id before queueing so the queued wire messages
       // and the eventual local bubble share one stable identity.
       const id = crypto.randomUUID()
@@ -3797,11 +3853,22 @@ export function useSfuChatRoom(
             afterSequence,
           })
         )
-        // #363 A1: file-start is on the wire, so the local transfer has
-        // genuinely begun. A compose-first caller uses this edge to release
-        // the rest of one submission without inventing any transactional
-        // guarantee for remote peers.
-        onInitiated?.()
+        // #363 review (point 1): decide the bounded Agent-readable copy up
+        // front and publish it concurrently with the Human transfer, so the
+        // composer's release edge never waits for the whole 20 MB transfer. A
+        // file with no applicable bounded copy keeps today's plain initiation
+        // edge, and a failed applicable copy is reported truthfully instead of
+        // silently releasing the text.
+        const copyApplies = agentReadableCopyApplies(file)
+        const copySession = sessionRef.current
+        if (copyApplies && copySession) {
+          void publishAgentReadableCopy(copySession, file).then(
+            () => hooks?.onReadiness?.(),
+            (error: unknown) => hooks?.onReadiness?.(error)
+          )
+        } else {
+          hooks?.onReadiness?.()
+        }
         for (let offset = 0; offset < file.size; offset += FILE_CHUNK_SIZE) {
           await waitForSendCapacity(channel)
           const chunk = await file
@@ -3823,42 +3890,14 @@ export function useSfuChatRoom(
           fileName: file.name,
           fileSize: file.size,
         })
-        const session = sessionRef.current
-        const hasConnectedAgent = [...participantMapRef.current.values()].some(
-          (participant) => participant.kind === "agent" && participant.connected
-        )
-        if (
-          session &&
-          hasConnectedAgent &&
-          (isAgentImage(file) || isAgentTextFile(file))
-        ) {
-          void (async () => {
-            try {
-              let uploadType = file.type
-              let uploadBody: ArrayBuffer | Blob = file
-              if (isAgentImage(file)) {
-                const visionCopy = await createAgentVisionCopy(file)
-                uploadType = visionCopy.type || file.type
-                uploadBody = await visionCopy.arrayBuffer()
-              } else {
-                uploadType = agentTextMime(file) ?? file.type
-              }
-              await fetch("/api/room/attachments", {
-                method: "POST",
-                headers: {
-                  "Content-Type": uploadType,
-                  "X-Room-Id": roomName,
-                  "X-Room-Participant-Id": session.participantId,
-                  "X-Room-Participant-Token": session.participantToken,
-                  "X-File-Name": encodeURIComponent(file.name.slice(0, 256)),
-                },
-                body: uploadBody,
-              })
-            } catch {
-              // Agent vision is secondary; human DataChannel delivery already succeeded.
-            }
-          })()
-        }
+        // Existing best-effort behaviour is preserved for the one case the
+        // release edge cannot cover: an Agent that only becomes connected while
+        // this transfer is already in flight still gets its bounded copy.
+        const lateSession = sessionRef.current
+        if (!copyApplies && lateSession && agentReadableCopyApplies(file))
+          void publishAgentReadableCopy(lateSession, file).catch(
+            () => undefined
+          )
       }
       const next = fileSendQueueRef.current.then(send, send)
       fileSendQueueRef.current = next.then(
@@ -3868,10 +3907,11 @@ export function useSfuChatRoom(
       return next
     },
     [
+      agentReadableCopyApplies,
       appendEphemeralMessage,
       latestObservedRoomSequence,
       nickName,
-      roomName,
+      publishAgentReadableCopy,
       waitForDataChannelOpen,
       waitForSendCapacity,
     ]
@@ -3889,15 +3929,22 @@ export function useSfuChatRoom(
       const session = sessionRef.current
       if (!session) throw new Error("Not connected to the room")
       if (file.size === 0) throw new Error("Empty files can't be attached")
-      if (file.size > MAX_AGENT_ATTACHMENT_BYTES)
-        throw new Error("Task attachments are limited to 768 KB")
       let uploadType = agentTextMime(file)
       let uploadBody: ArrayBuffer | Blob = file
       if (isAgentImage(file)) {
-        // Same bounded, Agent-readable image copy the ordinary Room path uses.
+        // #363 review (point 2): the Agent-readable 768 KB bound applies to the
+        // DERIVED uploaded copy, not to the source screenshot — the same
+        // resize/re-encode the ordinary Room path uses. A normal multi-MB
+        // screenshot therefore works here too.
         const visionCopy = await createAgentVisionCopy(file)
+        if (visionCopy.size > MAX_AGENT_ATTACHMENT_BYTES)
+          throw new Error("Task attachments are limited to 768 KB")
         uploadType = visionCopy.type || file.type
         uploadBody = await visionCopy.arrayBuffer()
+      } else if (file.size > MAX_AGENT_ATTACHMENT_BYTES) {
+        // A text-like source has no derived copy, so the raw Agent-readable
+        // bound still applies to it.
+        throw new Error("Task attachments are limited to 768 KB")
       }
       if (!uploadType)
         throw new Error("Only images and text files can be attached to a task")

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -374,6 +374,27 @@ function isAgentImage(file: File): boolean {
   return AGENT_IMAGE_TYPES.has(file.type)
 }
 
+/** #363 A2: Task attachments reuse the existing bounded Room attachment API,
+ * whose bounded failure surface is mapped to Human-readable text. */
+function taskAttachmentErrorMessage(error: unknown): string {
+  switch (error) {
+    case "attachment_too_large":
+      return "Task attachments are limited to 768 KB"
+    case "unsupported_image_type":
+    case "unsupported_attachment_type":
+      return "Only images and text files can be attached to a task"
+    case "task_target_not_in_room":
+    case "unknown_task_request":
+      return "This task is no longer active"
+    case "task_attachment_not_participant":
+      return "This task is no longer available"
+    case "room_expired":
+      return "This Room has expired"
+    default:
+      return "Couldn't attach the file to this task"
+  }
+}
+
 /** Text-like files are uploaded for read_attachment too; the MCP layer
  * returns them as decoded text instead of ImageContent. */
 function isAgentTextFile(file: File): boolean {
@@ -3751,7 +3772,7 @@ export function useSfuChatRoom(
   }, [createRuntimeProviderClaim, roomName])
 
   const sendFileMessage = useCallback(
-    async (file: File) => {
+    async (file: File, onInitiated?: () => void) => {
       // Allocate the transfer id before queueing so the queued wire messages
       // and the eventual local bubble share one stable identity.
       const id = crypto.randomUUID()
@@ -3776,6 +3797,11 @@ export function useSfuChatRoom(
             afterSequence,
           })
         )
+        // #363 A1: file-start is on the wire, so the local transfer has
+        // genuinely begun. A compose-first caller uses this edge to release
+        // the rest of one submission without inventing any transactional
+        // guarantee for remote peers.
+        onInitiated?.()
         for (let offset = 0; offset < file.size; offset += FILE_CHUNK_SIZE) {
           await waitForSendCapacity(channel)
           const chunk = await file
@@ -3851,6 +3877,52 @@ export function useSfuChatRoom(
     ]
   )
 
+  // #363 A2: Human attachment inside an ACTIVE Task. This deliberately reuses
+  // the existing bounded, task-correlated Room attachment API (same 768 KB
+  // Agent-readable bound, same ephemeral Room store) instead of the 20 MB
+  // Human DataChannel transfer, and it always carries the exact active
+  // taskRequestId so the Room can fail closed on a stale or unknown Task.
+  const sendTaskAttachment = useCallback(
+    async (file: File, taskRequestId: string): Promise<void> => {
+      const requestId = taskRequestId.trim()
+      if (!requestId) throw new Error("This task is no longer active")
+      const session = sessionRef.current
+      if (!session) throw new Error("Not connected to the room")
+      if (file.size === 0) throw new Error("Empty files can't be attached")
+      if (file.size > MAX_AGENT_ATTACHMENT_BYTES)
+        throw new Error("Task attachments are limited to 768 KB")
+      let uploadType = agentTextMime(file)
+      let uploadBody: ArrayBuffer | Blob = file
+      if (isAgentImage(file)) {
+        // Same bounded, Agent-readable image copy the ordinary Room path uses.
+        const visionCopy = await createAgentVisionCopy(file)
+        uploadType = visionCopy.type || file.type
+        uploadBody = await visionCopy.arrayBuffer()
+      }
+      if (!uploadType)
+        throw new Error("Only images and text files can be attached to a task")
+      const response = await fetch("/api/room/attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": uploadType,
+          "X-Room-Id": roomName,
+          "X-Room-Participant-Id": session.participantId,
+          "X-Room-Participant-Token": session.participantToken,
+          "X-File-Name": encodeURIComponent(file.name.slice(0, 256)),
+          "X-Task-Request-Id": requestId,
+        },
+        body: uploadBody,
+      })
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as {
+          error?: unknown
+        } | null
+        throw new Error(taskAttachmentErrorMessage(payload?.error))
+      }
+    },
+    [roomName]
+  )
+
   const retryVerification = useCallback(() => {
     if (closingRef.current) return
     setError("")
@@ -3882,6 +3954,7 @@ export function useSfuChatRoom(
     getRoomAppStats,
     sendTextMessage,
     sendFileMessage,
+    sendTaskAttachment,
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,

--- a/app/src/room/server.test.ts
+++ b/app/src/room/server.test.ts
@@ -21,19 +21,19 @@ describe("Worker Room route dispatch", () => {
   })
 })
 
-type CapturedUpload = { contentType: string | null }
+type CapturedUpload = { contentType: string | null; taskWake: string | null }
 type CapturedControl = {
   body: Record<string, unknown>
   contentType: string | null
 }
 
 function makeEnv(
-  doFetch: (upload: { contentType: string | null }) => Response
+  doFetch: (upload: CapturedUpload) => Response
 ): RoomProtocolEnv {
   const namespace = {
     idFromName: (name: string) => ({ name }),
     // handleRoomRequest calls stub.fetch(url, init); capture the forwarded
-    // Content-Type from the init headers.
+    // Content-Type and the bounded Task wake token from the init headers.
     get: () => ({
       fetch: (
         _url: string | URL,
@@ -44,6 +44,10 @@ function makeEnv(
             contentType:
               init?.headers?.get("Content-Type") ??
               init?.headers?.get("content-type") ??
+              null,
+            taskWake:
+              init?.headers?.get("X-Task-Attachment-Wake") ??
+              init?.headers?.get("x-task-attachment-wake") ??
               null,
           })
         ),
@@ -88,7 +92,8 @@ function liveTranscriptEnv(captured: CapturedControl[]): RoomProtocolEnv {
 function uploadRequest(
   mimeType: string,
   body: string,
-  participant?: { id: string; token: string }
+  participant?: { id: string; token: string },
+  options: { taskRequestId?: string; taskWake?: string } = {}
 ): Request {
   return new Request("https://www.free4.chat/api/room/attachments", {
     method: "POST",
@@ -103,6 +108,12 @@ function uploadRequest(
           }
         : {}),
       "X-File-Name": encodeURIComponent("notes.md"),
+      ...(options.taskRequestId
+        ? { "X-Task-Request-Id": options.taskRequestId }
+        : {}),
+      ...(options.taskWake === undefined
+        ? {}
+        : { "X-Task-Attachment-Wake": options.taskWake }),
     },
     body,
   })
@@ -125,7 +136,7 @@ describe("room attachment upload gate", () => {
       env
     )
     expect(response.status).toBe(200)
-    expect(uploads).toEqual([{ contentType: "text/markdown" }])
+    expect(uploads).toEqual([{ contentType: "text/markdown", taskWake: null }])
   })
 
   it("accepts text/plain, text/csv and application/json", async () => {
@@ -170,6 +181,54 @@ describe("room attachment upload gate", () => {
     const env = makeEnv(() => Response.json({}))
     const response = await handleRoomRequest(request, env)
     expect(response.status).toBe(403)
+  })
+})
+
+describe("Task attachment wake intent transport (#363 second review)", () => {
+  let uploads: CapturedUpload[]
+
+  beforeEach(() => {
+    uploads = []
+  })
+
+  it("forwards the composer's bounded wake tokens to the Room", async () => {
+    for (const [token, forwarded] of [
+      ["1", "1"],
+      ["0", "0"],
+    ] as const) {
+      uploads = []
+      const response = await handleRoomRequest(
+        uploadRequest(
+          "text/plain",
+          "task context",
+          { id: "human-1", token: "tok-1" },
+          { taskRequestId: "task-1", taskWake: token }
+        ),
+        envCapturing(uploads)
+      )
+      expect(response.status).toBe(200)
+      expect(uploads[0]).toMatchObject({
+        contentType: "text/plain",
+        taskWake: forwarded,
+      })
+    }
+  })
+
+  it("never invents a wake intent for an unknown or absent token", async () => {
+    for (const token of [undefined, "true", "yes", "2", ""]) {
+      uploads = []
+      const response = await handleRoomRequest(
+        uploadRequest(
+          "text/plain",
+          "task context",
+          { id: "human-1", token: "tok-1" },
+          { taskRequestId: "task-1", taskWake: token }
+        ),
+        envCapturing(uploads)
+      )
+      expect(response.status).toBe(200)
+      expect(uploads[0]?.taskWake).toBeNull()
+    }
   })
 })
 

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -1,5 +1,10 @@
 import { isAllowedOrigin } from "../common/origin"
 import { isRuntimeProviderClaimHash } from "../common/runtimeProviderCredential"
+import {
+  encodeTaskAttachmentWake,
+  parseTaskAttachmentWake,
+  TASK_ATTACHMENT_WAKE_HEADER,
+} from "../common/taskAttachmentWake"
 import type { RoomSession } from "../do/RoomSession"
 import { validateRuntimeHost } from "../do/runtimeHost"
 
@@ -365,6 +370,15 @@ export async function handleRoomRequest(
   const taskRequestId = request.headers.get("X-Task-Request-Id")?.trim()
   if (taskRequestId)
     headers.set("X-Task-Request-Id", taskRequestId.slice(0, 64))
+  // #363 second review: the composer's Task wake intent crosses the transport
+  // as exactly one bounded token. Only the two recognized tokens are
+  // forwarded; an unknown value or an absent header is simply not forwarded,
+  // which the Room reads as "no explicit wake intent" — never a wake.
+  const taskWake = parseTaskAttachmentWake(
+    request.headers.get(TASK_ATTACHMENT_WAKE_HEADER)
+  )
+  if (taskWake !== undefined)
+    headers.set(TASK_ATTACHMENT_WAKE_HEADER, encodeTaskAttachmentWake(taskWake))
   return stub.fetch("https://room/attachment", {
     method: "POST",
     headers,

--- a/app/src/room/taskAttachmentWake.test.ts
+++ b/app/src/room/taskAttachmentWake.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it } from "vitest"
+
+import { handleRoomRequest, type RoomProtocolEnv } from "./server"
+import type { RoomRecord } from "./types"
+import { encodeTaskAttachmentWake } from "../common/taskAttachmentWake"
+import { RoomSession } from "../do/RoomSession"
+
+/**
+ * #363 second review, end-to-end-ish regression across the real composer
+ * decision, the existing Worker attachment route, and the real RoomSession:
+ *
+ *   [ screenshot.png ] + "please inspect this"  => ONE wake/turn boundary
+ *
+ * The Task attachment is persisted first as Task context (its Agent event is
+ * NOT addressed), and the following Task text is the single addressed wake —
+ * so the first Harness turn sees both the attachment and the instruction.
+ * An attachment-only submission still wakes the Task Agent on its own.
+ *
+ * The composer's decision (`wakeAgent = text === ""`) and the hook's encoder
+ * are the only inputs this test supplies; the addressing decision itself is
+ * made and persisted by the Room, and re-derived identically from Room state.
+ */
+
+const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
+const TASK_ID = "task-1"
+const ATTACHMENT_WAKE_HEADER = "X-Task-Attachment-Wake"
+
+type AgentEventProjection = {
+  sequence?: number
+  type?: string
+  addressed?: boolean
+  scopeId?: string
+  text?: string
+  attachment?: { id: string; taskRequestId?: string }
+}
+
+function buildStoredRoom(): RoomRecord {
+  return {
+    createdAt: Date.now(),
+    expiresAt: FAR_FUTURE,
+    participants: {
+      "human-1": {
+        id: "human-1",
+        name: "Hannah",
+        kind: "human",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-human",
+        media: {
+          sessionId: "human-session",
+          muted: false,
+          fileChannelReady: true,
+          tracks: [],
+        },
+      },
+      "agent-a": {
+        id: "agent-a",
+        name: "Agent A",
+        kind: "agent",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-agent-a",
+        capabilities: { text: true },
+      },
+      "agent-b": {
+        id: "agent-b",
+        name: "Agent B",
+        kind: "agent",
+        connected: true,
+        joinedAt: 1,
+        lastSeenAt: Date.now(),
+        token: "tok-agent-b",
+        capabilities: { text: true },
+      },
+    },
+    messages: [
+      {
+        id: "task-request-1",
+        peerId: "human-1",
+        name: "Hannah",
+        kind: "human",
+        type: "action",
+        actionType: "collab",
+        sequence: 1,
+        createdAt: 1,
+        collab: {
+          requestId: TASK_ID,
+          kind: "request",
+          fromParticipantId: "human-1",
+          targetParticipantId: "agent-a",
+          summary: "Review the attached screenshot",
+        },
+        targets: ["agent-a"],
+      },
+    ],
+    nextMessageSequence: 1,
+    attachments: [],
+    meetingNotes: { active: false },
+    agentVoice: {},
+    liveTranscript: { active: false },
+    liveTranscriptSegments: [],
+    nextLiveTranscriptEpoch: 1,
+    nextTranscriptSequence: 1,
+    pendingMediaCleanup: [],
+  }
+}
+
+function harness() {
+  const store = new Map<string, unknown>([["room", buildStoredRoom()]])
+  const ctx = {
+    storage: {
+      get: async (key: string) => store.get(key),
+      put: async (key: string, value: unknown) => void store.set(key, value),
+      delete: async (key: string | string[]) => {
+        for (const candidate of Array.isArray(key) ? key : [key])
+          store.delete(candidate)
+      },
+      list: async (options?: { prefix?: string }) => {
+        const entries = [...store.entries()].filter(([key]) =>
+          options?.prefix ? key.startsWith(options.prefix) : true
+        )
+        return new Map(entries)
+      },
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+    getWebSockets: () => [] as WebSocket[],
+    waitUntil: (promise: Promise<unknown>) => void promise,
+    id: { name: "test-room", toString: () => "test-room" },
+  }
+  const session = new RoomSession(
+    ctx as never,
+    {
+      SFU_ROOM: {},
+      AGENT_MEDIA_ENABLED: "true",
+    } as never
+  )
+  // The real Worker route forwards to this Room through the DO namespace
+  // exactly as production does (idFromName(room) -> stub.fetch(request)).
+  const env = {
+    SFU_ROOM: {
+      idFromName: (name: string) => ({ name }),
+      get: () => ({
+        fetch: (url: string | URL, init?: RequestInit) =>
+          session.fetch(new Request(String(url), init)),
+      }),
+    },
+  } as unknown as RoomProtocolEnv
+
+  const control = async (body: Record<string, unknown>) => {
+    const response = await session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    )
+    return { status: response.status, json: await response.json() }
+  }
+  const agentWait = async (
+    participantId: string,
+    cursor: number,
+    timeoutSeconds = 0
+  ) =>
+    (
+      await control({
+        action: "agent-wait",
+        participantId,
+        token: `tok-${participantId}`,
+        cursor,
+        timeoutSeconds,
+      })
+    ).json as { events: AgentEventProjection[]; cursor: number }
+  const readContext = async (participantId: string, afterSequence = 0) =>
+    (
+      await control({
+        action: "agent-read-context",
+        participantId,
+        token: `tok-${participantId}`,
+        afterSequence,
+      })
+    ).json as { events: AgentEventProjection[] }
+  const sendHumanTaskText = (text: string) =>
+    (
+      session as unknown as {
+        handleClientMessage: (
+          socket: WebSocket,
+          attachment: unknown,
+          message: unknown
+        ) => Promise<void>
+      }
+    ).handleClientMessage(
+      { send: () => undefined, close: () => undefined } as unknown as WebSocket,
+      {
+        participantId: "human-1",
+        token: "tok-human",
+        connectionNonce: "human-connection",
+      },
+      { type: "chat", text, taskRequestId: TASK_ID }
+    )
+  const readAttachment = async (participantId: string, attachmentId: string) =>
+    (
+      await control({
+        action: "agent-read-attachment",
+        participantId,
+        token: `tok-${participantId}`,
+        attachmentId,
+      })
+    ).status
+  const storedRoom = () => store.get("room") as RoomRecord
+
+  /** One composer Send: the attachment half first (exactly as the composer
+   * awaits its readiness edge), then the text half when there is text. */
+  async function composerSubmit(text: string) {
+    const bytes = "screenshot bytes"
+    // The composer's own decision, mirrored verbatim.
+    const wakeAgent = text === ""
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/attachments", {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Content-Type": "image/png",
+          "Content-Length": String(bytes.length),
+          "X-Room-Id": "test-room",
+          "X-Room-Participant-Id": "human-1",
+          "X-Room-Participant-Token": "tok-human",
+          "X-File-Name": encodeURIComponent("screenshot.png"),
+          "X-Task-Request-Id": TASK_ID,
+          // The hook's own bounded encoding of that decision.
+          [ATTACHMENT_WAKE_HEADER]: encodeTaskAttachmentWake(wakeAgent),
+        },
+        body: bytes,
+      }),
+      env
+    )
+    expect(response.status).toBe(200)
+    const payload = (await response.json()) as { attachment: { id: string } }
+    if (text !== "") await sendHumanTaskText(text)
+    return payload.attachment.id
+  }
+
+  const submissionStart = () => storedRoom().nextMessageSequence
+  const attachmentEvent = (
+    events: AgentEventProjection[],
+    attachmentId: string
+  ) => events.find((event) => event.attachment?.id === attachmentId)
+  const addressedEvents = (events: AgentEventProjection[]) =>
+    events.filter((event) => event.addressed === true)
+
+  return {
+    env,
+    session,
+    composerSubmit,
+    submissionStart,
+    agentWait,
+    readContext,
+    readAttachment,
+    attachmentEvent,
+    addressedEvents,
+    storedRoom,
+  }
+}
+
+describe("Task composer submission wake boundary (#363 second review)", () => {
+  it("`attachment + text` produces exactly one wake boundary with the attachment inside it", async () => {
+    const test = harness()
+    const start = test.submissionStart()
+    const instruction = "please inspect this"
+
+    const attachmentId = await test.composerSubmit(instruction)
+
+    // Live delivery through the real Worker route + DO: the only addressed
+    // event of this submission is the Task text.
+    const { events } = await test.agentWait("agent-a", start)
+    const addressed = test.addressedEvents(events)
+    expect(addressed).toHaveLength(1)
+    expect(addressed[0]).toMatchObject({
+      type: "text",
+      text: instruction,
+      scopeId: `task:${TASK_ID}`,
+    })
+
+    // The attachment is visible in that same turn as unaddressed Task
+    // context, and its bytes are readable by the Task Agent.
+    const attachment = test.attachmentEvent(events, attachmentId)
+    expect(attachment).toMatchObject({
+      type: "image",
+      addressed: false,
+      scopeId: `task:${TASK_ID}`,
+    })
+    expect(attachment!.sequence!).toBeLessThan(addressed[0].sequence!)
+    expect(await test.readAttachment("agent-a", attachmentId)).toBe(200)
+
+    // Rebuilding the Agent events from persisted Room state (not the live
+    // broadcast) reproduces the identical single boundary.
+    const retained = (await test.readContext("agent-a", start)).events
+    const replayed = test.addressedEvents(retained)
+    expect(replayed).toHaveLength(1)
+    expect(replayed[0]).toMatchObject({ type: "text", text: instruction })
+    const replayedAttachment = test.attachmentEvent(retained, attachmentId)
+    expect(replayedAttachment).toMatchObject({
+      addressed: false,
+      scopeId: `task:${TASK_ID}`,
+    })
+    expect(replayedAttachment!.sequence!).toBeLessThan(replayed[0].sequence!)
+  })
+
+  it("does not resolve an idle Harness on the attachment half of `attachment + text`", async () => {
+    const test = harness()
+    const parked = test.agentWait("agent-a", test.submissionStart(), 25)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const attachmentId = await test.composerSubmit("please inspect this")
+
+    // The attachment half carries no wake at all.
+    const first = await parked
+    expect(test.attachmentEvent(first.events, attachmentId)).toMatchObject({
+      addressed: false,
+    })
+    expect(test.addressedEvents(first.events)).toHaveLength(0)
+
+    // The Task text is the single addressed boundary, and the attachment is
+    // already persisted inside its context window.
+    const { events } = await test.agentWait("agent-a", first.cursor)
+    expect(test.addressedEvents(events)).toHaveLength(1)
+    const retained = (await test.readContext("agent-a")).events
+    expect(test.attachmentEvent(retained, attachmentId)).toMatchObject({
+      addressed: false,
+    })
+  })
+
+  it("`attachment only` still wakes the Task Agent", async () => {
+    const test = harness()
+    const parked = test.agentWait("agent-a", test.submissionStart(), 25)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const attachmentId = await test.composerSubmit("")
+
+    const { events } = await parked
+    const addressed = test.addressedEvents(events)
+    expect(addressed).toHaveLength(1)
+    expect(addressed[0]).toMatchObject({
+      type: "image",
+      scopeId: `task:${TASK_ID}`,
+      attachment: { id: attachmentId, taskRequestId: TASK_ID },
+    })
+    // Replay carries the same persisted wake intent.
+    expect(test.storedRoom().attachments[0].taskWake).toBe(true)
+    expect(
+      test.attachmentEvent(
+        (await test.readContext("agent-a")).events,
+        attachmentId
+      )
+    ).toMatchObject({ addressed: true })
+  })
+
+  it("still fails closed for a Task the Room can no longer resolve", async () => {
+    const test = harness()
+    // The Task correlation is gone: the attachment half must never be
+    // silently downgraded to Room scope, and no Task event may appear.
+    const room = test.storedRoom()
+    room.messages = []
+    const bytes = "screenshot bytes"
+    const response = await handleRoomRequest(
+      new Request("https://www.free4.chat/api/room/attachments", {
+        method: "POST",
+        headers: {
+          Origin: "http://localhost:3000",
+          "Content-Type": "image/png",
+          "Content-Length": String(bytes.length),
+          "X-Room-Id": "test-room",
+          "X-Room-Participant-Id": "human-1",
+          "X-Room-Participant-Token": "tok-human",
+          "X-File-Name": encodeURIComponent("screenshot.png"),
+          "X-Task-Request-Id": TASK_ID,
+          [ATTACHMENT_WAKE_HEADER]: encodeTaskAttachmentWake(true),
+        },
+        body: bytes,
+      }),
+      test.env
+    )
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({
+      error: "unknown_task_request",
+    })
+    expect(test.storedRoom().attachments).toHaveLength(0)
+    const { events } = await test.agentWait("agent-a", 0)
+    expect(events.some((event) => event.attachment !== undefined)).toBe(false)
+  })
+})

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -318,6 +318,16 @@ export interface RoomAttachment {
   // Present only for an Agent artifact explicitly correlated with a retained
   // Task request. Omitted means the ordinary Room artifact timeline.
   taskRequestId?: string
+  // #363 (second review): the composer's explicit wake intent for a
+  // Task-correlated Human attachment, persisted with the record so a
+  // reconnect/replay rebuilds the exact same `addressed` value. It is never
+  // derived from the Task correlation alone: `true` means an attachment-only
+  // Task submission that addresses the participating Task Agent(s), while
+  // `false`/absent means Task context only — the following addressed Task text
+  // stays the single wake boundary. An Agent-authored Task artifact always
+  // persists `false`, and a Room-scope attachment carries no wake intent at
+  // all.
+  taskWake?: boolean
 }
 
 // #234: browser-safe standalone Room attachment projection. Bounded metadata


### PR DESCRIPTION
Implements the **first slice** of #363: **A. compose-first Room attachments** and **B. bounded Human attachments inside an active Task**. `Closes #363`.

**Base:** `93b2f0b91a96fa493ffc55a3f9a09e2b941e0eb2` (`cf-sfu`)
**Head:** `3741dee8603f39a05ebd3df2f5b1dfefe38d40b9` — 14 files, +3512 / −265

Two review rounds are folded in below.

## A1 — compose-first Room attachments

Picking a file creates a **composer draft** (chip with name/size/remove) instead of sending; one Send runs the attachment and the text.

- Send works for text-only, attachment-only, and text + attachment; `@Agent` targeting is resolved from the text exactly as before.
- Enter / Shift+Enter / IME handling is untouched; the Human browser DataChannel path and its **20 MB** limit are unchanged.
- **Readiness edge (review round 1, point 1):** `sendFileMessage(file, { onReadiness })` fires readiness only after the bounded Agent-readable copy has been **published**, when such a copy applies to the file — and it starts that copy **concurrently** with the 20 MB transfer, so the full transfer is never awaited. For a file with no applicable copy, readiness still fires at local initiation. If the copy cannot be published, the composer keeps the draft with a truthful error and does **not** release the text.
- The attachment is initiated first and awaited: a submission whose attachment could not even begin is never completed as an obviously partial text-only send.

## A2 — Human attachments inside an active Task

- The active Task composer exposes a small **Attach** affordance (the Room `+` menu with Whiteboard/Poll/Games stays hidden in Task scope exactly as before).
- Uploads use the existing bounded Room attachment path with `X-Task-Request-Id`; supported image/text types; the existing **768 KB** Agent-readable bound.
- **Derived-copy bound (review round 1, point 2):** for images the 768 KB bound applies to the **derived** `createAgentVisionCopy` result — the same resize/re-encode the ordinary Room path already uses — so a normal multi-MB screenshot now works in a Task too. Text-like sources keep the raw 768 KB bound.
- Renders only in its own Task; Task T never shows Task U's attachment; unknown/expired Task fails closed (409 `unknown_task_request`, 403 when no participating Agent is in the Room, 403 for a non-participating Agent) with no bytes stored and **never** a silent fallback to Room scope.

## Single wake boundary for one Human Task submission (review round 2)

The round-1 fix made every Human Task attachment `addressed: true`, which split `attachment + text` into two Harness turns. The composer now owns the wake intent and the Room **persists** it:

```text
wakeAgent = (text === "")          # chosen per submission by the composer
```

- new `app/src/common/taskAttachmentWake.ts` — a strict `X-Task-Attachment-Wake: "1" | "0"` token; absent/unknown fails closed to *not addressed*;
- `RoomAttachment.taskWake?: boolean` is stored on the existing attachment record (no new schema, store, or transport) and `validAttachment` accepts only `undefined | boolean`, so it survives normalization and a reconnect/replay rebuilds the same `addressed` value;
- `toAttachmentEvent` requires `senderKind === "human" && taskWake === true` **plus** the existing canonical-Task-participation resolution. Agent-authored Task artifacts, Room-scope attachments, and any upload without a validated Task correlation stay unaddressed;
- `room/server.ts` forwards only the two recognized tokens.

Result: **attachment only** → the attachment is the single addressed wake; **attachment + text** → the attachment is persisted first as Task context (unaddressed, lower sequence) and the following Task text is the single addressed wake, so the first Harness turn already sees both.

## Tests

**89 files / 819 tests.** No existing test file was modified or deleted.

- `app/src/room/taskAttachmentWake.test.ts` (new, real Worker route → real `RoomSession`): `attachment + text` yields exactly **one** addressed event **both live and on replay** from retained Room state, with the attachment unaddressed in the same Task scope at a lower sequence and readable by the Task Agent; an idle parked long-poll is **not** resolved by the attachment half; `attachment only` wakes on the attachment (live + replay, asserting the persisted `taskWake === true`); an unresolvable Task still fails closed.
- `common/taskAttachmentWake.test.ts`, `room/server.test.ts`, `do/roomSessionHumanTaskAttachment.test.ts`, `hooks/useSfuChatRoom.taskAttachment.test.tsx`, `components/{TextChatCard,RoomContent}.composeAttachment.test.tsx`: wake-intent encode/parse and per-submission computation, only `"1"`/`"0"` forwarded, `taskRequestId` on the bounded path, derived-copy bound, readiness edge, draft/remove/error semantics, `@Agent` targeting with an attachment present.

## Validation (re-run on this head)

| Command | Result |
|---|---|
| `yarn prettier --check .` | pass |
| `yarn lint --max-warnings 0` | pass, no unintended `--fix` edits |
| `yarn type-check` | pass |
| `yarn docs:check` | pass (docs untouched) |
| `npx vitest run` | **89 files / 819 tests passed** |
| `yarn cf-build` | exit 0, `.open-next/worker.js` produced |
| `git diff --check` | clean |
| CI | App Tests / Lint & Type Check / Format & lint autofix all **pass** |

The `Failed to copy <node_modules pkg>` lines during `cf-build` are pre-existing environment noise: the base commit produces the identical set with exit 0.

## Deviations

1. **Server-side changes were unavoidable** — `RoomSession.handleAttachmentUpload` rejected any Human task-correlated upload, and the wake intent has to be persisted server-side to survive replay.
2. `onSendFile` returns `Promise<void> | void` and resolves at genuine local initiation (readiness edge).
3. An **absent** wake token means *not addressed* (fail-closed); the updated composer always sends an explicit token, so this only affects a stale pre-change bundle.
4. `wakeAgent` is a **required** parameter, so every call site must choose.
5. A >20 MB Room pick now errors in the composer chip instead of a transient timeline bubble; the limit itself is unchanged.

## Non-goals honoured

No Room App placement/transport change, no Poll→App conversion, no Whiteboard/Games migration, no new message schema, no permanent storage or public URLs, no threads/replies, no multi-file framework, no analytics expansion, no `agent/**` change, no broad `TextChatCard`/`RoomContent` refactor.

## Remaining concerns

- In a Task composer the `@`-mention picker lists all connected agents; if a Human @-mentions only a **non-participating** agent together with text, no Task-agent wake occurs for that submission. That follows `wakeAgent = text === ""` literally and matches existing Task-text addressing semantics; tightening it (e.g. forcing the canonical Task agent as target) would be a separate change.
- On a readiness-edge copy failure the draft is kept although the Human DataChannel copy may already have transferred, so a retry re-sends the Human file — inherent to the requested fail-closed UX.

Not merged — leaving the merge decision to review.
