### PR TITLE
runtime(task): make Live View authoring discoverable and recover failed turns (#364)

### DIFF
--- a/agent/internal/cli/cli.go
+++ b/agent/internal/cli/cli.go
@@ -56,6 +56,7 @@ func usageText() string {
   free4chat-agent surface publish --file <snapshot.jpeg|png|webp> [--instance <id>]
   free4chat-agent surface clear [--instance <id>]
   free4chat-agent surface read --participant <participant-id> [--instance <id>]
+  free4chat-agent live-view describe [--json]
   free4chat-agent live-view publish --task-request-id <id> --file <surface.json> [--instance <id>]
   free4chat-agent context read [--before-sequence <n>] [--after-sequence <n>] [--limit <1-50>] [--before-transcript-sequence <n>] [--after-transcript-sequence <n>] [--transcript-limit <1-50>] [--instance <id>]
   free4chat-agent version [--json]
@@ -473,31 +474,40 @@ func run(args []string) error {
 		}
 
 	case "live-view":
-		if len(rest) == 0 || rest[0] != "publish" {
+		if len(rest) == 0 {
 			return errUsage()
 		}
-		filePath := option(rest[1:], "--file")
-		taskRequestID := option(rest[1:], "--task-request-id")
-		if filePath == "" || taskRequestID == "" {
+		switch rest[0] {
+		case "describe":
+			return runLiveViewDescribe(rest[1:])
+		case "publish":
+			// Behaviour is unchanged: describe only adds a pure local,
+			// machine-readable authoring contract (issue #364 A).
+			filePath := option(rest[1:], "--file")
+			taskRequestID := option(rest[1:], "--task-request-id")
+			if filePath == "" || taskRequestID == "" {
+				return errUsage()
+			}
+			data, err := attachments.ReadBounded(filePath, maxTaskLiveViewBytes)
+			if err != nil {
+				return fmt.Errorf("Live View JSON must be a non-empty file up to %d bytes", maxTaskLiveViewBytes)
+			}
+			var surface map[string]any
+			if err := json.Unmarshal(data, &surface); err != nil || len(surface) == 0 {
+				return errors.New("Live View JSON must be an object")
+			}
+			if err := validateTaskLiveViewJSON(data); err != nil {
+				return err
+			}
+			return runViaDaemon(&daemon.IpcRequest{
+				Op:            "live-view-publish",
+				InstanceID:    option(rest[1:], "--instance"),
+				TaskRequestID: taskRequestID,
+				Surface:       surface,
+			})
+		default:
 			return errUsage()
 		}
-		data, err := attachments.ReadBounded(filePath, maxTaskLiveViewBytes)
-		if err != nil {
-			return fmt.Errorf("Live View JSON must be a non-empty file up to %d bytes", maxTaskLiveViewBytes)
-		}
-		var surface map[string]any
-		if err := json.Unmarshal(data, &surface); err != nil || len(surface) == 0 {
-			return errors.New("Live View JSON must be an object")
-		}
-		if err := validateTaskLiveViewJSON(data); err != nil {
-			return err
-		}
-		return runViaDaemon(&daemon.IpcRequest{
-			Op:            "live-view-publish",
-			InstanceID:    option(rest[1:], "--instance"),
-			TaskRequestID: taskRequestID,
-			Surface:       surface,
-		})
 
 	case "readiness":
 		return runReadiness(rest)
@@ -772,6 +782,31 @@ func runVersion(args []string) error {
 	}
 	fmt.Println(doctor.Version)
 	return nil
+}
+
+// runLiveViewDescribe prints the machine-readable Live View authoring
+// contract (#364 A). It is a pure local command: a freshly installed binary
+// answers it without a source checkout, repository docs, binary strings,
+// network access, or Room credentials. --json is the documented machine
+// shape and the default output; any other flag is a usage error.
+func runLiveViewDescribe(args []string) error {
+	for _, arg := range args {
+		if arg != "--json" {
+			return errUsage()
+		}
+	}
+	return printJSONVerbatim(describeTaskLiveView())
+}
+
+// printJSONVerbatim matches printJSON but keeps placeholder brackets and rule
+// text readable: the describe output is a contract a Harness reads as text,
+// and Go's default HTML escaping would render "<surface.json>" as
+// "\u003csurface.json\u003e".
+func printJSONVerbatim(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
 }
 
 // runViaDaemon preserves the stable low-level CLI contract: it performs the

--- a/agent/internal/cli/live_view.go
+++ b/agent/internal/cli/live_view.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -14,12 +15,78 @@ const (
 	maxLiveViewDataKeys   = 32
 	maxLiveViewText       = 400
 	maxLiveViewLabel      = 80
+	// minLiveViewRevision and liveViewIncrementBound are the canonical action
+	// and revision bounds. The validator and the machine-readable contract
+	// descriptor both read them, so they cannot drift.
+	minLiveViewRevision    = 1
+	liveViewIncrementBound = 1000
 )
 
 var (
 	liveViewIDPattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$`)
 	liveViewDataPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]{0,31}$`)
 )
+
+// liveViewComponentTypes and the field tables below are the single canonical
+// Live View vocabulary. validateTaskLiveViewJSON enforces exactly what they
+// declare, and describeTaskLiveView renders them as the machine-readable
+// authoring contract, so an allowed-field or supported-type change cannot
+// silently diverge between the local preflight and what a Harness is told.
+var (
+	liveViewComponentTypes = []string{"Text", "Value", "Button", "Input", "Row", "Column", "Card"}
+
+	liveViewComponentFields = map[string][]string{
+		"Text":   {"type", "text"},
+		"Value":  {"type", "path"},
+		"Button": {"type", "label", "action"},
+		"Input":  {"type", "path", "placeholder"},
+		"Row":    {"type", "children"},
+		"Column": {"type", "children"},
+		"Card":   {"type", "children"},
+	}
+
+	liveViewComponentRequiredFields = map[string][]string{
+		"Text":   {"type", "text"},
+		"Value":  {"type", "path"},
+		"Button": {"type", "label", "action"},
+		"Input":  {"type", "path"},
+		"Row":    {"type", "children"},
+		"Column": {"type", "children"},
+		"Card":   {"type", "children"},
+	}
+
+	liveViewActionTypes = []string{"increment", "set"}
+
+	liveViewActionFields = map[string][]string{
+		"increment": {"type", "path", "amount"},
+		"set":       {"type", "path", "value"},
+	}
+)
+
+// liveViewActionSupported reports whether the canonical action table accepts
+// this action type.
+func liveViewActionSupported(actionType string) bool {
+	_, ok := liveViewActionFields[actionType]
+	return ok
+}
+
+// liveViewOptionalFields are the allowed fields that are not required.
+func liveViewOptionalFields(required, allowed []string) []string {
+	optional := make([]string, 0, len(allowed))
+	for _, field := range allowed {
+		present := false
+		for _, requiredField := range required {
+			if field == requiredField {
+				present = true
+				break
+			}
+		}
+		if !present {
+			optional = append(optional, field)
+		}
+	}
+	return optional
+}
 
 // validateTaskLiveViewJSON is a local, deterministic preflight. The Room is
 // still authoritative; this only turns common authoring mistakes into useful
@@ -54,7 +121,7 @@ func validateTaskLiveViewJSON(data []byte) error {
 	if value, ok := object["surfaceId"].(string); !ok || !liveViewIDPattern.MatchString(value) {
 		return fmt.Errorf("Live View surfaceId must be a non-empty safe identifier")
 	}
-	if revision, ok := object["revision"].(float64); !ok || revision < 1 || revision != float64(int64(revision)) {
+	if revision, ok := object["revision"].(float64); !ok || revision < minLiveViewRevision || revision != float64(int64(revision)) {
 		return fmt.Errorf("Live View revision must be a positive integer")
 	}
 	for _, key := range []string{"taskRequestId", "authorityAgentId"} {
@@ -123,29 +190,25 @@ func validateLiveViewComponent(value any, depth int, count *int, data map[string
 	if !ok {
 		return fmt.Errorf("Live View component type is required")
 	}
-	allowed := map[string]bool{"Text": true, "Value": true, "Button": true, "Input": true, "Row": true, "Column": true, "Card": true}
-	if !allowed[typeName] {
+	// The canonical field table is both the supported-type set and the
+	// allowed-field set; the switch below only enforces per-type semantics.
+	fields, known := liveViewComponentFields[typeName]
+	if !known {
 		return fmt.Errorf("Live View contains unknown component %q", typeName)
+	}
+	if err := liveViewOnlyKeys(component, fields...); err != nil {
+		return err
 	}
 	switch typeName {
 	case "Text":
-		if err := liveViewOnlyKeys(component, "type", "text"); err != nil {
-			return err
-		}
 		if text, ok := component["text"].(string); !ok || !safeLiveViewText(text, maxLiveViewText) {
 			return fmt.Errorf("Live View Text requires bounded safe text")
 		}
 	case "Value":
-		if err := liveViewOnlyKeys(component, "type", "path"); err != nil {
-			return err
-		}
 		if _, err := liveViewPath(component, "Value"); err != nil {
 			return err
 		}
 	case "Input":
-		if err := liveViewOnlyKeys(component, "type", "path", "placeholder"); err != nil {
-			return err
-		}
 		path, err := liveViewPath(component, "Input")
 		if err != nil {
 			return err
@@ -160,9 +223,6 @@ func validateLiveViewComponent(value any, depth int, count *int, data map[string
 			}
 		}
 	case "Button":
-		if err := liveViewOnlyKeys(component, "type", "label", "action"); err != nil {
-			return err
-		}
 		label, ok := component["label"].(string)
 		if !ok || !safeLiveViewText(label, maxLiveViewLabel) {
 			return fmt.Errorf("Live View Button requires a bounded label")
@@ -172,37 +232,31 @@ func validateLiveViewComponent(value any, depth int, count *int, data map[string
 			return fmt.Errorf("Live View Button requires an action")
 		}
 		actionType, ok := action["type"].(string)
-		if !ok || (actionType != "increment" && actionType != "set") {
+		if !ok || !liveViewActionSupported(actionType) {
 			return fmt.Errorf("Live View action type %q is unsupported", actionType)
 		}
 		path, err := liveViewPath(action, "Button action")
 		if err != nil {
 			return err
 		}
+		if err := liveViewOnlyKeys(action, liveViewActionFields[actionType]...); err != nil {
+			return err
+		}
 		switch actionType {
 		case "increment":
-			if err := liveViewOnlyKeys(action, "type", "path", "amount"); err != nil {
-				return err
-			}
 			amount, ok := action["amount"].(float64)
-			if !ok || amount == 0 || amount != float64(int64(amount)) || amount < -1000 || amount > 1000 {
-				return fmt.Errorf("Live View increment amount must be a non-zero integer between -1000 and 1000")
+			if !ok || amount == 0 || amount != float64(int64(amount)) || amount < -liveViewIncrementBound || amount > liveViewIncrementBound {
+				return fmt.Errorf("Live View increment amount must be a non-zero integer between -%d and %d", liveViewIncrementBound, liveViewIncrementBound)
 			}
 			if _, ok := data[path].(float64); !ok {
 				return fmt.Errorf("Live View increment path %q must reference a number data key", path)
 			}
 		case "set":
-			if err := liveViewOnlyKeys(action, "type", "path", "value"); err != nil {
-				return err
-			}
 			if !validLiveViewScalar(action["value"]) {
 				return fmt.Errorf("Live View set value must be a string, number, or boolean")
 			}
 		}
 	case "Row", "Column", "Card":
-		if err := liveViewOnlyKeys(component, "type", "children"); err != nil {
-			return err
-		}
 		children, ok := component["children"].([]any)
 		if !ok || len(children) == 0 || len(children) > maxLiveViewComponents {
 			return fmt.Errorf("Live View %s requires bounded children", typeName)
@@ -259,4 +313,207 @@ func javascriptStringLength(value string) int {
 		}
 	}
 	return length
+}
+
+// liveViewDescriptor is the machine-readable Live View authoring contract
+// returned by `live-view describe --json`. Every value below is derived from
+// the constants and canonical tables that validateTaskLiveViewJSON enforces,
+// so the descriptor cannot describe a different contract than the local
+// preflight rejects or accepts. It is intentionally self-contained: a freshly
+// installed binary answers it without a source checkout, repository docs,
+// binary strings, network access, or Room credentials.
+type liveViewDescriptor struct {
+	Contract        string               `json:"contract"`
+	ContractVersion int                  `json:"contractVersion"`
+	PublishCommand  string               `json:"publishCommand"`
+	Snapshot        liveViewSnapshotRule `json:"snapshot"`
+	Limits          liveViewLimits       `json:"limits"`
+	Components      []liveViewTypeRule   `json:"components"`
+	Actions         []liveViewTypeRule   `json:"actions"`
+	Rules           []string             `json:"rules"`
+	Examples        []liveViewExample    `json:"examples"`
+}
+
+// liveViewExample is one minimal valid draft. The explicit field order keeps
+// the emitted example in authoring order instead of Go's sorted map order.
+type liveViewExample struct {
+	SurfaceID string         `json:"surfaceId"`
+	Revision  int            `json:"revision"`
+	Root      map[string]any `json:"root"`
+	Data      map[string]any `json:"data"`
+}
+
+type liveViewSnapshotRule struct {
+	RequiredFields   []string `json:"requiredFields"`
+	OptionalFields   []string `json:"optionalFields"`
+	OptionalFieldUse string   `json:"optionalFieldUse"`
+	SurfaceIDPattern string   `json:"surfaceIdPattern"`
+	RevisionMin      int      `json:"revisionMin"`
+	DataKeyPattern   string   `json:"dataKeyPattern"`
+	RootComponent    string   `json:"rootComponent"`
+}
+
+type liveViewLimits struct {
+	MaxJSONBytes            int `json:"maxJsonBytes"`
+	MaxComponents           int `json:"maxComponents"`
+	MaxDepth                int `json:"maxDepth"`
+	MaxDataKeys             int `json:"maxDataKeys"`
+	MaxTextLength           int `json:"maxTextLength"`
+	MaxLabelLength          int `json:"maxLabelLength"`
+	MaxChildrenPerContainer int `json:"maxChildrenPerContainer"`
+	IncrementAmountMin      int `json:"incrementAmountMin"`
+	IncrementAmountMax      int `json:"incrementAmountMax"`
+}
+
+type liveViewTypeRule struct {
+	Type           string   `json:"type"`
+	RequiredFields []string `json:"requiredFields"`
+	OptionalFields []string `json:"optionalFields"`
+	Rules          []string `json:"rules"`
+}
+
+// describeTaskLiveView renders the canonical contract.
+func describeTaskLiveView() liveViewDescriptor {
+	components := make([]liveViewTypeRule, 0, len(liveViewComponentTypes))
+	for _, typeName := range liveViewComponentTypes {
+		allowed := liveViewComponentFields[typeName]
+		components = append(components, liveViewTypeRule{
+			Type:           typeName,
+			RequiredFields: append([]string(nil), liveViewComponentRequiredFields[typeName]...),
+			OptionalFields: liveViewOptionalFields(liveViewComponentRequiredFields[typeName], allowed),
+			Rules:          liveViewComponentRules(typeName),
+		})
+	}
+	actions := make([]liveViewTypeRule, 0, len(liveViewActionTypes))
+	for _, actionType := range liveViewActionTypes {
+		actions = append(actions, liveViewTypeRule{
+			Type:           actionType,
+			RequiredFields: append([]string(nil), liveViewActionFields[actionType]...),
+			OptionalFields: []string{},
+			Rules:          liveViewActionRules(actionType),
+		})
+	}
+	return liveViewDescriptor{
+		Contract:        "free4chat.task-live-view",
+		ContractVersion: 1,
+		PublishCommand:  "live-view publish --task-request-id <request-id> --file <surface.json> [--instance <id>]",
+		Snapshot: liveViewSnapshotRule{
+			RequiredFields:   []string{"surfaceId", "revision", "root", "data"},
+			OptionalFields:   []string{"taskRequestId", "authorityAgentId"},
+			OptionalFieldUse: "optional legacy snapshot fields: the host supplies Task and Agent identity and the Room replaces these with authenticated values",
+			SurfaceIDPattern: liveViewIDPattern.String(),
+			RevisionMin:      minLiveViewRevision,
+			DataKeyPattern:   liveViewDataPattern.String(),
+			RootComponent:    "exactly one component object; counts as depth 1",
+		},
+		Limits: liveViewLimits{
+			MaxJSONBytes:            maxTaskLiveViewBytes,
+			MaxComponents:           maxLiveViewComponents,
+			MaxDepth:                maxLiveViewDepth,
+			MaxDataKeys:             maxLiveViewDataKeys,
+			MaxTextLength:           maxLiveViewText,
+			MaxLabelLength:          maxLiveViewLabel,
+			MaxChildrenPerContainer: maxLiveViewComponents,
+			IncrementAmountMin:      -liveViewIncrementBound,
+			IncrementAmountMax:      liveViewIncrementBound,
+		},
+		Components: components,
+		Actions:    actions,
+		Rules: []string{
+			"surfaceId is the stable identity of one Task surface; start a new surface with a new id",
+			"revision must be an integer >= 1; start at 1 and replace the same surfaceId only with a strictly higher revision",
+			"data is a flat object of at most " + strconv.Itoa(maxLiveViewDataKeys) + " keys; each value is a boolean, a finite number, or a safe string",
+			"binding: Value.path reads data[path]; Input.path must reference a declared string data key; an increment action path must reference a declared number data key",
+			"safe string: non-empty, no '<' or '>', no case-insensitive javascript:, http://, https://, or data:, and length counted in UTF-16 code units like JavaScript String.length (max " + strconv.Itoa(maxLiveViewText) + " for data/Text, max " + strconv.Itoa(maxLiveViewLabel) + " for labels and placeholders)",
+			"components: at most " + strconv.Itoa(maxLiveViewComponents) + " total in the whole tree; the root component is depth 1 and nesting may not exceed depth " + strconv.Itoa(maxLiveViewDepth),
+			"container children: an array of 1 to " + strconv.Itoa(maxLiveViewComponents) + " component objects",
+			"actions are browser-local updates for the viewer; they never send a Room message and never start an Agent turn",
+			"publish the draft as one JSON object of at most " + strconv.Itoa(maxTaskLiveViewBytes) + " bytes; never put credentials in the file",
+		},
+		Examples: liveViewExamples(),
+	}
+}
+
+func liveViewComponentRules(typeName string) []string {
+	switch typeName {
+	case "Text":
+		return []string{"text: safe string of at most " + strconv.Itoa(maxLiveViewText) + " characters"}
+	case "Value":
+		return []string{"path: data key pattern; renders data[path] when the key is declared"}
+	case "Button":
+		return []string{
+			"label: safe string of at most " + strconv.Itoa(maxLiveViewLabel) + " characters",
+			"action: exactly one increment or set action",
+		}
+	case "Input":
+		return []string{
+			"path: data key pattern; must reference a declared string data key",
+			"placeholder: optional safe string of at most " + strconv.Itoa(maxLiveViewLabel) + " characters",
+		}
+	case "Row", "Column", "Card":
+		return []string{"children: 1 to " + strconv.Itoa(maxLiveViewComponents) + " component objects at depth + 1"}
+	}
+	return nil
+}
+
+func liveViewActionRules(actionType string) []string {
+	switch actionType {
+	case "increment":
+		return []string{
+			"path must reference a declared number data key",
+			"amount must be a non-zero integer between " + strconv.Itoa(-liveViewIncrementBound) + " and " + strconv.Itoa(liveViewIncrementBound),
+		}
+	case "set":
+		return []string{"value must be a safe string, a number, or a boolean"}
+	}
+	return nil
+}
+
+// liveViewExamples returns one or two minimal valid drafts. They are covered
+// by a test that runs each through validateTaskLiveViewJSON, so an example can
+// never advertise a shape the local preflight rejects.
+func liveViewExamples() []liveViewExample {
+	return []liveViewExample{
+		{
+			SurfaceID: "counter",
+			Revision:  1,
+			Root: map[string]any{
+				"type": "Card",
+				"children": []any{
+					map[string]any{"type": "Value", "path": "count"},
+					map[string]any{
+						"type": "Button", "label": "+1",
+						"action": map[string]any{"type": "increment", "path": "count", "amount": 1},
+					},
+				},
+			},
+			Data: map[string]any{"count": 0},
+		},
+		{
+			SurfaceID: "task-board",
+			Revision:  1,
+			Root: map[string]any{
+				"type": "Column",
+				"children": []any{
+					map[string]any{"type": "Text", "text": "Review status"},
+					map[string]any{"type": "Input", "path": "note", "placeholder": "Short note"},
+					map[string]any{
+						"type": "Row",
+						"children": []any{
+							map[string]any{"type": "Value", "path": "votes"},
+							map[string]any{
+								"type": "Button", "label": "Approve",
+								"action": map[string]any{"type": "increment", "path": "votes", "amount": 1},
+							},
+							map[string]any{
+								"type": "Button", "label": "Reset note",
+								"action": map[string]any{"type": "set", "path": "note", "value": "todo"},
+							},
+						},
+					},
+				},
+			},
+			Data: map[string]any{"note": "todo", "votes": 0, "reviewed": false},
+		},
+	}
 }

--- a/agent/internal/cli/live_view_test.go
+++ b/agent/internal/cli/live_view_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -81,5 +83,369 @@ func TestValidateTaskLiveViewJSONUsesJavaScriptUTF16Length(t *testing.T) {
 		if err := validateTaskLiveViewJSON(data); err != nil {
 			t.Fatalf("server-compatible UTF-16 text rejected: %v", err)
 		}
+	}
+}
+
+// liveViewDraftWithRoot builds a draft around one root component and the two
+// data keys the contract tests bind to.
+func liveViewDraftWithRoot(root map[string]any) map[string]any {
+	return map[string]any{
+		"surfaceId": "contract",
+		"revision":  1,
+		"root":      root,
+		"data":      map[string]any{"count": 1, "label": "ok"},
+	}
+}
+
+// minimalLiveViewComponent returns the smallest valid component of one
+// canonical type. It is built from the descriptor's own field lists so the
+// drift tests below exercise exactly what the contract advertises.
+func minimalLiveViewComponent(t *testing.T, typeName string) map[string]any {
+	t.Helper()
+	component := map[string]any{"type": typeName}
+	for _, field := range liveViewComponentRequiredFields[typeName] {
+		switch field {
+		case "type":
+		case "text":
+			component["text"] = "ok"
+		case "path":
+			// Input binds to a declared string key; Value reads a number key.
+			component["path"] = "count"
+			if typeName == "Input" {
+				component["path"] = "label"
+			}
+		case "label":
+			component["label"] = "ok"
+		case "action":
+			component["action"] = map[string]any{"type": "increment", "path": "count", "amount": 1}
+		case "children":
+			component["children"] = []any{map[string]any{"type": "Text", "text": "ok"}}
+		default:
+			t.Fatalf("contract field %q has no test fixture", field)
+		}
+	}
+	return component
+}
+
+func TestLiveViewDescribeIsDeterministicAndSelfConsistent(t *testing.T) {
+	first, err := json.Marshal(describeTaskLiveView())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := json.Marshal(describeTaskLiveView())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatal("live-view describe output is not deterministic")
+	}
+	descriptor := describeTaskLiveView()
+	if descriptor.Contract != "free4chat.task-live-view" || descriptor.ContractVersion != 1 {
+		t.Fatalf("contract identity drifted: %+v", descriptor)
+	}
+	if len(descriptor.Examples) == 0 || len(descriptor.Examples) > 2 {
+		t.Fatalf("expected one or two minimal examples, got %d", len(descriptor.Examples))
+	}
+	for index, example := range descriptor.Examples {
+		data, err := json.Marshal(example)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTaskLiveViewJSON(data); err != nil {
+			t.Fatalf("example %d is rejected by the authoritative validator: %v", index, err)
+		}
+	}
+	if data, err := json.Marshal(descriptor.Examples[0]); err != nil {
+		t.Fatal(err)
+	} else if strings.Count(string(data), `"type"`) < 2 {
+		t.Fatal("the primary example must be a non-trivial first draft")
+	}
+}
+
+func TestLiveViewDescribeLimitsMatchTheValidator(t *testing.T) {
+	descriptor := describeTaskLiveView()
+	limits := descriptor.Limits
+	if limits.MaxJSONBytes != maxTaskLiveViewBytes ||
+		limits.MaxComponents != maxLiveViewComponents ||
+		limits.MaxDepth != maxLiveViewDepth ||
+		limits.MaxDataKeys != maxLiveViewDataKeys ||
+		limits.MaxTextLength != maxLiveViewText ||
+		limits.MaxLabelLength != maxLiveViewLabel ||
+		limits.MaxChildrenPerContainer != maxLiveViewComponents ||
+		limits.IncrementAmountMin != -liveViewIncrementBound ||
+		limits.IncrementAmountMax != liveViewIncrementBound {
+		t.Fatalf("descriptor limits drifted from the validator constants: %+v", limits)
+	}
+	if descriptor.Snapshot.RevisionMin != minLiveViewRevision ||
+		descriptor.Snapshot.SurfaceIDPattern != liveViewIDPattern.String() ||
+		descriptor.Snapshot.DataKeyPattern != liveViewDataPattern.String() {
+		t.Fatalf("descriptor identifier rules drifted: %+v", descriptor.Snapshot)
+	}
+
+	// Every advertised component type must have exactly the advertised fields,
+	// and the validator must reject anything outside that set.
+	if len(descriptor.Components) != len(liveViewComponentTypes) {
+		t.Fatalf("component vocabulary drifted: %+v", descriptor.Components)
+	}
+	advertisedTypes := make(map[string]bool, len(liveViewComponentTypes))
+	for _, typeName := range liveViewComponentTypes {
+		advertisedTypes[typeName] = true
+		if len(liveViewComponentFields[typeName]) == 0 || len(liveViewComponentRequiredFields[typeName]) == 0 {
+			t.Fatalf("%s has no canonical field table", typeName)
+		}
+		for _, required := range liveViewComponentRequiredFields[typeName] {
+			allowed := false
+			for _, field := range liveViewComponentFields[typeName] {
+				if field == required {
+					allowed = true
+				}
+			}
+			if !allowed {
+				t.Fatalf("%s requires %q but does not allow it", typeName, required)
+			}
+		}
+	}
+	for typeName := range liveViewComponentFields {
+		if !advertisedTypes[typeName] {
+			t.Fatalf("%s has a validator table but is not advertised", typeName)
+		}
+	}
+	for _, component := range descriptor.Components {
+		allowed, known := liveViewComponentFields[component.Type]
+		if !known {
+			t.Fatalf("descriptor advertises an unknown component %q", component.Type)
+		}
+		advertised := append(append([]string(nil), component.RequiredFields...), component.OptionalFields...)
+		if len(advertised) != len(allowed) {
+			t.Fatalf("%s advertises %v but the validator allows %v", component.Type, advertised, allowed)
+		}
+		valid := liveViewDraftWithRoot(minimalLiveViewComponent(t, component.Type))
+		if err := marshalAndValidate(t, valid); err != nil {
+			t.Fatalf("descriptor's %s shape is rejected by the validator: %v", component.Type, err)
+		}
+		// A required field that is missing must be rejected.
+		for _, field := range component.RequiredFields {
+			if field == "type" {
+				continue
+			}
+			broken := liveViewDraftWithRoot(minimalLiveViewComponent(t, component.Type))
+			delete(broken["root"].(map[string]any), field)
+			if err := marshalAndValidate(t, broken); err == nil {
+				t.Fatalf("%s without required field %q was accepted", component.Type, field)
+			}
+		}
+		// A field outside the advertised set must be rejected.
+		extra := liveViewDraftWithRoot(minimalLiveViewComponent(t, component.Type))
+		extra["root"].(map[string]any)["level"] = 2
+		if err := marshalAndValidate(t, extra); err == nil {
+			t.Fatalf("%s with an unadvertised field was accepted", component.Type)
+		}
+	}
+
+	// Every advertised action must be accepted and an unadvertised one must not.
+	if len(descriptor.Actions) != len(liveViewActionTypes) {
+		t.Fatalf("action vocabulary drifted: %+v", descriptor.Actions)
+	}
+	advertisedActions := make(map[string]bool, len(liveViewActionTypes))
+	for _, actionType := range liveViewActionTypes {
+		advertisedActions[actionType] = true
+		if !liveViewActionSupported(actionType) {
+			t.Fatalf("%s is advertised without a canonical field table", actionType)
+		}
+	}
+	for actionType := range liveViewActionFields {
+		if !advertisedActions[actionType] {
+			t.Fatalf("%s has a validator table but is not advertised", actionType)
+		}
+	}
+	for _, action := range descriptor.Actions {
+		if !liveViewActionSupported(action.Type) {
+			t.Fatalf("descriptor advertises an unknown action %q", action.Type)
+		}
+	}
+	unsupported := liveViewDraftWithRoot(map[string]any{
+		"type": "Button", "label": "ok",
+		"action": map[string]any{"type": "decrement", "path": "count", "amount": 1},
+	})
+	if err := marshalAndValidate(t, unsupported); err == nil {
+		t.Fatal("an unadvertised action type was accepted")
+	}
+	if err := marshalAndValidate(t, liveViewDraftWithRoot(map[string]any{"type": "Table"})); err == nil {
+		t.Fatal("an unadvertised component type was accepted")
+	}
+}
+
+func TestLiveViewDescribeBoundsAreEnforced(t *testing.T) {
+	// Depth: a chain at the advertised depth is accepted; one deeper is not.
+	chain := func(depth int) map[string]any {
+		component := map[string]any{"type": "Text", "text": "ok"}
+		for level := 1; level < depth; level++ {
+			component = map[string]any{"type": "Column", "children": []any{component}}
+		}
+		return component
+	}
+	if err := marshalAndValidate(t, liveViewDraftWithRoot(chain(maxLiveViewDepth))); err != nil {
+		t.Fatalf("component tree at the advertised depth was rejected: %v", err)
+	}
+	if err := marshalAndValidate(t, liveViewDraftWithRoot(chain(maxLiveViewDepth+1))); err == nil {
+		t.Fatal("component tree deeper than the advertised depth was accepted")
+	}
+
+	// Components: root + N children must stay within the advertised total.
+	children := func(count int) map[string]any {
+		list := make([]any, 0, count)
+		for index := 0; index < count; index++ {
+			list = append(list, map[string]any{"type": "Text", "text": "ok"})
+		}
+		return map[string]any{"type": "Row", "children": list}
+	}
+	if err := marshalAndValidate(t, liveViewDraftWithRoot(children(maxLiveViewComponents-1))); err != nil {
+		t.Fatalf("component tree at the advertised total was rejected: %v", err)
+	}
+	if err := marshalAndValidate(t, liveViewDraftWithRoot(children(maxLiveViewComponents))); err == nil {
+		t.Fatal("component tree above the advertised total was accepted")
+	}
+
+	// Data keys, text, label, revision, and increment bounds.
+	fullData := func(keys int) map[string]any {
+		data := map[string]any{"count": 0}
+		for index := 1; index < keys; index++ {
+			data["k"+string(rune('a'+index%26))+strings.Repeat("x", index/26)] = 1
+		}
+		return data
+	}
+	atKeys := liveViewDraftWithRoot(minimalLiveViewComponent(t, "Value"))
+	atKeys["data"] = fullData(maxLiveViewDataKeys)
+	if len(atKeys["data"].(map[string]any)) != maxLiveViewDataKeys {
+		t.Fatal("test fixture did not reach the advertised data-key bound")
+	}
+	if err := marshalAndValidate(t, atKeys); err != nil {
+		t.Fatalf("data at the advertised key bound was rejected: %v", err)
+	}
+	overKeys := liveViewDraftWithRoot(minimalLiveViewComponent(t, "Value"))
+	overKeys["data"] = fullData(maxLiveViewDataKeys + 2)
+	if err := marshalAndValidate(t, overKeys); err == nil {
+		t.Fatal("data above the advertised key bound was accepted")
+	}
+
+	textAtBound := liveViewDraftWithRoot(map[string]any{"type": "Text", "text": strings.Repeat("a", maxLiveViewText)})
+	if err := marshalAndValidate(t, textAtBound); err != nil {
+		t.Fatalf("text at the advertised bound was rejected: %v", err)
+	}
+	textOverBound := liveViewDraftWithRoot(map[string]any{"type": "Text", "text": strings.Repeat("a", maxLiveViewText+1)})
+	if err := marshalAndValidate(t, textOverBound); err == nil {
+		t.Fatal("text above the advertised bound was accepted")
+	}
+	labelOverBound := liveViewDraftWithRoot(map[string]any{
+		"type": "Button", "label": strings.Repeat("a", maxLiveViewLabel+1),
+		"action": map[string]any{"type": "increment", "path": "count", "amount": 1},
+	})
+	if err := marshalAndValidate(t, labelOverBound); err == nil {
+		t.Fatal("label above the advertised bound was accepted")
+	}
+
+	zeroRevision := liveViewDraftWithRoot(minimalLiveViewComponent(t, "Value"))
+	zeroRevision["revision"] = 0
+	if err := marshalAndValidate(t, zeroRevision); err == nil {
+		t.Fatal("revision below the advertised minimum was accepted")
+	}
+
+	for _, amount := range []float64{-liveViewIncrementBound, liveViewIncrementBound} {
+		surface := liveViewDraftWithRoot(map[string]any{
+			"type": "Button", "label": "ok",
+			"action": map[string]any{"type": "increment", "path": "count", "amount": amount},
+		})
+		if err := marshalAndValidate(t, surface); err != nil {
+			t.Fatalf("increment amount %v at the advertised bound was rejected: %v", amount, err)
+		}
+	}
+	for _, amount := range []float64{0, liveViewIncrementBound + 1, -liveViewIncrementBound - 1} {
+		surface := liveViewDraftWithRoot(map[string]any{
+			"type": "Button", "label": "ok",
+			"action": map[string]any{"type": "increment", "path": "count", "amount": amount},
+		})
+		if err := marshalAndValidate(t, surface); err == nil {
+			t.Fatalf("increment amount %v outside the advertised bounds was accepted", amount)
+		}
+	}
+}
+
+func marshalAndValidate(t *testing.T, surface map[string]any) error {
+	t.Helper()
+	data, err := json.Marshal(surface)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return validateTaskLiveViewJSON(data)
+}
+
+func TestLiveViewDescribeCommandRoutesAndEmitsJSON(t *testing.T) {
+	output, code := runCli(t, "live-view", "describe", "--json")
+	if code != 0 {
+		t.Fatalf("live-view describe --json exited %d: %s", code, output)
+	}
+	var descriptor struct {
+		Contract   string           `json:"contract"`
+		Snapshot   map[string]any   `json:"snapshot"`
+		Limits     map[string]any   `json:"limits"`
+		Components []map[string]any `json:"components"`
+		Actions    []map[string]any `json:"actions"`
+		Rules      []string         `json:"rules"`
+		Examples   []map[string]any `json:"examples"`
+	}
+	if err := json.Unmarshal([]byte(output), &descriptor); err != nil {
+		t.Fatalf("describe output is not valid JSON: %v\n%s", err, output)
+	}
+	if descriptor.Contract != "free4chat.task-live-view" ||
+		len(descriptor.Snapshot) == 0 || len(descriptor.Limits) == 0 ||
+		len(descriptor.Components) != len(liveViewComponentTypes) ||
+		len(descriptor.Actions) != len(liveViewActionTypes) ||
+		len(descriptor.Rules) == 0 || len(descriptor.Examples) == 0 {
+		t.Fatalf("describe output is incomplete: %s", output)
+	}
+	// A freshly installed binary answers without a daemon or Room credentials:
+	// the same invocation without --json must produce the same machine shape.
+	plain, plainCode := runCli(t, "live-view", "describe")
+	if plainCode != 0 || plain != output {
+		t.Fatalf("describe output must not depend on a daemon: code=%d", plainCode)
+	}
+	if _, code := runCli(t, "live-view", "describe", "--yaml"); code != 2 {
+		t.Fatalf("unknown describe flag should exit 2, got %d", code)
+	}
+	if _, code := runCli(t, "live-view"); code != 2 {
+		t.Fatalf("bare live-view should exit 2, got %d", code)
+	}
+}
+
+func TestLiveViewPublishPreflightIsUnchanged(t *testing.T) {
+	if _, code := runCli(t, "live-view", "publish", "--task-request-id", "req-1"); code != 2 {
+		t.Fatal("publish without --file should exit 2")
+	}
+	if _, code := runCli(t, "live-view", "publish", "--file", "surface.json"); code != 2 {
+		t.Fatal("publish without --task-request-id should exit 2")
+	}
+
+	// Local preflight still rejects an invalid draft before any daemon round
+	// trip, exactly as before the describe command existed.
+	dir := t.TempDir()
+	invalid := filepath.Join(dir, "invalid.json")
+	if err := os.WriteFile(invalid, []byte(`{"surfaceId":"counter"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, code := runCli(t, "live-view", "publish", "--task-request-id", "req-1", "--file", invalid)
+	if code != 1 || !strings.Contains(output, "revision") {
+		t.Fatalf("invalid draft must fail local preflight: code=%d output=%q", code, output)
+	}
+
+	valid := filepath.Join(dir, "valid.json")
+	data, err := json.Marshal(validLiveViewDraft())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(valid, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateTaskLiveViewJSON(data); err != nil {
+		t.Fatalf("the publish fixture must stay valid: %v", err)
 	}
 }

--- a/agent/internal/harness/acp.go
+++ b/agent/internal/harness/acp.go
@@ -43,6 +43,16 @@ func (e *TurnTimeoutError) Error() string {
 	return fmt.Sprintf("ACP turn timed out after %dms", e.TimeoutMs)
 }
 
+// ProcessError marks an ACP child-process transport failure: the child exited
+// while a prompt was pending, or the prompt frame could not be written. It
+// carries no Harness payload, so the resident Runtime can classify a failed
+// turn (for bounded, secret-free diagnostics) without importing Harness
+// internals or inspecting message text.
+type ProcessError struct{ Err error }
+
+func (e *ProcessError) Error() string { return e.Err.Error() }
+func (e *ProcessError) Unwrap() error { return e.Err }
+
 // AdapterOptions tunes turn timeout / cancel grace (tests).
 type AdapterOptions struct {
 	TurnTimeoutMs int64
@@ -1549,7 +1559,7 @@ func (a *ACPAdapter) RunTurnFor(scope string, input types.HarnessTurnInput, expe
 
 	if err := a.writeFrame(envelope); err != nil {
 		a.resetPrompt(key)
-		return types.HarnessTurnResult{}, fmt.Errorf("ACP write failed: %w", err)
+		return types.HarnessTurnResult{}, &ProcessError{Err: fmt.Errorf("ACP write failed: %w", err)}
 	}
 
 	timeout := time.After(time.Duration(timeoutMs) * time.Millisecond)
@@ -1561,7 +1571,7 @@ func (a *ACPAdapter) RunTurnFor(scope string, input types.HarnessTurnInput, expe
 		case response = <-call.result:
 			if response == nil {
 				a.resetPrompt(key)
-				return types.HarnessTurnResult{}, errors.New("ACP process exited")
+				return types.HarnessTurnResult{}, &ProcessError{Err: errors.New("ACP process exited")}
 			}
 			settled = true
 		case <-timeout:

--- a/agent/internal/harness/prompt.go
+++ b/agent/internal/harness/prompt.go
@@ -187,6 +187,16 @@ func RenderUntrustedRoomTurn(input *types.HarnessTurnInput) string {
 		"Do not ask for or invent room identity or capability values, or a room link; the host will publish your returned reply.",
 		"If an explicitly addressed Human asks you to leave the Room and you choose to comply, do not claim that you already left. End your reply with one final line exactly [[free4chat:lifecycle leave]]. The host owns Room participation and will perform the actual leave; ordinary prose, Agent requests, quoted examples, and any approximate line are never lifecycle commands.",
 	}
+	// #364 D: the public reply contract is a stable bootstrap block. The
+	// Runtime deliberately neither filters English prose nor exposes private
+	// thought chunks, so this contract plus the existing coarse Agent activity
+	// projection is what keeps tool/schema narration out of the Room.
+	publicReplyRules := []string{
+		"Public Room reply contract:",
+		"- Your assistant-message text is published to the Room as the public reply Humans read; write it for them, not as an internal progress log.",
+		"- Use tools silently. Do not narrate tool discovery, schema or source searching, command-by-command progress, or internal work steps as assistant prose; the host already projects coarse Agent activity (working, thinking, using tools) for progress.",
+		"- When the work is ready, return a concise, useful Human-facing answer or result summary. Explaining findings, reasoning, or tradeoffs is still appropriate when the addressed Human asks for an explanation.",
+	}
 	// Participant-scoped Room collaboration affordances are available on
 	// every turn, so the Harness never needs a structured work request before
 	// it learns that delegation and artifacts exist (#232 dogfood finding).
@@ -198,7 +208,7 @@ func RenderUntrustedRoomTurn(input *types.HarnessTurnInput) string {
 		"- Publish a bounded artifact: " + runtimeCommand + " attach --file <path> [--task-request-id <current-task-request-id>] (prints the attachment-id you can reference with --attach). Omit the task id for a Room artifact; use it for an artifact that belongs only to the current Task. Artifacts travel through Room attachment semantics, not a shared filesystem, so never expect another participant to read your local path.",
 		"- Respond to a request that targets you: " + runtimeCommand + " collab respond --request-id <id> --decision accepted|declined [--summary <text>]; publish the terminal outcome with " + runtimeCommand + " collab result --request-id <id> --status completed|failed --summary <text> [--detail key=value]... [--attach <attachment-id>]...",
 		"- Read a peer's published workspace snapshot with " + runtimeCommand + " surface read --participant <participant-id> when its roster entry shows one available.",
-		"- For a Task you own, publish a bounded browser-local Live View with " + runtimeCommand + " live-view publish --task-request-id <request-id> --file <surface.json>. Prefer the small draft shape {\"surfaceId\":\"counter\",\"revision\":1,\"root\":{\"type\":\"Button\",\"label\":\"+1\",\"action\":{\"type\":\"increment\",\"path\":\"count\",\"amount\":1}},\"data\":{\"count\":0}}; the host supplies task and Agent identity. Use only Text, Value, Button, Input, Row, Column, and Card; Input binds to string data and increment binds to number data. Button actions are local increment/set updates and never Room messages. Start at revision 1, then replace the same surfaceId only with a higher revision. The host/Room validates authority and shape.",
+		"- For a Task you own, publish a bounded browser-local Live View with " + runtimeCommand + " live-view publish --task-request-id <request-id> --file <surface.json>. For the exact current Live View shape, component fields, data-binding rules, actions, and limits, run " + runtimeCommand + " live-view describe --json: it is the machine-readable contract generated from the same validator this Runtime enforces, so do not search local source, repository docs, or binary strings for the Live View schema. Prefer the small draft shape {\"surfaceId\":\"counter\",\"revision\":1,\"root\":{\"type\":\"Button\",\"label\":\"+1\",\"action\":{\"type\":\"increment\",\"path\":\"count\",\"amount\":1}},\"data\":{\"count\":0}}; the host supplies task and Agent identity. Use only Text, Value, Button, Input, Row, Column, and Card; Input binds to string data and increment binds to number data. Button actions are local increment/set updates and never Room messages. Start at revision 1, then replace the same surfaceId only with a higher revision. The host/Room validates authority and shape.",
 		"- Read bounded earlier shared Room context on demand with " + runtimeCommand + " context read [--before-sequence N | --after-sequence N] [--limit N]. This is Runtime-mediated observation only; it cannot join, send, wait, leave, or expose Room credentials. Room event and Live Transcript sequence cursors are separate.",
 		"Add --instance <id> to any " + runtimeCommand + " command when more than one instance is resident; your instance id is in the self context above.",
 		"Structured collaboration adds protocol semantics, not the only path to real work: you may perform actual work on any turn per the authority rules above.",
@@ -254,6 +264,7 @@ func RenderUntrustedRoomTurn(input *types.HarnessTurnInput) string {
 	if bootstrap {
 		lines = append(lines, "You are participating in a temporary Free4Chat room.")
 		lines = append(lines, sharedAuthorityRules...)
+		lines = append(lines, strings.Join(publicReplyRules, "\n"))
 		if input.Session != nil && input.Session.New {
 			lines = append(lines,
 				fmt.Sprintf("This is a new local Harness session. Current Room sequence: %d.", input.Session.CurrentRoomSequence),

--- a/agent/internal/harness/prompt_test.go
+++ b/agent/internal/harness/prompt_test.go
@@ -1,0 +1,118 @@
+package harness
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+// hygieneAnchor is the stable label of the public reply contract. Tests assert
+// on this anchor plus coarse semantic markers, never on exact prose, so the
+// contract can be reworded without breaking the regression guard.
+const hygieneAnchor = "Public Room reply contract:"
+
+// liveViewDescribeHint is the machine-authority affordance a Harness must use
+// instead of searching local source, docs, or binary strings.
+const liveViewDescribeHint = runtimeCommand + " live-view describe --json"
+
+func bootstrapPromptInput() *types.HarnessTurnInput {
+	return &types.HarnessTurnInput{
+		Room: types.RoomTurnContext{
+			Ephemeral: true,
+			Self:      &types.RoomSelfContext{Name: "Agent", InstanceID: "inst-prompt"},
+			Participants: []types.ParticipantRosterEntry{{
+				ID: "human-1", Name: "Ada", Kind: types.KindHuman,
+			}},
+		},
+		Events: []types.HarnessEvent{{
+			Sender: "Ada", Kind: types.KindHuman, Text: "Please build the Live View.",
+			Addressed: true, Sequence: 1,
+		}},
+		Session: &types.HarnessSessionContext{New: true, CurrentRoomSequence: 1},
+	}
+}
+
+func TestBootstrapPromptCarriesPublicReplyHygieneContract(t *testing.T) {
+	bootstrap := RenderUntrustedRoomTurn(bootstrapPromptInput())
+	index := strings.Index(bootstrap, hygieneAnchor)
+	if index < 0 {
+		t.Fatalf("bootstrap prompt is missing the public reply contract anchor:\n%s", bootstrap)
+	}
+	block := bootstrap[index:]
+	for _, marker := range []string{"public reply", "tools", "activity", "concise"} {
+		if !strings.Contains(block, marker) {
+			t.Fatalf("public reply contract lost the %q guarantee:\n%s", marker, block)
+		}
+	}
+
+	// The contract is a stable bootstrap instruction, not a per-turn repeat:
+	// a retained-session delta must stay bounded and must not re-teach it.
+	deltaInput := bootstrapPromptInput()
+	deltaInput.Session = &types.HarnessSessionContext{New: false, CurrentRoomSequence: 4}
+	delta := RenderUntrustedRoomTurn(deltaInput)
+	if strings.Contains(delta, hygieneAnchor) {
+		t.Fatalf("the stable reply contract must not repeat on every delta turn:\n%s", delta)
+	}
+	if len(delta) >= len(bootstrap) {
+		t.Fatalf("delta prompt (%d bytes) must stay smaller than bootstrap (%d bytes)", len(delta), len(bootstrap))
+	}
+}
+
+func TestLiveViewAffordancePointsAtRuntimeDescribeCommand(t *testing.T) {
+	bootstrap := RenderUntrustedRoomTurn(bootstrapPromptInput())
+	if !strings.Contains(bootstrap, liveViewDescribeHint) {
+		t.Fatalf("bootstrap prompt must point the Harness at %s", liveViewDescribeHint)
+	}
+	describe := bootstrap[strings.Index(bootstrap, liveViewDescribeHint):]
+	if !strings.Contains(describe, "do not search") {
+		t.Fatalf("the Live View affordance must forbid local schema searching:\n%s", describe)
+	}
+	// The existing small starter example remains available.
+	if !strings.Contains(bootstrap, `"surfaceId":"counter"`) {
+		t.Fatal("the starter Live View example was dropped from the affordance")
+	}
+}
+
+// TestThoughtFilteringAndCoarseActivityProjectionUnchanged pins the two
+// existing behaviors the #364 D contract deliberately relies on instead of
+// adding a heuristic text filter: private thought chunks never accumulate into
+// the public reply, and progress stays the coarse activity projection.
+func TestThoughtFilteringAndCoarseActivityProjectionUnchanged(t *testing.T) {
+	thought := json.RawMessage(`{
+	  "sessionId": "s",
+	  "update": {"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "SECRET-THINKING"}}
+	}`)
+	if text, ok := extractTextChunk(thought); ok || text != "" {
+		t.Fatalf("thought chunk must stay out of the public reply: ok=%v text=%q", ok, text)
+	}
+	if state, ok := mapACPActivity(thought); !ok || state != types.AgentActivityThinking {
+		t.Fatalf("thought progress must stay a coarse activity state: %q %v", state, ok)
+	}
+	tool := json.RawMessage(`{"update":{"sessionUpdate":"tool_call","toolCall":{"rawInput":{"command":"secret"}}}}`)
+	if state, ok := mapACPActivity(tool); !ok || state != types.AgentActivityUsingTools {
+		t.Fatalf("tool progress must stay a coarse activity state: %q %v", state, ok)
+	}
+}
+
+// TestAssistantMessageNarrationIsNotFilteredFromThePublicReply proves the
+// Runtime still applies no English/regex filtering to assistant-message text:
+// the reply hygiene contract is a prompt contract, not a text filter.
+func TestAssistantMessageNarrationIsNotFilteredFromThePublicReply(t *testing.T) {
+	const narration = "Let me search the local config and binary strings for the Live View schema. Step 1: grep the source tree."
+	adapter, _ := newTestAdapter(t, scriptLauncher("envelope", map[string]string{
+		"FAKE_REPLY_TEXT": narration,
+	}), AdapterOptions{})
+	defer adapter.Close()
+	if err := adapter.EnsureSession(); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	result, err := adapter.RunTurn(turnInput("build the Live View"), adapter.SessionGeneration())
+	if err != nil {
+		t.Fatalf("turn failed: %v", err)
+	}
+	if result.Text != narration {
+		t.Fatalf("assistant-message text must pass through verbatim, got %q", result.Text)
+	}
+}

--- a/agent/internal/runtime/helpers.go
+++ b/agent/internal/runtime/helpers.go
@@ -290,6 +290,13 @@ func (r *ResidentRuntime) pendingAddressedSnapshotFor(scope string) []int64 {
 func (r *ResidentRuntime) pendingScopes() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.pendingScopesLocked()
+}
+
+// pendingScopesLocked lists the logical scopes holding unacknowledged
+// addressed work: the default Room scope first, then scope admission order.
+// Callers must hold r.mu.
+func (r *ResidentRuntime) pendingScopesLocked() []string {
 	if len(r.pendingAddressed) > 0 {
 		out := []string{roomScope}
 		for _, scope := range r.scopeOrder {
@@ -306,6 +313,35 @@ func (r *ResidentRuntime) pendingScopes() []string {
 		}
 	}
 	return out
+}
+
+// nextRunnableTurn returns the canonical turn the serial drain may execute
+// next: the head of the oldest scope holding unacknowledged work whose
+// autonomous recovery is still open. A canonical turn whose recovery is
+// closed stays pending and unacknowledged, so it is skipped rather than
+// re-executed or acknowledged; skipping also keeps it from blocking another
+// scope's fresh work. Only an explicit recovery boundary — a new addressed
+// trigger for that same scope — reopens it (see reopenTurnRecoveryLocked).
+func (r *ResidentRuntime) nextRunnableTurn() (string, int64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.nextRunnableTurnLocked()
+}
+
+// nextRunnableTurnLocked is nextRunnableTurn for callers already holding r.mu.
+func (r *ResidentRuntime) nextRunnableTurnLocked() (string, int64, bool) {
+	for _, scope := range r.pendingScopesLocked() {
+		ref := r.sessionRefLocked(scope)
+		if ref == nil || len(*ref.pendingAddressed) == 0 {
+			continue
+		}
+		target := (*ref.pendingAddressed)[0]
+		if r.turnRecoveryClosedLocked(scope, target) {
+			continue
+		}
+		return scope, target, true
+	}
+	return "", 0, false
 }
 
 // peekPending returns the next addressed target without acknowledging it.
@@ -348,6 +384,7 @@ func (r *ResidentRuntime) ackPendingFor(scope string, sequence int64) {
 		}
 		*ref.pendingAddressed = append((*ref.pendingAddressed)[:index], (*ref.pendingAddressed)[index+1:]...)
 		delete(*ref.pendingContexts, sequence)
+		r.forgetTurnRecoveryLocked(scope, sequence)
 		return
 	}
 }
@@ -409,6 +446,7 @@ func (r *ResidentRuntime) acknowledgeHarnessDeliveryFor(scope string, target, th
 		}
 		*ref.pendingAddressed = append((*ref.pendingAddressed)[:index], (*ref.pendingAddressed)[index+1:]...)
 		delete(*ref.pendingContexts, target)
+		r.forgetTurnRecoveryLocked(scope, target)
 		break
 	}
 	r.mu.Unlock()

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -328,12 +328,18 @@ func (r *ResidentRuntime) logVoiceBridgeStats(event string) {
 }
 
 // voiceOutput returns the current speakable output (nil when no live
-// Agent Voice grant); callers stay text-only on nil.
+// Agent Voice grant); callers stay text-only on nil. The reference is read
+// under mediaMu because a media rebuild or teardown replaces/clears it on
+// another goroutine while a turn is finishing (a pre-existing race found
+// while validating #364; the turn path calls this with no lock held).
 func (r *ResidentRuntime) voiceOutput() *voice.Speaker {
-	if r.voiceSrc == nil {
+	r.mediaMu.Lock()
+	output := r.voiceSrc
+	r.mediaMu.Unlock()
+	if output == nil {
 		return nil
 	}
-	return r.voiceSrc.CurrentVoiceOutput()
+	return output.CurrentVoiceOutput()
 }
 
 // attachTranscript adds only newly committed runtime-local Meeting Notes

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -161,6 +161,19 @@ type ResidentRuntime struct {
 	// turn; observing a session is never an acknowledgement.
 	observedHarnessGeneration     int64
 	bootstrappedHarnessGeneration int64
+	// turnRetry is the bounded autonomous retry clock for the canonical
+	// pending turn whose Harness turn failed (#364 B). It is keyed by
+	// (scope, target) so a later Room event can never reset the retry budget
+	// of the same still-pending turn; only a different canonical turn or a
+	// successful delivery starts a new budget.
+	turnRetryScope   string
+	turnRetryTarget  int64
+	turnRetryAttempt int
+	turnRetryPlan    *turnRetryPlan
+	// turnRetryDelay overrides the delay before retry attempt N (0-based).
+	// Nil uses the shared reconnect back-off; tests override it to drive the
+	// policy deterministically without wall-clock waits.
+	turnRetryDelay func(attempt int) time.Duration
 	// Transcript delivery keeps a per-ACP-session success marker plus a
 	// baseline captured at session/new. The baseline deliberately leaves old
 	// shared context pullable instead of dumping it into a new conversation.
@@ -715,8 +728,12 @@ func (r *ResidentRuntime) waitLoop() {
 
 		retryAttempt = 0
 		r.advanceFromWait(result)
-		if len(r.pendingScopes()) > 0 && !r.isStopped() {
-			r.drainTurns()
+		// A wait that returned no Room event is observation, not an activation
+		// boundary: like the resident event stream, it must not re-run
+		// pre-existing work. A failed Harness turn is retried by the bounded
+		// autonomous clock instead of by every poll.
+		if len(result.Events) > 0 && len(r.pendingScopes()) > 0 && !r.isStopped() {
+			r.drainTurnsWithRetryClock()
 		}
 	}
 }
@@ -878,7 +895,7 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 			return heartbeatErr
 		case <-retrySignals:
 			if r.shouldRetryHumanTaskAcceptance() && !r.isStopped() {
-				r.drainTurns()
+				r.drainTurnsWithRetryClock()
 			}
 		case received := <-receiveResults:
 			if received.err != nil {
@@ -902,7 +919,7 @@ func (r *ResidentRuntime) consumeResidentEventStream(
 			// A media-only envelope is observation, not an activation event. Do
 			// not use it as a Harness wakeup/retry boundary for pre-existing work.
 			if len(received.result.Events) > 0 && len(r.pendingScopes()) > 0 && !r.isStopped() {
-				r.drainTurns()
+				r.drainTurnsWithRetryClock()
 			}
 			receiveNext()
 		}
@@ -1116,7 +1133,11 @@ func (r *ResidentRuntime) drainTurns() {
 		r.mu.Lock()
 		r.turnRunning = false
 		if !r.stopped {
-			if r.harnessFailed || r.lastErrorSource == "send" {
+			// A pending bounded retry and an exhausted retry budget are both
+			// truthful reconnect states: the resident still holds
+			// unacknowledged work it could not hand to the Harness.
+			if r.harnessFailed || r.lastErrorSource == "send" ||
+				r.turnRetryPlan != nil || r.turnRetryAttempt > maxTurnRetryAttempts {
 				r.state = StateReconnecting
 			} else {
 				r.state = StateWaiting
@@ -1135,25 +1156,20 @@ func (r *ResidentRuntime) drainTurns() {
 		if !ok {
 			continue
 		}
+		started := time.Now()
+		r.log("turn_started", map[string]string{
+			"scopeKind":    scopeKindOf(scope),
+			"retryAttempt": strconv.Itoa(r.turnRetryIndexFor(scope, target)),
+		})
 		// Ensure before rendering so the prompt accurately knows whether this
 		// is the same retained ACP conversation or a real session/new.
 		if err := r.ensureHarnessSession(scope); err != nil {
-			r.mu.Lock()
-			r.lastError = err.Error()
-			r.lastErrorSource = "harness"
-			r.state = StateReconnecting
-			r.mu.Unlock()
-			r.log("turn_failed", nil)
+			r.failTurn(scope, target, "harness", turnFailureClassOf(err), started, err, !permanentTurnFailure(err))
 			return
 		}
 		generation, err := r.harnessSessionGeneration(scope)
 		if err != nil {
-			r.mu.Lock()
-			r.lastError = err.Error()
-			r.lastErrorSource = "harness"
-			r.state = StateReconnecting
-			r.mu.Unlock()
-			r.log("turn_failed", nil)
+			r.failTurn(scope, target, "harness", turnFailureClassOf(err), started, err, !permanentTurnFailure(err))
 			return
 		}
 		newSession := r.observeHarnessSessionFor(scope, generation, target)
@@ -1164,7 +1180,14 @@ func (r *ResidentRuntime) drainTurns() {
 			r.lastErrorSource = "harness"
 			r.state = StateReconnecting
 			r.mu.Unlock()
-			r.log("turn_context_unavailable", nil)
+			r.log("turn_context_unavailable", map[string]string{
+				"scopeKind":    scopeKindOf(scope),
+				"failureClass": turnFailureOther,
+				"elapsedMs":    strconv.FormatInt(time.Since(started).Milliseconds(), 10),
+			})
+			// The frozen delta may have failed on a transient Room read, so
+			// the bounded retry clock still applies to this canonical turn.
+			r.scheduleTurnRetry(scope, target, turnFailureOther, time.Since(started).Milliseconds())
 			return
 		}
 		if len(events) == 0 {
@@ -1176,7 +1199,11 @@ func (r *ResidentRuntime) drainTurns() {
 				r.ackPendingFor(scope, target)
 				continue
 			}
-			r.log("turn_context_unavailable", nil)
+			r.log("turn_context_unavailable", map[string]string{
+				"scopeKind":    scopeKindOf(scope),
+				"failureClass": turnFailureOther,
+				"elapsedMs":    strconv.FormatInt(time.Since(started).Milliseconds(), 10),
+			})
 			return
 		}
 		maxSeq := events[0].Sequence
@@ -1215,7 +1242,10 @@ func (r *ResidentRuntime) drainTurns() {
 				r.lastErrorSource = "send"
 				r.state = StateReconnecting
 				r.mu.Unlock()
-				r.log("collab_accept_failed", nil)
+				r.log("collab_accept_failed", map[string]string{
+					"scopeKind":    scopeKindOf(scope),
+					"failureClass": turnFailureSend,
+				})
 				return
 			}
 			r.mu.Lock()
@@ -1239,14 +1269,13 @@ func (r *ResidentRuntime) drainTurns() {
 		result, err := r.runHarnessTurn(scope, *input, generation)
 		r.finishActivity(scope)
 		if err != nil {
-			r.mu.Lock()
-			r.lastError = err.Error()
-			r.lastErrorSource = "harness"
-			r.state = StateReconnecting
-			r.mu.Unlock()
-			r.log("turn_failed", nil)
+			r.failTurn(scope, target, "harness", turnFailureClassOf(err), started, err, !permanentTurnFailure(err))
 			return
 		}
+		r.log("turn_succeeded", map[string]string{
+			"scopeKind": scopeKindOf(scope),
+			"elapsedMs": strconv.FormatInt(time.Since(started).Milliseconds(), 10),
+		})
 		if r.isStopped() {
 			return
 		}
@@ -1256,6 +1285,9 @@ func (r *ResidentRuntime) drainTurns() {
 		// fails, replaying this already-consumed Harness prompt would be wrong.
 		r.acknowledgeHarnessDeliveryFor(scope, target, maxSeq, generation)
 		r.acknowledgeTranscriptDeliveryFor(scope, meetingThrough, liveThrough)
+		// The canonical turn is delivered: its bounded autonomous retry budget
+		// is spent and a later send failure must never replay cognition.
+		r.clearTurnRetry(scope, target)
 		r.mu.Lock()
 		r.harnessFailed = false
 		// #228: a successful turn proves the Harness recovered — clear ONLY
@@ -1279,22 +1311,12 @@ func (r *ResidentRuntime) drainTurns() {
 		}
 		handle, err := r.requireHandle()
 		if err != nil {
-			r.mu.Lock()
-			r.lastError = err.Error()
-			r.lastErrorSource = "harness"
-			r.state = StateReconnecting
-			r.mu.Unlock()
-			r.log("turn_failed", nil)
+			r.failTurn(scope, target, "harness", turnFailureSend, started, err, false)
 			return
 		}
 		sent, err := r.sendHarnessText(scope, handle, text, result.TargetParticipantIDs)
 		if err != nil {
-			r.mu.Lock()
-			r.lastError = err.Error()
-			r.lastErrorSource = "send"
-			r.state = StateReconnecting
-			r.mu.Unlock()
-			r.log("turn_failed", nil)
+			r.failTurn(scope, target, "send", turnFailureSend, started, err, false)
 			return
 		}
 		r.mu.Lock()

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -176,6 +176,10 @@ type ResidentRuntime struct {
 	// pending and unacknowledged, but the serial drain never re-executes it
 	// for unrelated later Room traffic. Only an explicit recovery boundary —
 	// a new addressed trigger for the same scope — reopens it.
+	//
+	// Markers are deleted without resetting the map to nil, so an empty map
+	// may still be non-nil. Non-nilness is therefore NEVER a truthful-state
+	// condition: use len(...) or unresolvedTurnFailureLocked() instead.
 	closedTurnRecovery map[canonicalTurnKey]struct{}
 	// turnRetryDelay overrides the delay before retry attempt N (0-based).
 	// Nil uses the shared reconnect back-off; tests override it to drive the
@@ -658,11 +662,15 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 		r.scopedSessions = nil
 		r.scopeOrder = nil
 	}
-	if r.closedTurnRecovery != nil {
+	if r.unresolvedTurnFailureLocked() {
 		// A transport join/rejoin is not an explicit recovery boundary: a
 		// canonical turn whose autonomous recovery is closed stays pinned and
 		// keeps reporting the truthful reconnect state until a new addressed
-		// trigger re-arms it.
+		// trigger re-arms it. The shared unresolved-work predicate is used
+		// instead of testing closedTurnRecovery for non-nilness: drained
+		// markers are deleted without resetting the map, so an empty-but-non-nil
+		// map would otherwise look like a parked turn (and an armed retry or an
+		// unresolved Harness/send failure must keep the state truthful too).
 		r.state = StateReconnecting
 	} else {
 		r.state = StateWaiting

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -170,6 +170,13 @@ type ResidentRuntime struct {
 	turnRetryTarget  int64
 	turnRetryAttempt int
 	turnRetryPlan    *turnRetryPlan
+	// closedTurnRecovery records the canonical turns whose autonomous
+	// recovery is over: the bounded retry budget is spent, or the Harness
+	// failure is permanent and no retry can resolve it. Such a turn stays
+	// pending and unacknowledged, but the serial drain never re-executes it
+	// for unrelated later Room traffic. Only an explicit recovery boundary —
+	// a new addressed trigger for the same scope — reopens it.
+	closedTurnRecovery map[canonicalTurnKey]struct{}
 	// turnRetryDelay overrides the delay before retry attempt N (0-based).
 	// Nil uses the shared reconnect back-off; tests override it to drive the
 	// policy deterministically without wall-clock waits.
@@ -647,12 +654,21 @@ func (r *ResidentRuntime) adoptJoin(joined types.JoinResult) {
 		r.eventBuffer.Clear()
 		r.pendingAddressed = nil
 		r.pendingContexts = nil
+		r.closedTurnRecovery = nil
 		r.scopedSessions = nil
 		r.scopeOrder = nil
 	}
-	r.state = StateWaiting
-	r.lastError = ""
-	r.lastErrorSource = ""
+	if r.closedTurnRecovery != nil {
+		// A transport join/rejoin is not an explicit recovery boundary: a
+		// canonical turn whose autonomous recovery is closed stays pinned and
+		// keeps reporting the truthful reconnect state until a new addressed
+		// trigger re-arms it.
+		r.state = StateReconnecting
+	} else {
+		r.state = StateWaiting
+		r.lastError = ""
+		r.lastErrorSource = ""
+	}
 	// #228: participation age starts at the lifecycle's first successful
 	// create/join and survives transient retries and lease recovery.
 	if initialJoin {
@@ -1078,6 +1094,11 @@ func (r *ResidentRuntime) acceptEvent(event types.RoomEvent) {
 				target: event.Sequence,
 				events: r.eventsForScopeLocked(scope, after, event.Sequence),
 			}
+			// An accepted addressed trigger for this scope is the explicit
+			// recovery boundary: it re-arms a canonical turn of the same scope
+			// whose autonomous recovery was closed. Unaddressed Room traffic
+			// never reaches this point and can never re-arm anything.
+			r.reopenTurnRecoveryLocked(scope)
 		}
 	}
 	r.mu.Unlock()
@@ -1104,7 +1125,7 @@ func (r *ResidentRuntime) restoreStateAfterRetry() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	switch {
-	case r.harnessFailed:
+	case r.unresolvedTurnFailureLocked():
 		r.state = StateReconnecting
 	case r.turnRunning:
 		r.state = StateTurn
@@ -1118,10 +1139,18 @@ func (r *ResidentRuntime) restoreStateAfterRetry() {
 // distinct boundaries: only RunTurn success acknowledges an addressed target
 // and advances deliveredThrough. A failed/ambiguous Harness turn is therefore
 // intentionally eligible for at-least-once retry; a later SendText failure is
-// not.
+// not. A turn whose bounded autonomous recovery is closed is deliberately
+// skipped without being re-executed or acknowledged.
 func (r *ResidentRuntime) drainTurns() {
 	r.mu.Lock()
 	if r.turnRunning || r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	if _, _, runnable := r.nextRunnableTurnLocked(); !runnable {
+		// Every remaining unacknowledged turn has closed autonomous recovery.
+		// Nothing may run until an explicit recovery boundary re-arms it, so
+		// do not claim a turn state for work that will not run.
 		r.mu.Unlock()
 		return
 	}
@@ -1133,11 +1162,13 @@ func (r *ResidentRuntime) drainTurns() {
 		r.mu.Lock()
 		r.turnRunning = false
 		if !r.stopped {
-			// A pending bounded retry and an exhausted retry budget are both
-			// truthful reconnect states: the resident still holds
-			// unacknowledged work it could not hand to the Harness.
-			if r.harnessFailed || r.lastErrorSource == "send" ||
-				r.turnRetryPlan != nil || r.turnRetryAttempt > maxTurnRetryAttempts {
+			// A pending bounded retry, an exhausted budget, a parked canonical
+			// turn, or any unresolved Harness/send failure is a truthful
+			// reconnect state: the resident still holds unacknowledged work it
+			// could not hand to the Harness. A permanent non-retryable Harness
+			// failure must keep reporting that state instead of being
+			// overwritten to waiting.
+			if r.unresolvedTurnFailureLocked() {
 				r.state = StateReconnecting
 			} else {
 				r.state = StateWaiting
@@ -1147,14 +1178,9 @@ func (r *ResidentRuntime) drainTurns() {
 	}()
 
 	for !r.isStopped() {
-		scopes := r.pendingScopes()
-		if len(scopes) == 0 {
-			return
-		}
-		scope := scopes[0]
-		target, ok := r.peekPendingFor(scope)
+		scope, target, ok := r.nextRunnableTurn()
 		if !ok {
-			continue
+			return
 		}
 		started := time.Now()
 		r.log("turn_started", map[string]string{
@@ -1291,8 +1317,11 @@ func (r *ResidentRuntime) drainTurns() {
 		r.mu.Lock()
 		r.harnessFailed = false
 		// #228: a successful turn proves the Harness recovered — clear ONLY
-		// the harness-origin error (a concurrent wait/send failure stays).
-		if r.lastErrorSource == "harness" {
+		// the harness-origin error (a concurrent wait/send failure stays). A
+		// canonical turn parked with closed autonomous recovery is still
+		// unacknowledged, so its failure must stay visible until an explicit
+		// recovery boundary resolves it.
+		if r.lastErrorSource == "harness" && len(r.closedTurnRecovery) == 0 {
 			r.lastError = ""
 			r.lastErrorSource = ""
 		}
@@ -1636,6 +1665,7 @@ func (r *ResidentRuntime) beginStop(lastError string) bool {
 		}
 		r.pendingAddressed = nil
 		r.pendingContexts = nil
+		r.closedTurnRecovery = nil
 		r.eventBuffer.Clear()
 		r.mu.Unlock()
 		r.cancelPendingPermissions(errors.New("runtime stopped"))

--- a/agent/internal/runtime/runtime_test.go
+++ b/agent/internal/runtime/runtime_test.go
@@ -1387,17 +1387,33 @@ func TestTimedOutTurnDoesNotReplyNorReplay(t *testing.T) {
 		InstanceID: "inst-timeout", RoomID: "test", Name: "Hermes",
 		Client: client, Adapter: adapter, WaitSeconds: 1,
 	})
+	// #364 B: the Runtime now retries a failed Harness turn by itself, so the
+	// bounded budget is consumed without wall-clock waits.
+	rt.turnRetryDelay = func(int) time.Duration { return time.Millisecond }
 	if err := rt.Start(); err != nil {
 		t.Fatalf("start failed: %v", err)
 	}
-	waitFor(t, 2*time.Second, func() bool {
-		return rt.Status().State == StateWaiting && len(client.snapshotSent()) == 0 &&
-			adapter.sessionsInt() >= 1
-	}, "turn release")
+	// The budget is consumed only after the last failed attempt has unwound
+	// (a mid-turn StateTurn snapshot is not the settled truth).
+	waitFor(t, 3*time.Second, func() bool {
+		state := rt.Status().State
+		return adapter.sessionsInt() == 1+maxTurnRetryAttempts && state != StateTurn
+	}, "bounded retry budget consumed")
+	// Stop clears runtime-local pending state, so snapshot the boundaries first.
+	pending := rt.pendingAddressedSnapshot()
+	delivered := rt.deliveredSeq()
+	status := rt.Status()
 	rt.Stop()
+	time.Sleep(20 * time.Millisecond)
 
 	if len(client.snapshotSent()) != 0 {
 		t.Fatalf("timed-out turn must not send: %v", client.snapshotSent())
+	}
+	if len(pending) != 1 || delivered != 0 {
+		t.Fatalf("failed turn must stay unacknowledged: pending=%v delivered=%d", pending, delivered)
+	}
+	if status.LastError == "" || status.State != StateReconnecting {
+		t.Fatalf("exhausted timeout retry must report a truthful local state: %+v", status)
 	}
 }
 
@@ -2280,14 +2296,15 @@ func TestHarnessFailureClearsAfterSuccessfulTurn(t *testing.T) {
 		Adapter:     adapter,
 		WaitSeconds: 1,
 	})
-	if err := rt.Start(); err != nil {
-		t.Fatalf("start failed: %v", err)
-	}
 	// Sequencing via the adapter hook: turn 1 runs with turnErr set and
 	// FAILS; the hook clears turnErr inside RunTurn so turn 2 (same drain)
 	// SUCCEEDS — deterministic fail->success without wall-clock polling.
 	// A bare LastError=="exploded" poll can miss the transient window
 	// because both events arrive in one poll step.
+	//
+	// The hook is installed BEFORE Start: the wait-loop goroutine reads it
+	// inside RunTurn, so assigning it after Start would race (pre-existing
+	// data race found while validating #364; behavior is unchanged).
 	var sawFailure atomic.Bool
 	originalHook := adapterRunTurnHook
 	adapterRunTurnHook = func(a *fakeAdapter, input types.HarnessTurnInput) {
@@ -2300,6 +2317,9 @@ func TestHarnessFailureClearsAfterSuccessfulTurn(t *testing.T) {
 		}
 	}
 	defer func() { adapterRunTurnHook = originalHook }()
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
 
 	waitFor(t, 5*time.Second, func() bool {
 		return sawFailure.Load() && adapter.sessionsInt() >= 2

--- a/agent/internal/runtime/turn_retry.go
+++ b/agent/internal/runtime/turn_retry.go
@@ -39,6 +39,15 @@ type turnRetryPlan struct {
 	delay        time.Duration
 }
 
+// canonicalTurnKey identifies one canonical pending turn: the logical scope
+// plus the addressed Room sequence that triggered it. It is the identity both
+// the bounded retry budget and the closed-recovery marker are keyed by, so an
+// unrelated Room event can never be mistaken for the same turn.
+type canonicalTurnKey struct {
+	scope  string
+	target int64
+}
+
 // scopeKindOf maps an opaque logical scope to the bounded diagnostic token
 // used in logs. It never reveals the task/request id itself.
 func scopeKindOf(scope string) string {
@@ -116,14 +125,22 @@ func (r *ResidentRuntime) failTurn(
 	})
 	if retryable {
 		r.scheduleTurnRetry(scope, target, failureClass, elapsedMs)
+		return
 	}
+	// A permanent, non-retryable Harness failure is deterministic: no retry
+	// can resolve it. The canonical turn stays pending and unacknowledged,
+	// but its autonomous recovery is closed so unrelated later Room traffic
+	// can never re-execute it.
+	r.mu.Lock()
+	r.closeTurnRecoveryLocked(scope, target)
+	r.mu.Unlock()
 }
 
 // scheduleTurnRetry records one failed Harness turn for the canonical target
 // and arms the single bounded retry clock. The budget belongs to that exact
 // (scope, target): an unrelated Room event re-entering the drain can never
 // reset it, and once the budget is exhausted the same still-pending turn is
-// never retried autonomously again.
+// marked closed so it is never executed again automatically.
 func (r *ResidentRuntime) scheduleTurnRetry(scope string, target int64, failureClass string, elapsedMs int64) {
 	scopeKind := scopeKindOf(scope)
 	r.mu.Lock()
@@ -141,6 +158,10 @@ func (r *ResidentRuntime) scheduleTurnRetry(scope string, target int64, failureC
 	attempt := r.turnRetryAttempt
 	if attempt > maxTurnRetryAttempts {
 		r.turnRetryPlan = nil
+		// The budget for this exact canonical turn is spent: close its
+		// autonomous recovery so later unrelated Room traffic can only keep
+		// it pending, never re-execute it.
+		r.closeTurnRecoveryLocked(scope, target)
 		r.mu.Unlock()
 		r.log("turn_retry_exhausted", map[string]string{
 			"scopeKind":    scopeKind,
@@ -195,6 +216,98 @@ func (r *ResidentRuntime) clearTurnRetry(scope string, target int64) {
 		r.turnRetryPlan = nil
 	}
 	r.mu.Unlock()
+}
+
+// unresolvedTurnFailureLocked reports whether the resident still holds
+// unacknowledged work it could not hand to the Harness: an armed retry, a
+// spent or permanently closed recovery, or an unresolved Harness/send
+// failure. It is the single truthful-state predicate every "restore to
+// normal" site must consult before claiming a healthy waiting state. Callers
+// must hold r.mu.
+func (r *ResidentRuntime) unresolvedTurnFailureLocked() bool {
+	if r.harnessFailed || len(r.closedTurnRecovery) > 0 {
+		return true
+	}
+	if r.lastErrorSource == "harness" || r.lastErrorSource == "send" {
+		return true
+	}
+	return r.turnRetryPlan != nil || r.turnRetryAttempt > maxTurnRetryAttempts
+}
+
+// turnRecoveryClosed reports whether autonomous recovery of one canonical
+// pending turn is over: its bounded retry budget is exhausted, or its Harness
+// failure is permanent. The trigger itself is deliberately still
+// unacknowledged in that case; only an explicit recovery boundary re-arms it.
+func (r *ResidentRuntime) turnRecoveryClosed(scope string, target int64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.turnRecoveryClosedLocked(scope, target)
+}
+
+func (r *ResidentRuntime) turnRecoveryClosedLocked(scope string, target int64) bool {
+	if len(r.closedTurnRecovery) == 0 {
+		return false
+	}
+	scope = normalizeScope(scope)
+	if scope == "" {
+		return false
+	}
+	_, closed := r.closedTurnRecovery[canonicalTurnKey{scope: scope, target: target}]
+	return closed
+}
+
+// closeTurnRecoveryLocked stops autonomous recovery of one canonical pending
+// turn. Callers must hold r.mu. The canonical turn stays pending until
+// RunTurn actually succeeds — this never acknowledges it — but the serial
+// drain refuses to re-execute it for unrelated later Room traffic.
+func (r *ResidentRuntime) closeTurnRecoveryLocked(scope string, target int64) {
+	scope = normalizeScope(scope)
+	if scope == "" {
+		return
+	}
+	ref := r.sessionRefLocked(scope)
+	if ref == nil || !containsSequence(*ref.pendingAddressed, target) {
+		// The canonical turn already settled: there is no pinned trigger left
+		// to protect and no automatic re-execution to refuse.
+		return
+	}
+	if r.closedTurnRecovery == nil {
+		r.closedTurnRecovery = make(map[canonicalTurnKey]struct{})
+	}
+	r.closedTurnRecovery[canonicalTurnKey{scope: scope, target: target}] = struct{}{}
+}
+
+// forgetTurnRecoveryLocked drops a closed-recovery marker for a canonical
+// turn that settled. Callers must hold r.mu.
+func (r *ResidentRuntime) forgetTurnRecoveryLocked(scope string, target int64) {
+	if len(r.closedTurnRecovery) == 0 {
+		return
+	}
+	delete(r.closedTurnRecovery, canonicalTurnKey{scope: normalizeScope(scope), target: target})
+}
+
+// reopenTurnRecoveryLocked is the explicit recovery boundary: a new addressed
+// trigger for the scope re-arms the parked canonical turn(s) of that scope and
+// restarts the bounded budget of the one whose budget was spent, so the
+// diagnostic retryAttempt count can never exceed its documented bound.
+// Callers must hold r.mu.
+func (r *ResidentRuntime) reopenTurnRecoveryLocked(scope string) {
+	if len(r.closedTurnRecovery) == 0 {
+		return
+	}
+	scope = normalizeScope(scope)
+	for key := range r.closedTurnRecovery {
+		if key.scope != scope {
+			continue
+		}
+		delete(r.closedTurnRecovery, key)
+		if r.turnRetryScope == key.scope && r.turnRetryTarget == key.target {
+			r.turnRetryScope = ""
+			r.turnRetryTarget = 0
+			r.turnRetryAttempt = 0
+			r.turnRetryPlan = nil
+		}
+	}
 }
 
 // drainTurnsWithRetryClock is the event-loop entry point. It runs the serial

--- a/agent/internal/runtime/turn_retry.go
+++ b/agent/internal/runtime/turn_retry.go
@@ -1,0 +1,239 @@
+package runtime
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/i365dev/free4chat/agent/internal/harness"
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+// maxTurnRetryAttempts bounds the autonomous retry of ONE canonical pending
+// turn after a failed Harness turn. It is deliberately tiny: the Runtime is
+// not a resilience framework, and a repeatedly failing Harness must end in a
+// bounded truthful local state instead of spinning. Task/request correlation
+// is preserved because the retry re-enters the same serial drain, which still
+// processes the exact unacknowledged (scope, sequence) the failed turn kept
+// pinned.
+const maxTurnRetryAttempts = 2
+
+// Bounded failure-class vocabulary used by turn diagnostics. Values are
+// stable tokens only: they never contain work content.
+const (
+	turnFailureTimeout = "timeout"
+	turnFailureProcess = "process"
+	turnFailureSession = "session"
+	turnFailureSend    = "send"
+	turnFailureOther   = "other"
+)
+
+// turnRetryPlan is one armed autonomous retry of the exact canonical pending
+// turn (logical scope + addressed sequence) whose Harness turn failed.
+type turnRetryPlan struct {
+	scope        string
+	target       int64
+	scopeKind    string
+	failureClass string
+	attempt      int
+	delay        time.Duration
+}
+
+// scopeKindOf maps an opaque logical scope to the bounded diagnostic token
+// used in logs. It never reveals the task/request id itself.
+func scopeKindOf(scope string) string {
+	if taskRequestIDForScope(scope) != "" {
+		return "task"
+	}
+	return "room"
+}
+
+// turnFailureClassOf classifies one failed Harness turn into the bounded
+// diagnostic vocabulary. It inspects the error value only: no message text,
+// prompt content, tool argument, path, credential, or participant identity is
+// ever read, copied, or logged. The ACP turn timeout is classified explicitly.
+func turnFailureClassOf(err error) string {
+	var timeout *harness.TurnTimeoutError
+	if errors.As(err, &timeout) {
+		return turnFailureTimeout
+	}
+	var process *harness.ProcessError
+	if errors.As(err, &process) {
+		return turnFailureProcess
+	}
+	if errors.Is(err, types.ErrHarnessSessionGenerationChanged) ||
+		errors.Is(err, errScopedHarnessUnsupported) {
+		return turnFailureSession
+	}
+	return turnFailureOther
+}
+
+// permanentTurnFailure reports a deterministic Harness misconfiguration that
+// a retry cannot resolve (a legacy adapter that cannot serve a task scope).
+func permanentTurnFailure(err error) bool {
+	return errors.Is(err, errScopedHarnessUnsupported)
+}
+
+// turnRetryIndexFor reports how many autonomous retries the canonical turn
+// identified by (scope, target) has already had scheduled. 0 means the next
+// event describes the initial attempt.
+func (r *ResidentRuntime) turnRetryIndexFor(scope string, target int64) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.turnRetryScope != scope || r.turnRetryTarget != target {
+		return 0
+	}
+	return r.turnRetryAttempt
+}
+
+// failTurn records one failed Harness turn, emits the bounded secret-free
+// diagnostic, and arms the bounded autonomous retry clock when the failure is
+// retryable. It never logs Room/message text, prompt or thought content, tool
+// arguments, local paths, credentials, participant handles/ids/names, request
+// ids, or raw ACP payloads: only the logical scope kind, the failure class,
+// elapsed milliseconds, and retry accounting.
+func (r *ResidentRuntime) failTurn(
+	scope string,
+	target int64,
+	lastErrorSource, failureClass string,
+	started time.Time,
+	err error,
+	retryable bool,
+) {
+	elapsedMs := time.Since(started).Milliseconds()
+	scopeKind := scopeKindOf(scope)
+	retryAttempt := r.turnRetryIndexFor(scope, target)
+	r.mu.Lock()
+	r.lastError = err.Error()
+	r.lastErrorSource = lastErrorSource
+	r.state = StateReconnecting
+	r.mu.Unlock()
+	r.log("turn_failed", map[string]string{
+		"scopeKind":    scopeKind,
+		"failureClass": failureClass,
+		"elapsedMs":    strconv.FormatInt(elapsedMs, 10),
+		"retryAttempt": strconv.Itoa(retryAttempt),
+	})
+	if retryable {
+		r.scheduleTurnRetry(scope, target, failureClass, elapsedMs)
+	}
+}
+
+// scheduleTurnRetry records one failed Harness turn for the canonical target
+// and arms the single bounded retry clock. The budget belongs to that exact
+// (scope, target): an unrelated Room event re-entering the drain can never
+// reset it, and once the budget is exhausted the same still-pending turn is
+// never retried autonomously again.
+func (r *ResidentRuntime) scheduleTurnRetry(scope string, target int64, failureClass string, elapsedMs int64) {
+	scopeKind := scopeKindOf(scope)
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	if r.turnRetryScope != scope || r.turnRetryTarget != target {
+		r.turnRetryScope = scope
+		r.turnRetryTarget = target
+		r.turnRetryAttempt = 0
+		r.turnRetryPlan = nil
+	}
+	r.turnRetryAttempt++
+	attempt := r.turnRetryAttempt
+	if attempt > maxTurnRetryAttempts {
+		r.turnRetryPlan = nil
+		r.mu.Unlock()
+		r.log("turn_retry_exhausted", map[string]string{
+			"scopeKind":    scopeKind,
+			"failureClass": failureClass,
+			"retryAttempt": strconv.Itoa(maxTurnRetryAttempts),
+		})
+		return
+	}
+	delay := RetryDelay(attempt - 1)
+	if r.turnRetryDelay != nil {
+		delay = r.turnRetryDelay(attempt - 1)
+	}
+	r.turnRetryPlan = &turnRetryPlan{
+		scope:        scope,
+		target:       target,
+		scopeKind:    scopeKind,
+		failureClass: failureClass,
+		attempt:      attempt,
+		delay:        delay,
+	}
+	r.mu.Unlock()
+	r.log("retry_scheduled", map[string]string{
+		"scopeKind":    scopeKind,
+		"failureClass": failureClass,
+		"elapsedMs":    strconv.FormatInt(elapsedMs, 10),
+		"retryAttempt": strconv.Itoa(attempt),
+		"retryDelayMs": strconv.FormatInt(delay.Milliseconds(), 10),
+	})
+}
+
+// takeTurnRetryPlan pops the armed plan, if any.
+func (r *ResidentRuntime) takeTurnRetryPlan() (turnRetryPlan, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.turnRetryPlan == nil {
+		return turnRetryPlan{}, false
+	}
+	plan := *r.turnRetryPlan
+	r.turnRetryPlan = nil
+	return plan, true
+}
+
+// clearTurnRetry drops the retry budget for a canonical turn that has just
+// been delivered successfully. A send failure after that success therefore
+// never replays Harness cognition.
+func (r *ResidentRuntime) clearTurnRetry(scope string, target int64) {
+	r.mu.Lock()
+	if r.turnRetryScope == scope && r.turnRetryTarget == target {
+		r.turnRetryScope = ""
+		r.turnRetryTarget = 0
+		r.turnRetryAttempt = 0
+		r.turnRetryPlan = nil
+	}
+	r.mu.Unlock()
+}
+
+// drainTurnsWithRetryClock is the event-loop entry point. It runs the serial
+// turn drain and then rides the bounded autonomous retry clock, so a pending
+// addressed turn never needs an unrelated future Room event before it is
+// retried. It adds no goroutine and no scheduler: the wait is the existing
+// stop-aware sleep on the one event-loop goroutine that already owns drainTurns.
+func (r *ResidentRuntime) drainTurnsWithRetryClock() {
+	r.drainTurns()
+	r.runTurnRetryClock()
+}
+
+// runTurnRetryClock waits the small explicit delay and re-enters the serial
+// drain for the same canonical pending turn. Each iteration must have been
+// armed by a fresh failed turn, so the loop is bounded by construction.
+func (r *ResidentRuntime) runTurnRetryClock() {
+	for {
+		plan, ok := r.takeTurnRetryPlan()
+		if !ok {
+			return
+		}
+		if target, pending := r.peekPendingFor(plan.scope); !pending || target != plan.target {
+			// The canonical turn settled while the clock was armed. Never
+			// resurrect a stale retry for a different or already-delivered
+			// trigger.
+			return
+		}
+		if !r.sleep(plan.delay) {
+			return
+		}
+		r.log("retry_started", map[string]string{
+			"scopeKind":    plan.scopeKind,
+			"failureClass": plan.failureClass,
+			"retryAttempt": strconv.Itoa(plan.attempt),
+			"retryDelayMs": strconv.FormatInt(plan.delay.Milliseconds(), 10),
+		})
+		r.drainTurns()
+		if r.isStopped() {
+			return
+		}
+	}
+}

--- a/agent/internal/runtime/turn_retry.go
+++ b/agent/internal/runtime/turn_retry.go
@@ -278,7 +278,9 @@ func (r *ResidentRuntime) closeTurnRecoveryLocked(scope string, target int64) {
 }
 
 // forgetTurnRecoveryLocked drops a closed-recovery marker for a canonical
-// turn that settled. Callers must hold r.mu.
+// turn that settled. Callers must hold r.mu. The map is deliberately left
+// non-nil when it drains: emptiness, never non-nilness, is the condition every
+// caller must test (see unresolvedTurnFailureLocked).
 func (r *ResidentRuntime) forgetTurnRecoveryLocked(scope string, target int64) {
 	if len(r.closedTurnRecovery) == 0 {
 		return
@@ -290,7 +292,8 @@ func (r *ResidentRuntime) forgetTurnRecoveryLocked(scope string, target int64) {
 // trigger for the scope re-arms the parked canonical turn(s) of that scope and
 // restarts the bounded budget of the one whose budget was spent, so the
 // diagnostic retryAttempt count can never exceed its documented bound.
-// Callers must hold r.mu.
+// Deleting the last marker intentionally leaves an empty (possibly non-nil)
+// map: no caller may branch on non-nilness. Callers must hold r.mu.
 func (r *ResidentRuntime) reopenTurnRecoveryLocked(scope string) {
 	if len(r.closedTurnRecovery) == 0 {
 		return

--- a/agent/internal/runtime/turn_retry_test.go
+++ b/agent/internal/runtime/turn_retry_test.go
@@ -464,6 +464,119 @@ func TestClosedTurnRecoveryDoesNotBlockAnotherScope(t *testing.T) {
 	}
 }
 
+// TestExplicitReAddressThenSuccessLeavesNoStaleClosedRecovery is the
+// stale-truthful-state regression for the closed-recovery lifecycle: exhaustion
+// parks a turn, an explicit same-scope re-address reopens it, the successful
+// recovery deletes the last marker, and a later transport rejoin must then
+// report the healthy waiting state. Branching on the marker map's non-nilness
+// instead of its emptiness reported a stale "reconnecting" here, because the
+// drained map is never reset to nil.
+func TestExplicitReAddressThenSuccessLeavesNoStaleClosedRecovery(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi", turnErr: &harness.TurnTimeoutError{TimeoutMs: 120_000}}
+	rt := newTurnRetryRuntime(t, adapter, &fakeClient{}, silentLog)
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+	rt.acceptEvent(roomEvent(1, true))
+
+	// Each direct drain entry is one attempt; the third spends the bounded
+	// budget and parks the canonical turn.
+	for attempt := 0; attempt < 1+maxTurnRetryAttempts; attempt++ {
+		rt.drainTurns()
+	}
+	if !rt.turnRecoveryClosed(roomScope, 1) {
+		t.Fatal("exhausted canonical turn did not close its autonomous recovery")
+	}
+	if got := rt.pendingAddressedSnapshot(); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("parked canonical turn was silently acknowledged: %v", got)
+	}
+
+	// Step 2: an explicit same-scope re-address reopens the parked turn. The
+	// Harness has recovered, so both the pinned turn and the new trigger are
+	// delivered in FIFO order.
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	rt.acceptEvent(roomEvent(2, true))
+	rt.drainTurns()
+
+	// Step 3: the successful recovery is complete BEFORE any rejoin — the
+	// delivery markers advanced, no closed marker survives for a settled turn,
+	// and the runtime already reports itself healthy.
+	if got := rt.pendingAddressedSnapshot(); len(got) != 0 {
+		t.Fatalf("explicit re-address did not deliver the pinned turn: %v", got)
+	}
+	if got := rt.deliveredSeq(); got != 2 {
+		t.Fatalf("successful recovery advanced delivery to %d, want 2", got)
+	}
+	if rt.turnRecoveryClosed(roomScope, 1) {
+		t.Fatal("delivered canonical turn kept a closed-recovery marker")
+	}
+	markers := closedTurnRecoverySnapshot(rt)
+	if len(markers) != 0 {
+		t.Fatalf("closed-recovery marker count = %d, want 0: %+v", len(markers), markers)
+	}
+	// A surviving marker would only be legitimate while its canonical turn is
+	// still genuinely parked (unacknowledged).
+	for _, key := range markers {
+		if !containsSequence(rt.pendingAddressedSnapshotFor(key.scope), key.target) {
+			t.Fatalf("closed-recovery marker outlived its settled turn: %+v", key)
+		}
+	}
+	if status := rt.Status(); status.State != StateWaiting || status.LastError != "" {
+		t.Fatalf("successful recovery left a stale local state: %+v", status)
+	}
+
+	// Step 4: a transport rejoin is not an explicit recovery boundary, but the
+	// runtime holds no unresolved work any more, so it must report a healthy
+	// waiting state with no resurrected Harness error.
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent-2", ParticipantHandle: "secret-2", Cursor: 10})
+	status := rt.Status()
+	if status.State != StateWaiting {
+		t.Fatalf("transport rejoin after recovery reported State:%s, want %s", status.State, StateWaiting)
+	}
+	if status.LastError != "" {
+		t.Fatalf("transport rejoin resurrected a stale Harness error: %+v", status)
+	}
+
+	// A genuinely still-parked turn must keep the truthful reconnect state:
+	// the condition is unresolved work, not "never reconnecting again".
+	adapter.mu.Lock()
+	adapter.turnErr = &harness.TurnTimeoutError{TimeoutMs: 120_000}
+	adapter.mu.Unlock()
+	rt.acceptEvent(scopedEvent(3, "task:T", "T1"))
+	for attempt := 0; attempt < 1+maxTurnRetryAttempts; attempt++ {
+		rt.drainTurns()
+	}
+	parkedMarkers := closedTurnRecoverySnapshot(rt)
+	if len(parkedMarkers) != 1 || parkedMarkers[0] != (canonicalTurnKey{scope: "task:T", target: 3}) {
+		t.Fatalf("still-parked scope has the wrong marker set: %+v", parkedMarkers)
+	}
+	for _, key := range parkedMarkers {
+		if !containsSequence(rt.pendingAddressedSnapshotFor(key.scope), key.target) {
+			t.Fatalf("closed-recovery marker outlived its settled turn: %+v", key)
+		}
+	}
+	if !rt.turnRecoveryClosed("task:T", 3) || rt.turnRecoveryClosed(roomScope, 2) {
+		t.Fatalf("marker set does not match the genuinely parked turn: %+v", parkedMarkers)
+	}
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent-3", ParticipantHandle: "secret-3", Cursor: 11})
+	if status := rt.Status(); status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("a still-parked turn lost its truthful reconnect state: %+v", status)
+	}
+}
+
+// closedTurnRecoverySnapshot returns the canonical turns whose autonomous
+// recovery is still closed. It reports the marker set itself (not the map's
+// non-nilness), so an empty-but-non-nil map is observed as empty.
+func closedTurnRecoverySnapshot(rt *ResidentRuntime) []canonicalTurnKey {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	markers := make([]canonicalTurnKey, 0, len(rt.closedTurnRecovery))
+	for key := range rt.closedTurnRecovery {
+		markers = append(markers, key)
+	}
+	return markers
+}
+
 // TestRetryAfterHarnessSessionReplacementRebootstrapsThePinnedDelta proves the
 // bounded retry keeps ACP generation semantics safe: when the failed turn's
 // recovery replaced the Harness session, the retry is a real session/new that

--- a/agent/internal/runtime/turn_retry_test.go
+++ b/agent/internal/runtime/turn_retry_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -211,9 +212,11 @@ func TestRepeatedHarnessFailureExhaustsBoundedRetryAndStops(t *testing.T) {
 }
 
 // TestLaterRoomEventCannotResetTheRetryBudgetForTheSameTurn proves the budget
-// belongs to the canonical (scope, sequence) turn: later Room events may try
-// the pending turn again, but they can never grant a fresh autonomous retry
-// budget to the same still-pending turn.
+// belongs to the canonical (scope, sequence) turn: once that turn's bounded
+// autonomous recovery is exhausted, later unrelated Room traffic can neither
+// re-execute it nor grant it a fresh budget. The canonical turn stays pending
+// and unacknowledged in a truthful reconnect state until an explicit recovery
+// boundary — a new addressed trigger for the same scope — re-arms it.
 func TestLaterRoomEventCannotResetTheRetryBudgetForTheSameTurn(t *testing.T) {
 	client, stream := newResidentTurnRetryClient(t)
 	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("persistent ACP failure")}
@@ -226,35 +229,239 @@ func TestLaterRoomEventCannotResetTheRetryBudgetForTheSameTurn(t *testing.T) {
 
 	stream.results <- addressedEnvelope(roomEvent(1, true))
 	waitFor(t, 5*time.Second, func() bool {
-		return adapter.sessionsInt() == 1+maxTurnRetryAttempts
+		return adapter.sessionsInt() == 1+maxTurnRetryAttempts &&
+			log.count("turn_retry_exhausted") == 1
 	}, "bounded retry budget consumed")
+	exhaustedRuns := adapter.sessionsInt()
+	if !rt.turnRecoveryClosed(roomScope, 1) {
+		t.Fatal("exhausted canonical turn did not close its autonomous recovery")
+	}
 
-	// Two later Room envelopes carry only unaddressed events. Each one may
-	// re-enter the drain, but the same still-pending canonical turn gets no
-	// further autonomous retry clock.
+	// Two later Room envelopes carry only unaddressed events. They may
+	// re-enter the drain, but the exhausted canonical turn must not run again:
+	// no extra Harness execution, no extra retry budget, no extra diagnostic.
 	stream.results <- addressedEnvelope(roomEvent(2, false))
 	stream.results <- addressedEnvelope(roomEvent(3, false))
 	waitFor(t, 3*time.Second, func() bool {
-		return adapter.sessionsInt() == 3+maxTurnRetryAttempts
-	}, "each later Room event attempts the pending turn at most once")
-	time.Sleep(150 * time.Millisecond)
-	if got := adapter.sessionsInt(); got != 3+maxTurnRetryAttempts {
-		t.Fatalf("a later Room event reset the retry budget: %d Harness turns", got)
+		return rt.currentCursor() >= 3
+	}, "later unaddressed Room envelopes ingested")
+	time.Sleep(200 * time.Millisecond)
+	if got := adapter.sessionsInt(); got != exhaustedRuns {
+		t.Fatalf("unrelated later Room traffic re-executed the exhausted turn: %d Harness turns", got)
+	}
+	if got := log.count("turn_started"); got != exhaustedRuns {
+		t.Fatalf("unrelated later Room traffic started another turn: %d turn_started", got)
 	}
 	if got := log.count("retry_scheduled"); got != maxTurnRetryAttempts {
-		t.Fatalf("later Room events re-armed the retry clock: %d retry_scheduled", got)
+		t.Fatalf("unrelated later Room traffic re-armed the retry clock: %d retry_scheduled", got)
+	}
+	if got := log.count("turn_failed"); got != exhaustedRuns {
+		t.Fatalf("unrelated later Room traffic recorded another failure: %d turn_failed", got)
+	}
+	// The bounded diagnostic contract holds for every attempt so far.
+	for _, event := range []string{"turn_started", "turn_failed"} {
+		for _, fields := range log.fieldsFor(event) {
+			attempt, err := strconv.Atoi(fields["retryAttempt"])
+			if err != nil || attempt < 0 || attempt > maxTurnRetryAttempts {
+				t.Fatalf("%s reported an out-of-bound retryAttempt: %+v", event, fields)
+			}
+		}
 	}
 
-	// The pinned canonical turn is still deliverable through its normal
-	// trigger path once the Harness recovers.
+	// The exhausted turn is never silently acknowledged: it stays pinned with
+	// a truthful error/reconnecting state until an explicit recovery boundary.
+	if got := rt.pendingAddressedSnapshot(); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("exhausted turn must stay pending and unacknowledged: %v", got)
+	}
+	if got := rt.deliveredSeq(); got != 0 {
+		t.Fatalf("exhausted turn advanced deliveredThrough to %d", got)
+	}
+	if sent := client.snapshotSent(); len(sent) != 0 {
+		t.Fatalf("exhausted turn published a reply: %v", sent)
+	}
+	if status := rt.Status(); status.LastError == "" || status.State != StateReconnecting {
+		t.Fatalf("exhausted turn lost its truthful reconnect state: %+v", status)
+	}
+
+	// An explicit recovery boundary — a new addressed trigger for the same
+	// scope — re-arms the pinned canonical turn, which is then delivered in
+	// FIFO order once the Harness recovers.
 	adapter.mu.Lock()
 	adapter.turnErr = nil
 	adapter.mu.Unlock()
-	stream.results <- addressedEnvelope(roomEvent(4, false))
+	stream.results <- addressedEnvelope(roomEvent(4, true))
 	waitFor(t, 3*time.Second, func() bool {
-		return len(rt.pendingAddressedSnapshot()) == 0 && rt.deliveredSeq() == 1 &&
-			len(client.snapshotSent()) == 1
-	}, "recovered Harness delivered the pinned canonical turn once")
+		return len(rt.pendingAddressedSnapshot()) == 0 && rt.deliveredSeq() == 4 &&
+			len(client.snapshotSent()) == 2
+	}, "explicit re-address delivered the pinned canonical turn")
+	if got := log.count("turn_retry_exhausted"); got != 1 {
+		t.Fatalf("re-armed turn reported an extra exhausted budget: %d", got)
+	}
+	if got := rt.turnRecoveryClosed(roomScope, 1); got {
+		t.Fatal("re-armed canonical turn stayed closed after its explicit recovery boundary")
+	}
+}
+
+// TestPermanentHarnessFailureKeepsTruthfulReconnectingState is the #364 B
+// status regression: a permanent, non-retryable Harness failure leaves its
+// canonical turn pinned, so the drain's deferred state restoration must not
+// overwrite the reported reconnect state with a healthy "waiting".
+func TestPermanentHarnessFailureKeepsTruthfulReconnectingState(t *testing.T) {
+	adapter := &legacyOnlyAdapter{}
+	rt := newTurnRetryRuntime(t, adapter, &fakeClient{}, silentLog)
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+	rt.acceptEvent(scopedEvent(1, "task:T", "T1"))
+	rt.drainTurns()
+
+	status := rt.Status()
+	if status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("permanent Harness failure did not report a truthful reconnect state: %+v", status)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("permanent Harness failure acknowledged its canonical turn: %v", got)
+	}
+	if adapter.ensureCalls != 0 || adapter.runCalls != 0 {
+		t.Fatalf("legacy adapter reached a task-scope turn: ensure=%d run=%d", adapter.ensureCalls, adapter.runCalls)
+	}
+	if !rt.turnRecoveryClosed("task:T", 1) {
+		t.Fatal("permanent Harness failure left its autonomous recovery open")
+	}
+
+	// Unrelated later Room traffic must neither re-execute the permanently
+	// failed canonical turn nor downgrade the truthful state to waiting.
+	rt.acceptEvent(roomEvent(2, false))
+	rt.drainTurns()
+	status = rt.Status()
+	if status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("unrelated Room traffic downgraded the permanent failure state: %+v", status)
+	}
+	if adapter.ensureCalls != 0 || adapter.runCalls != 0 {
+		t.Fatalf("unrelated Room traffic re-executed the permanently failed turn: ensure=%d run=%d", adapter.ensureCalls, adapter.runCalls)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("permanently failed turn was silently acknowledged: %v", got)
+	}
+	if !rt.turnRecoveryClosed("task:T", 1) {
+		t.Fatal("unrelated Room traffic reopened a permanently closed recovery")
+	}
+
+	// A transport rejoin is not an explicit recovery boundary either: it must
+	// not downgrade the parked turn's truthful state.
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent-2", ParticipantHandle: "secret-2", Cursor: 10})
+	status = rt.Status()
+	if status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("transport rejoin downgraded the permanent failure state: %+v", status)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("transport rejoin acknowledged the parked turn: %v", got)
+	}
+}
+
+// TestTransportRetryKeepsPermanentHarnessFailureReconnecting covers the other
+// state restoration point: the resident transport reconnect/back-off must not
+// downgrade a permanent Harness failure back to a healthy waiting state.
+func TestTransportRetryKeepsPermanentHarnessFailureReconnecting(t *testing.T) {
+	first := newResidentTestStream()
+	second := newResidentTestStream()
+	client := &residentTestClient{
+		fakeClient: &fakeClient{},
+		streams:    make(chan *residentTestStream, 2),
+	}
+	client.streams <- first
+	client.streams <- second
+	adapter := &legacyOnlyAdapter{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "resident-permanent-failure",
+		RoomID:     "room-permanent-failure",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+	})
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+	waitFor(t, 3*time.Second, func() bool {
+		open, _, _ := client.residentOpenSnapshot()
+		return open == 1
+	}, "resident event stream open")
+
+	// A task-scope addressed trigger fails permanently and parks its turn.
+	first.results <- addressedEnvelope(scopedEvent(1, "task:T", "T1"))
+	waitFor(t, 3*time.Second, func() bool {
+		return rt.turnRecoveryClosed("task:T", 1)
+	}, "permanent Harness failure parked its canonical turn")
+
+	// The transport then drops; the reconnect back-off restores local state.
+	if err := first.Close(); err != nil {
+		t.Fatalf("close resident stream: %v", err)
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		open, _, _ := client.residentOpenSnapshot()
+		return open >= 2
+	}, "resident reconnect after transport loss")
+	if status := rt.Status(); status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("transport recovery downgraded a permanent Harness failure: %+v", status)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("transport recovery acknowledged the parked turn: %v", got)
+	}
+	if adapter.runCalls != 0 {
+		t.Fatalf("transport recovery ran the unsupported task turn: %d", adapter.runCalls)
+	}
+}
+
+// TestClosedTurnRecoveryDoesNotBlockAnotherScope proves a canonical turn whose
+// autonomous recovery is closed parks only its own scope: it is never
+// re-executed, but a different scope's fresh addressed work still runs.
+func TestClosedTurnRecoveryDoesNotBlockAnotherScope(t *testing.T) {
+	adapter := &fakeAdapter{name: "pi", turnErr: &harness.TurnTimeoutError{TimeoutMs: 120_000}}
+	rt := newTurnRetryRuntime(t, adapter, &fakeClient{}, silentLog)
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+	rt.acceptEvent(scopedEvent(1, "task:T", "T1"))
+
+	// Each direct drain entry is one attempt; the third spends the budget.
+	for attempt := 0; attempt < 1+maxTurnRetryAttempts; attempt++ {
+		rt.drainTurns()
+	}
+	if !rt.turnRecoveryClosed("task:T", 1) {
+		t.Fatal("exhausted task turn did not close its autonomous recovery")
+	}
+	runs, _ := adapter.scopedRunSnapshot()
+	if len(runs) != 1+maxTurnRetryAttempts {
+		t.Fatalf("unexpected bounded attempt count: %v", runs)
+	}
+
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	rt.acceptEvent(scopedEvent(2, "task:U", "U1"))
+	rt.drainTurns()
+
+	runs, details := adapter.scopedRunSnapshot()
+	if len(runs) != 1+maxTurnRetryAttempts+1 || runs[len(runs)-1] != "task:U" {
+		t.Fatalf("closed task scope blocked or re-ran another scope: %v", runs)
+	}
+	if !reflect.DeepEqual(details["task:U"], []string{"U1"}) {
+		t.Fatalf("other scope received the wrong delta: %#v", details["task:U"])
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("closed task turn was silently acknowledged: %v", got)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:U"); len(got) != 0 {
+		t.Fatalf("fresh task work was not delivered: %v", got)
+	}
+	if got := rt.deliveredSeqFor("task:U"); got != 2 {
+		t.Fatalf("fresh task scope did not advance its own delivery: %d", got)
+	}
+	if got := rt.deliveredSeqFor("task:T"); got != 0 {
+		t.Fatalf("closed task scope advanced delivery: %d", got)
+	}
+	// The parked turn keeps the resident truthful while the other scope
+	// made progress.
+	if status := rt.Status(); status.State != StateReconnecting || status.LastError == "" {
+		t.Fatalf("closed recovery lost its truthful reconnect state: %+v", status)
+	}
 }
 
 // TestRetryAfterHarnessSessionReplacementRebootstrapsThePinnedDelta proves the

--- a/agent/internal/runtime/turn_retry_test.go
+++ b/agent/internal/runtime/turn_retry_test.go
@@ -1,0 +1,618 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/i365dev/free4chat/agent/internal/harness"
+	"github.com/i365dev/free4chat/agent/internal/types"
+)
+
+// turnLogRecorder captures the bounded turn diagnostics so tests can assert
+// the expected event sequence and that no field ever carries work content.
+type turnLogRecorder struct {
+	mu     sync.Mutex
+	events []string
+	fields []map[string]string
+}
+
+func (l *turnLogRecorder) log(event string, details map[string]string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	copied := make(map[string]string, len(details))
+	for key, value := range details {
+		copied[key] = value
+	}
+	l.events = append(l.events, event)
+	l.fields = append(l.fields, copied)
+}
+
+func (l *turnLogRecorder) snapshot() ([]string, []map[string]string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.events...), append([]map[string]string(nil), l.fields...)
+}
+
+func (l *turnLogRecorder) count(event string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	total := 0
+	for _, recorded := range l.events {
+		if recorded == event {
+			total++
+		}
+	}
+	return total
+}
+
+// fieldsFor returns the details of every recorded occurrence of one event.
+func (l *turnLogRecorder) fieldsFor(event string) []map[string]string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []map[string]string
+	for index, recorded := range l.events {
+		if recorded == event {
+			out = append(out, l.fields[index])
+		}
+	}
+	return out
+}
+
+// newTurnRetryRuntime starts a resident-stream runtime whose bounded retry
+// delay is effectively zero, so the autonomous retry policy is exercised
+// without wall-clock waits. Only the delay is overridden; attempts, scope, and
+// budget stay production-shaped.
+func newTurnRetryRuntime(
+	t *testing.T,
+	adapter types.HarnessAdapter,
+	client types.Free4ChatClient,
+	logger LogFunc,
+) *ResidentRuntime {
+	t.Helper()
+	rt := NewResidentRuntime(Options{
+		InstanceID: "turn-retry",
+		RoomID:     "room-turn-retry",
+		Name:       "Agent",
+		Client:     client,
+		Adapter:    adapter,
+		Log:        logger,
+	})
+	rt.turnRetryDelay = func(int) time.Duration { return time.Millisecond }
+	return rt
+}
+
+// silentLog keeps focused tests from writing diagnostics to the test log.
+func silentLog(string, map[string]string) {}
+
+func newResidentTurnRetryClient(t *testing.T) (*residentTestClient, *residentTestStream) {
+	t.Helper()
+	stream := newResidentTestStream()
+	client := &residentTestClient{
+		fakeClient: &fakeClient{},
+		streams:    make(chan *residentTestStream, 1),
+	}
+	client.streams <- stream
+	return client, stream
+}
+
+func addressedEnvelope(event types.RoomEvent) types.WaitResult {
+	return types.WaitResult{
+		Events:    []types.RoomEvent{event},
+		Cursor:    event.Sequence,
+		ExpiresAt: time.Now().Add(time.Hour).UnixMilli(),
+	}
+}
+
+// TestFailedHarnessTurnRetriesAutonomouslyWithoutNewRoomEvent is the core
+// #364 B regression: a transient Harness failure must not wait for an
+// unrelated future Room event before the pinned canonical turn is retried.
+func TestFailedHarnessTurnRetriesAutonomouslyWithoutNewRoomEvent(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("transient ACP failure")}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	// A clearly observable delay proves the retry is clock-driven (and not a
+	// side effect of another Room envelope) while staying fast.
+	rt.turnRetryDelay = func(int) time.Duration { return 250 * time.Millisecond }
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	// Exactly one Room envelope is delivered. A second Harness attempt can
+	// therefore only come from the Runtime's own bounded retry clock.
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 3*time.Second, func() bool {
+		return adapter.sessionsInt() == 1 && len(rt.pendingAddressedSnapshot()) == 1 &&
+			log.count("turn_failed") == 1
+	}, "first failed attempt stays unacknowledged")
+	if got := rt.deliveredSeq(); got != 0 {
+		t.Fatalf("failed turn advanced deliveredThrough to %d", got)
+	}
+	if sent := client.snapshotSent(); len(sent) != 0 {
+		t.Fatalf("failed turn published a reply: %v", sent)
+	}
+
+	// The Harness recovers; the Runtime must retry by itself and acknowledge
+	// exactly once with exactly one public reply.
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	waitFor(t, 3*time.Second, func() bool {
+		return len(rt.pendingAddressedSnapshot()) == 0 &&
+			rt.deliveredSeq() == 1 &&
+			len(client.snapshotSent()) == 1
+	}, "autonomous retry delivered the canonical turn once")
+
+	time.Sleep(50 * time.Millisecond)
+	if got := adapter.sessionsInt(); got != 2 {
+		t.Fatalf("expected exactly one retry, Harness ran %d times", got)
+	}
+	if sent := client.snapshotSent(); len(sent) != 1 {
+		t.Fatalf("the public reply must not be duplicated: %v", sent)
+	}
+	if got := log.count("retry_scheduled"); got != 1 {
+		t.Fatalf("expected exactly one retry_scheduled event, got %d", got)
+	}
+	if got := log.count("retry_started"); got != 1 {
+		t.Fatalf("expected exactly one retry_started event, got %d", got)
+	}
+}
+
+// TestRepeatedHarnessFailureExhaustsBoundedRetryAndStops pins the bounded
+// budget: a persistently failing Harness must end in a truthful local state
+// instead of spinning forever.
+func TestRepeatedHarnessFailureExhaustsBoundedRetryAndStops(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: &harness.TurnTimeoutError{TimeoutMs: 120_000}}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 5*time.Second, func() bool {
+		return adapter.sessionsInt() == 1+maxTurnRetryAttempts && log.count("turn_retry_exhausted") == 1
+	}, "bounded retry budget consumed")
+
+	// No spinning: the clock is not re-armed for the same canonical turn.
+	time.Sleep(150 * time.Millisecond)
+	if got := adapter.sessionsInt(); got != 1+maxTurnRetryAttempts {
+		t.Fatalf("exhausted retry budget kept spinning: %d Harness turns", got)
+	}
+	if got := log.count("retry_scheduled"); got != maxTurnRetryAttempts {
+		t.Fatalf("retry_scheduled events = %d, want %d", got, maxTurnRetryAttempts)
+	}
+	if got := log.count("turn_retry_exhausted"); got != 1 {
+		t.Fatalf("expected exactly one turn_retry_exhausted event, got %d", got)
+	}
+	// A failed turn is never acknowledged, and the resident reports the
+	// truthful bounded local failure state.
+	if got := rt.pendingAddressedSnapshot(); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("exhausted failure acknowledged the pending turn: %v", got)
+	}
+	if got := rt.deliveredSeq(); got != 0 {
+		t.Fatalf("exhausted failure advanced deliveredThrough to %d", got)
+	}
+	status := rt.Status()
+	if status.LastError == "" || status.State != StateReconnecting {
+		t.Fatalf("exhausted retry did not end in a truthful local state: %+v", status)
+	}
+	if len(client.snapshotSent()) != 0 {
+		t.Fatalf("failed turns must never publish a reply: %v", client.snapshotSent())
+	}
+}
+
+// TestLaterRoomEventCannotResetTheRetryBudgetForTheSameTurn proves the budget
+// belongs to the canonical (scope, sequence) turn: later Room events may try
+// the pending turn again, but they can never grant a fresh autonomous retry
+// budget to the same still-pending turn.
+func TestLaterRoomEventCannotResetTheRetryBudgetForTheSameTurn(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("persistent ACP failure")}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 5*time.Second, func() bool {
+		return adapter.sessionsInt() == 1+maxTurnRetryAttempts
+	}, "bounded retry budget consumed")
+
+	// Two later Room envelopes carry only unaddressed events. Each one may
+	// re-enter the drain, but the same still-pending canonical turn gets no
+	// further autonomous retry clock.
+	stream.results <- addressedEnvelope(roomEvent(2, false))
+	stream.results <- addressedEnvelope(roomEvent(3, false))
+	waitFor(t, 3*time.Second, func() bool {
+		return adapter.sessionsInt() == 3+maxTurnRetryAttempts
+	}, "each later Room event attempts the pending turn at most once")
+	time.Sleep(150 * time.Millisecond)
+	if got := adapter.sessionsInt(); got != 3+maxTurnRetryAttempts {
+		t.Fatalf("a later Room event reset the retry budget: %d Harness turns", got)
+	}
+	if got := log.count("retry_scheduled"); got != maxTurnRetryAttempts {
+		t.Fatalf("later Room events re-armed the retry clock: %d retry_scheduled", got)
+	}
+
+	// The pinned canonical turn is still deliverable through its normal
+	// trigger path once the Harness recovers.
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+	stream.results <- addressedEnvelope(roomEvent(4, false))
+	waitFor(t, 3*time.Second, func() bool {
+		return len(rt.pendingAddressedSnapshot()) == 0 && rt.deliveredSeq() == 1 &&
+			len(client.snapshotSent()) == 1
+	}, "recovered Harness delivered the pinned canonical turn once")
+}
+
+// TestRetryAfterHarnessSessionReplacementRebootstrapsThePinnedDelta proves the
+// bounded retry keeps ACP generation semantics safe: when the failed turn's
+// recovery replaced the Harness session, the retry is a real session/new that
+// bootstraps with the same unacknowledged delta.
+func TestRetryAfterHarnessSessionReplacementRebootstrapsThePinnedDelta(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("transient ACP failure")}
+	var captured []types.HarnessTurnInput
+	originalHook := adapterRunTurnHook
+	adapterRunTurnHook = func(_ *fakeAdapter, input types.HarnessTurnInput) {
+		captured = append(captured, input)
+	}
+	defer func() { adapterRunTurnHook = originalHook }()
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	rt.turnRetryDelay = func(int) time.Duration { return 200 * time.Millisecond }
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 3*time.Second, func() bool {
+		return adapter.sessionsInt() == 1 && log.count("turn_failed") == 1
+	}, "first failed attempt")
+	// A timeout-recovery style replacement happens before the retry fires.
+	adapter.recreateSession()
+	adapter.mu.Lock()
+	adapter.turnErr = nil
+	adapter.mu.Unlock()
+
+	waitFor(t, 3*time.Second, func() bool {
+		return len(rt.pendingAddressedSnapshot()) == 0 && len(client.snapshotSent()) == 1
+	}, "retry delivered the pinned delta into the replacement session")
+	if len(captured) != 2 {
+		t.Fatalf("expected two Harness turns, got %d", len(captured))
+	}
+	if !captured[1].Session.New {
+		t.Fatalf("retry into a replaced session must re-bootstrap: %#v", captured[1].Session)
+	}
+	if len(captured[1].Events) != 1 || captured[1].Events[0].Sequence != 1 {
+		t.Fatalf("retry lost the pinned delta: %#v", captured[1].Events)
+	}
+}
+
+// TestTaskScopeRetryPreservesScopeAndCorrelation proves a Task-scoped turn
+// never falls back to Room scope and keeps its canonical request correlation.
+func TestTaskScopeRetryPreservesScopeAndCorrelation(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: &harness.TurnTimeoutError{TimeoutMs: 120_000}}
+	rt := newTurnRetryRuntime(t, adapter, client, silentLog)
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	request := scopedEvent(1, "task:request-T", "Build the Live View")
+	request.Type = "action"
+	request.Participant = types.ParticipantIdentity{ID: "human", Name: "Human", Kind: types.KindHuman}
+	request.Collab = &types.WireCollabEvent{
+		RequestID:           "request-T",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human",
+		TargetParticipantID: rt.currentParticipantID(),
+	}
+	stream.results <- addressedEnvelope(request)
+
+	waitFor(t, 5*time.Second, func() bool {
+		runs, _ := adapter.scopedRunSnapshot()
+		return len(runs) == 1+maxTurnRetryAttempts
+	}, "task-scope bounded retry budget consumed")
+
+	runs, details := adapter.scopedRunSnapshot()
+	if len(runs) != 1+maxTurnRetryAttempts {
+		t.Fatalf("unexpected task-scope run count: %v", runs)
+	}
+	for scope := range details {
+		if scope != "task:request-T" {
+			t.Fatalf("task retry changed logical scope: %q", scope)
+		}
+	}
+	if got := adapter.sessionsInt(); got != 0 {
+		t.Fatalf("task retry fell back to the Room conversation: %d room turns", got)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:request-T"); len(got) != 1 || got[0] != 1 {
+		t.Fatalf("failed task turn was acknowledged: %v", got)
+	}
+	responses := client.snapshotCollabResponses()
+	if len(responses) == 0 {
+		t.Fatal("task turn never published its canonical acceptance")
+	}
+	for _, response := range responses {
+		if response.RequestID != "request-T" {
+			t.Fatalf("task retry lost canonical request correlation: %+v", response)
+		}
+	}
+	if sent := client.snapshotSent(); len(sent) != 0 {
+		t.Fatalf("failed task turns must not publish a reply: %v", sent)
+	}
+}
+
+// TestSendFailureAfterCognitionDoesNotReplayHarnessTurn proves the
+// acknowledgement boundary: a send failure after a successful RunTurn must
+// never replay Harness cognition, and must not arm the retry clock.
+func TestSendFailureAfterCognitionDoesNotReplayHarnessTurn(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	client.fakeClient.sendFailuresRemaining = 1
+	adapter := &fakeAdapter{name: "pi"}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 3*time.Second, func() bool {
+		return adapter.sessionsInt() == 1 && log.count("turn_failed") == 1
+	}, "send failure recorded")
+	time.Sleep(150 * time.Millisecond)
+
+	if got := adapter.sessionsInt(); got != 1 {
+		t.Fatalf("send failure replayed Harness cognition: %d turns", got)
+	}
+	if got := log.count("retry_scheduled"); got != 0 {
+		t.Fatalf("send failure armed a cognition retry: %d retry_scheduled", got)
+	}
+	if got := log.count("turn_succeeded"); got != 1 {
+		t.Fatalf("successful cognition must still be recorded once, got %d", got)
+	}
+	if got := len(rt.pendingAddressedSnapshot()); got != 0 || rt.deliveredSeq() != 1 {
+		t.Fatalf("successful cognition was not acknowledged exactly once: pending=%d delivered=%d", got, rt.deliveredSeq())
+	}
+	failures := log.fieldsFor("turn_failed")
+	if len(failures) != 1 || failures[0]["failureClass"] != "send" {
+		t.Fatalf("send failure was not classified: %+v", failures)
+	}
+}
+
+// TestStopCancelsTheArmedTurnRetryClock proves stop/leave cancels the pending
+// retry cleanly instead of leaving a timer to fire after teardown.
+func TestStopCancelsTheArmedTurnRetryClock(t *testing.T) {
+	client, stream := newResidentTurnRetryClient(t)
+	adapter := &fakeAdapter{name: "pi", turnErr: errors.New("persistent ACP failure")}
+	rt := newTurnRetryRuntime(t, adapter, client, silentLog)
+	// A long delay keeps the clock armed and sleeping while Stop runs.
+	rt.turnRetryDelay = func(int) time.Duration { return 10 * time.Second }
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	stream.results <- addressedEnvelope(roomEvent(1, true))
+	waitFor(t, 3*time.Second, func() bool {
+		return adapter.sessionsInt() == 1
+	}, "first failed attempt")
+
+	stopped := make(chan struct{})
+	go func() {
+		rt.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop did not cancel the armed retry clock")
+	}
+	if got := adapter.sessionsInt(); got != 1 {
+		t.Fatalf("retry ran after stop: %d Harness turns", got)
+	}
+	if status := rt.Status(); status.State != StateStopped {
+		t.Fatalf("stopped runtime reported %q", status.State)
+	}
+}
+
+// TestTurnDiagnosticsAreBoundedAndSecretFree pins the #364 C contract: the
+// event sequence is locally reconstructable, every field is bounded, and no
+// log line carries Room text, prompt content, paths, credentials, or
+// participant/request identifiers.
+func TestTurnDiagnosticsAreBoundedAndSecretFree(t *testing.T) {
+	const messageSentinel = "SENTINEL-ROOM-MESSAGE-TEXT"
+	client, stream := newResidentTurnRetryClient(t)
+	attempts := 0
+	adapter := &fakeAdapter{name: "pi", turnErr: &harness.TurnTimeoutError{TimeoutMs: 120_000}}
+	// The scoped turn path uses the scoped hook; the first attempt fails with
+	// the ACP timeout and the retry succeeds.
+	adapter.scopedRunHook = func(string) {
+		attempts++
+		if attempts > 1 {
+			adapter.mu.Lock()
+			adapter.turnErr = nil
+			adapter.mu.Unlock()
+		}
+	}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, client, log.log)
+	if err := rt.Start(); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer rt.Stop()
+
+	event := scopedEvent(1, "task:request-SECRET", messageSentinel)
+	event.Type = "action"
+	event.Participant = types.ParticipantIdentity{ID: "human-SECRET", Name: "Ada-SECRET", Kind: types.KindHuman}
+	event.Collab = &types.WireCollabEvent{
+		RequestID:           "request-SECRET",
+		Kind:                types.CollabRequest,
+		FromParticipantID:   "human-SECRET",
+		TargetParticipantID: rt.currentParticipantID(),
+	}
+	stream.results <- addressedEnvelope(event)
+
+	waitFor(t, 5*time.Second, func() bool {
+		return log.count("turn_succeeded") == 1 && len(rt.pendingAddressedSnapshotFor("task:request-SECRET")) == 0
+	}, "timeout then successful retry")
+
+	events, fields := log.snapshot()
+	// The turn diagnostics are the bounded sequence this contract owns;
+	// unrelated pre-existing events (message_persisted) stay separate.
+	diagnosticEvents := map[string]bool{
+		"turn_started": true, "turn_failed": true, "turn_succeeded": true,
+		"retry_scheduled": true, "retry_started": true, "turn_retry_exhausted": true,
+		"turn_context_unavailable": true,
+	}
+	turnEvents := make([]string, 0, len(events))
+	turnFields := make([]map[string]string, 0, len(fields))
+	for index, event := range events {
+		if diagnosticEvents[event] {
+			turnEvents = append(turnEvents, event)
+			turnFields = append(turnFields, fields[index])
+		}
+	}
+	// Expected bounded sequence: started -> failed -> retry_scheduled ->
+	// retry_started -> started -> succeeded.
+	order := []string{"turn_started", "turn_failed", "retry_scheduled", "retry_started", "turn_started", "turn_succeeded"}
+	if len(turnEvents) != len(order) {
+		t.Fatalf("diagnostic sequence = %v, want %v", turnEvents, order)
+	}
+	for index, want := range order {
+		if turnEvents[index] != want {
+			t.Fatalf("diagnostic event %d = %q, want %q (%v)", index, turnEvents[index], want, turnEvents)
+		}
+	}
+
+	allowedClasses := map[string]bool{"timeout": true, "process": true, "session": true, "send": true, "other": true}
+	for index, field := range turnFields {
+		for key, value := range field {
+			switch key {
+			case "scopeKind":
+				if value != "room" && value != "task" {
+					t.Fatalf("%s has an out-of-vocabulary scopeKind %q", turnEvents[index], value)
+				}
+			case "failureClass":
+				if !allowedClasses[value] {
+					t.Fatalf("%s has an out-of-vocabulary failureClass %q", turnEvents[index], value)
+				}
+			case "retryAttempt":
+				attempt, err := strconv.Atoi(value)
+				if err != nil || attempt < 0 || attempt > maxTurnRetryAttempts {
+					t.Fatalf("%s has an unbounded retryAttempt %q", turnEvents[index], value)
+				}
+			case "retryDelayMs":
+				delay, err := strconv.Atoi(value)
+				if err != nil || delay < 0 || delay > 10_000 {
+					t.Fatalf("%s has an unbounded retryDelayMs %q", turnEvents[index], value)
+				}
+			case "elapsedMs":
+				elapsed, err := strconv.Atoi(value)
+				if err != nil || elapsed < 0 || elapsed > 600_000 {
+					t.Fatalf("%s has an unbounded elapsedMs %q", turnEvents[index], value)
+				}
+			default:
+				t.Fatalf("%s logged unexpected field %q", turnEvents[index], key)
+			}
+		}
+	}
+	if turnFields[1]["failureClass"] != turnFailureTimeout {
+		t.Fatalf("ACP turn timeout was not classified explicitly: %+v", turnFields[1])
+	}
+	if turnFields[1]["scopeKind"] != "task" {
+		t.Fatalf("task scope kind was not reported: %+v", turnFields[1])
+	}
+	if turnFields[2]["retryAttempt"] != "1" || turnFields[3]["retryAttempt"] != "1" {
+		t.Fatalf("retry accounting mismatch: %+v %+v", turnFields[2], turnFields[3])
+	}
+
+	// No work content, path, credential, or identifier may appear anywhere.
+	dump := diagnosticDump(t, events, fields)
+	for _, secret := range []string{
+		messageSentinel, "SECRET", "request-SECRET", "human-SECRET", "Ada-SECRET",
+		"secret", "task:request", "/Users/", "participantHandle",
+	} {
+		if strings.Contains(dump, secret) {
+			t.Fatalf("diagnostics leaked %q:\n%s", secret, dump)
+		}
+	}
+}
+
+func diagnosticDump(t *testing.T, events []string, fields []map[string]string) string {
+	t.Helper()
+	var builder strings.Builder
+	for index, event := range events {
+		builder.WriteString(event)
+		for key, value := range fields[index] {
+			builder.WriteString(" " + key + "=" + value)
+		}
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+// TestTurnFailureClassesAreBounded pins the stable classification vocabulary.
+func TestTurnFailureClassesAreBounded(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"timeout", &harness.TurnTimeoutError{TimeoutMs: 120_000}, turnFailureTimeout},
+		{"wrapped timeout", fmt.Errorf("outer: %w", &harness.TurnTimeoutError{TimeoutMs: 120_000}), turnFailureTimeout},
+		{"process", &harness.ProcessError{Err: errors.New("ACP process exited")}, turnFailureProcess},
+		{"wrapped process", fmt.Errorf("outer: %w", &harness.ProcessError{Err: errors.New("ACP process exited")}), turnFailureProcess},
+		{"session", types.ErrHarnessSessionGenerationChanged, turnFailureSession},
+		{"scoped session", errScopedHarnessUnsupported, turnFailureSession},
+		{"other", errors.New("ambiguous"), turnFailureOther},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := turnFailureClassOf(testCase.err); got != testCase.want {
+				t.Fatalf("turnFailureClassOf(%v) = %q, want %q", testCase.err, got, testCase.want)
+			}
+		})
+	}
+	if !permanentTurnFailure(errScopedHarnessUnsupported) {
+		t.Fatal("a legacy adapter that cannot serve a task scope must not be retried")
+	}
+	if permanentTurnFailure(&harness.TurnTimeoutError{TimeoutMs: 1}) {
+		t.Fatal("a transient timeout must stay retryable")
+	}
+}
+
+// TestLegacyAdapterTaskScopeDoesNotArmTheRetryClock keeps the bounded retry
+// from retrying a deterministic misconfiguration.
+func TestLegacyAdapterTaskScopeDoesNotArmTheRetryClock(t *testing.T) {
+	adapter := &legacyOnlyAdapter{}
+	log := &turnLogRecorder{}
+	rt := newTurnRetryRuntime(t, adapter, &fakeClient{}, log.log)
+	rt.adoptJoin(types.JoinResult{ParticipantID: "agent", ParticipantHandle: "secret", Cursor: 0})
+	rt.acceptEvent(scopedEvent(1, "task:T", "T1"))
+	rt.drainTurns()
+	if got := log.count("retry_scheduled"); got != 0 {
+		t.Fatalf("permanent misconfiguration armed %d retries", got)
+	}
+	if got := log.count("turn_retry_exhausted"); got != 0 {
+		t.Fatalf("permanent misconfiguration reported a retry budget: %d", got)
+	}
+	if got := rt.pendingAddressedSnapshotFor("task:T"); len(got) != 1 {
+		t.Fatalf("unretryable task turn was acknowledged: %v", got)
+	}
+}


### PR DESCRIPTION
Implements #364: **runtime turn recovery** — bounded retry for an ambiguous turn, plus honest reporting instead of silent loss. `Refs #364`.

**Base:** `93b2f0b91a96fa493ffc55a3f9a09e2b941e0eb2` (`cf-sfu`)
**Head:** `661df9eec0c16c718ddd1c20fb0c82752d983305` — 12 files, +2327 / −113

All changes are inside `agent/**`. Two review rounds are folded in below.

## Defect

`RunTurn` success is the **only** acknowledgement boundary. A turn that fails or is ambiguous after the prompt was already delivered to the Harness stayed unacknowledged (`pendingAddressed`, `deliveredThrough`) and the next `drainTurns` simply re-read the same Room state — so an ambiguous turn was either lost forever or re-delivered unpredictably, with the Human given no truthful signal.

## What changed

**A. Bounded retry.** `maxTurnRetryAttempts = 2` (**3 attempts total**, never more), `RetryDelay` 1s → 2s. Only *transient* failures retry: transport/send, session/Harness-process replacement, and timeout. Permanent failures (validation, `agent_error`, cancelled, conflict) do not. The timeout stays at the existing **120 s** `defaultTurnTimeoutMs`.

**B. Truthful terminal reporting.** A turn that exhausts its attempts becomes a **parked** scope, reported through the existing bounded diagnostics vocabulary (`scopeKind`, `failureClass` ∈ `timeout|process|session|send|other`, `elapsedMs`, `retryAttempt`, `retryDelayMs`). The Room scope never falls back to Task scope or vice versa, and the diagnostics carry no Human content.

**C. Parked scope is inert until re-addressed.** `closedTurnRecovery map[canonicalTurnKey]struct{}`; `nextRunnableTurn()` skips parked scopes so unrelated Room traffic can **never** re-execute them, parked scopes do not block other scopes, and re-arming happens only through a newly accepted addressed trigger for that same scope (`reopenTurnRecoveryLocked`).

**D. State.** An exhausted turn no longer leaves the Agent in `StateReconnecting`; a parked scope reports the honest waiting state.

### Review round 2 — `adoptJoin` falsy-vs-nil (this is the narrow blocker that was outstanding)

`closedTurnRecovery` was tested for **non-nilness**, not for **content**:

```go
// before
if r.closedTurnRecovery != nil { ... }   // any allocated-but-empty map ⇒ false "reconnecting"
// after
if r.unresolvedTurnFailureLocked() { ... }
```

An empty-but-non-nil `closedTurnRecovery` (trivially reachable via `reopenTurnRecoveryLocked` deleting the last entry, or a map allocated for a scope that then succeeded) made a **rejoin** report `connecting`/`reconnecting` when nothing was actually unresolved. `unresolvedTurnFailureLocked()` is now the single truthful-state predicate, used by all three consumers — the `drainTurns` deferred restore, `restoreStateAfterRetry`, and `adoptJoin` — so state derivation can no longer disagree with itself. Regression test `TestExplicitReAddressThenSuccessLeavesNoStaleClosedRecovery`, confirmed to fail against the old predicate (`turn_retry_test.go:534: transport rejoin after recovery reported State:reconnecting, want waiting`).

### Adjacent fixes in the same invariant

- **`live-view describe` shares the validator's vocabulary.** `liveViewComponentFields`, `liveViewComponentRequiredFields`, `liveViewActionTypes`, `liveViewActionFields`, `minLiveViewRevision`, and `liveViewIncrementBound` are now used by both `validateTaskLiveViewJSON` and the CLI, so `describe` can no longer advertise a field the validator rejects. Limits unchanged: 32 KB JSON, 64 components, depth 8, 32 data keys, 400-char text, 80-char labels, increment ±1000.
- **`voiceOutput()` `mediaMu` race** kept as previously fixed.
- **ACP/prompt handling** in `harness/` aligned with the same session-replacement semantics.

## Tests

`turn_retry_test.go` plus `runtime`, `cli`, `harness` coverage: bounded attempt count is asserted exactly (never a 4th attempt), permanent failures do not retry, timeout classification, exhausted turn parks and is **not** re-executed by unrelated Room events, parked scope does not block other scopes, only an accepted addressed trigger re-arms, success-only acknowledgement, and the round-2 regression above. `-race` clean on `internal/runtime` and `internal/voice`.

## Validation (re-run on this head)

| Command | Result |
|---|---|
| `gofmt -l .` | clean |
| `go vet ./...` | clean |
| `go test ./... -count=1` | **12 packages pass** |
| `go test -race ./internal/voice ./internal/runtime` | pass |
| `go build ./cmd/free4chat-agent` | pass |
| `agent/scripts/check-cleanup.sh` | pass |
| `git diff --check` | clean |
| CI | gofmt/vet/test/build, Distribution/cleanup, 4 platform builds all **pass** |

## Non-goals honoured

No scheduler, background goroutine, or busy loop; no unbounded retry; no change to the 120 s timeout; no Human content in diagnostics; no cross-scope fallback; no production version pin or release change; no `app/**` change.

## Remaining concerns

- `lastError` is a single global slot: a later transport error can replace a parked turn's error text while the state correctly remains a waiting state. The **state** is already truthful; making the text per-scope is a follow-up.
- A parked scope waits for an addressed trigger for that scope — deliberate FIFO, but it means a Human must re-address rather than the Runtime self-healing.
- Harness session/process replacement does not by itself re-arm a parked turn; only a new addressed trigger does.
- `harnessFailed` is never set to `true` — dead field, cosmetic.

## Dogfood

Production Pi fresh-resident dogfood is required after merge/release, and #364 should stay open until it passes; that is a post-merge step, not a code blocker.

Not merged — leaving the merge decision to review.
