### PR TITLE
chore(agent): bump Runtime to 0.5.33

### DIFF
--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.32"
+var Version = "0.5.33"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"


### PR DESCRIPTION
Canonical **source version bump only**: `agent/internal/doctor/doctor.go`

```diff
-var Version = "0.5.32"
+var Version = "0.5.33"
```

**Base:** `3c2894a340464757021773788545f9809fa43003` (`cf-sfu`)
**Head:** `53df546192e1397bac34ae95e856843d4ab655a5` — 1 file, +1 / −1

## Why this PR is deliberately this small

This is step 1 of the canonical release sequence:

```text
1. source-version PR            ← this PR
2. verified native GitHub Release (agent-v0.5.33)
3. live bootstrap / docs activation PR
```

This PR intentionally does **not** touch:

- `app/public/agent.md`
- generated `app/public/llms-full.txt`
- the public bootstrap version pin (`expected_version="0.5.32"`)

Reason: a fresh Invite/bootstrap must not request `0.5.33` until the native
GitHub Release for `agent-v0.5.33` actually exists and has been verified.
Activation happens only in step 3, after the release assets are checksum- and
binary-verified.

This staged rollout is an explicitly supported contract, not an oversight —
`agent/scripts/test-bootstrap-contract.sh` asserts it:

```text
PASS: source and live bootstrap versions may be staged independently
PASS: source version can lead live bootstrap activation
```

## Preconditions verified before opening

| Check | Result |
|---|---|
| latest GitHub Agent release | `agent-v0.5.32` (still latest) |
| source `Version` at `cf-sfu` | `0.5.32` |
| live bootstrap pin in `app/public/agent.md` | `0.5.32` (×2 occurrences) |
| `agent-v0.5.33` tag/release pre-existing | no — does not exist |

## Validation (rerun on this head)

| Command | Result |
|---|---|
| `gofmt -l .` | clean |
| `go vet ./...` | pass |
| `go test ./... -count=1` | 12 packages pass |
| `go test -race ./internal/voice ./internal/runtime` | pass |
| `go build ./cmd/free4chat-agent` | pass |
| `bash scripts/test-install-agent.sh` | 19 passed, 0 failed |
| `bash scripts/test-bootstrap-contract.sh` | OK (staged-version contract asserted) |
| `git diff --check` | clean |

The built binary reports the new version:

```json
{ "version": "0.5.33" }
```

## No behavior change

`Version` is a build-overridable `var` that release builds already inject via
`-ldflags -X .../internal/doctor.Version=<tag>`. This bump only aligns the
default with the next release line. No Runtime, SFU, Room, Task, or Live View
behavior changes.

## Next steps

1. Merge this PR after green CI.
2. Tag `agent-v0.5.33` **at the merge commit** and let the Agent Release workflow publish and verify the five assets.
3. Open the single docs/activation PR (bootstrap pin → `0.5.33`, document `live-view describe --json`, document Human Task attachments) and merge it after its green CI and after the production deploy.
