### PR TITLE
ux(room): put active Room Apps on the visual Stage (#367)

### DIFF
--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1290,6 +1290,58 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect(screen.getAllByTestId("room-app-iframe")).toHaveLength(1)
     })
 
+    it("offers Screen while an App is open even without a Task Live View", async () => {
+      renderAppRoom({
+        resolvedRoomType: "screenshare",
+        participants: [
+          {
+            peerId: "local-peer",
+            name: "Alice",
+            kind: "human",
+            room: "test-room",
+            muteState: false,
+            screenShareEnabled: false,
+            screenShareStream: null,
+          },
+          {
+            peerId: "publisher-a",
+            name: "Bob",
+            kind: "human",
+            room: "test-room",
+            screenShareEnabled: true,
+            screenShareStream: {} as MediaStream,
+          },
+        ],
+      })
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(await screen.findByTestId("room-app-host")).toBeInTheDocument()
+      expect(screen.queryByTestId("stage-view-live-view")).toBeNull()
+
+      // Screen is a Stage surface in its own right: it must stay reachable
+      // while an App is open, with no Live View sharing the switcher.
+      fireEvent.click(screen.getByTestId("stage-view-screen"))
+      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(document.querySelector("video")).toBeInTheDocument()
+    })
+
+    it("offers Live View while an App is open even without a screen share", async () => {
+      renderAppRoom({
+        messages: [taskRequestMessage],
+        taskLiveViews: { "task-live": taskLiveViewSnapshot },
+      })
+
+      fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      expect(await screen.findByTestId("room-app-host")).toBeInTheDocument()
+      expect(screen.queryByTestId("stage-view-screen")).toBeNull()
+
+      // Live View is likewise reachable on its own availability.
+      fireEvent.click(screen.getByTestId("stage-view-live-view"))
+      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(screen.getByTestId("task-live-view")).toBeInTheDocument()
+    })
+
     it("leaves the App when the Stage switches back to Screen or Live View", async () => {
       renderAppRoom({
         resolvedRoomType: "screenshare",

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -96,6 +96,43 @@ const baseHookReturn = {
 
 const LATE_JOIN_EXPIRY = Date.now() + 365 * 24 * 60 * 60 * 1000
 
+// Shared fixtures for the Room App Stage tests: one Task conversation and its
+// bounded Live View surface.
+const taskRequestMessage: Message = {
+  peerId: "local-peer",
+  name: "Alice",
+  kind: "human",
+  type: "action",
+  actionType: "collab",
+  sequence: 1,
+  collab: {
+    requestId: "task-live",
+    kind: "request",
+    fromParticipantId: "local-peer",
+    targetParticipantId: "agent-a",
+    summary: "Counter",
+  },
+}
+
+const taskLiveViewSnapshot = {
+  taskRequestId: "task-live",
+  surfaceId: "counter",
+  authorityAgentId: "agent-a",
+  revision: 1,
+  root: {
+    type: "Column",
+    children: [
+      { type: "Text", text: "Count" },
+      {
+        type: "Button",
+        label: "+1",
+        action: { type: "increment", path: "count", amount: 1 },
+      },
+    ],
+  },
+  data: { count: 0 },
+}
+
 function lateJoinRoom(): RoomRecord {
   return {
     createdAt: 1,
@@ -228,6 +265,7 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
 
   afterEach(() => {
     delete (window as { turnstile?: unknown }).turnstile
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -1088,32 +1126,216 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
   })
 
-  it("keeps a selected Room App tab mounted instead of treating it as a stale Task", async () => {
-    mockUseSfuChatRoom.mockReturnValue({
-      ...baseHookReturn,
-      connectionStatus: "connected",
-      roomAppsEnabled: true,
-      participants: [
-        {
-          peerId: "local-peer",
-          name: "Alice",
-          kind: "human",
-          room: "test-room",
-          muteState: false,
-        },
-      ],
+  describe("Room App Stage placement", () => {
+    class TestPort {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      postMessage = vi.fn()
+      start = vi.fn()
+      close = vi.fn()
+    }
+
+    let channels: { port1: TestPort; port2: TestPort }[] = []
+
+    class TestMessageChannel {
+      port1 = new TestPort()
+      port2 = new TestPort()
+
+      constructor() {
+        channels.push(this)
+      }
+    }
+
+    function renderAppRoom(overrides: Record<string, unknown> = {}) {
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [
+          {
+            peerId: "local-peer",
+            name: "Alice",
+            kind: "human",
+            room: "test-room",
+            muteState: false,
+          },
+        ],
+        ...overrides,
+      })
+      return render(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+    }
+
+    /** Loads an App iframe so the host really opens its MessagePort. */
+    function loadAppIframe(iframe: HTMLIFrameElement) {
+      const frameWindow = { postMessage: vi.fn() }
+      Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+      fireEvent.load(iframe)
+      return frameWindow
+    }
+
+    beforeEach(() => {
+      channels = []
+      vi.stubGlobal("MessageChannel", TestMessageChannel)
     })
 
-    render(
-      <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
-    )
+    it("mounts the active Room App on the visual Stage while the Room conversation stays", async () => {
+      renderAppRoom()
 
-    const appTab = screen.getByTestId("interaction-tab-app-shared-canvas")
-    fireEvent.click(appTab)
-    expect(appTab).toHaveAttribute("aria-selected", "true")
-    await waitFor(() =>
+      // Conversation scope starts on Room; the Stage starts on participants.
+      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+
+      const host = await screen.findByTestId("room-app-host")
+      const stage = screen.getByTestId("room-stage")
+      expect(stage.contains(host)).toBe(true)
+      // The App is Stage content, never conversation content: the same
+      // structure keeps it out of the stacked mobile conversation pane.
+      expect(host.closest(".room-participants-panel")).not.toBeNull()
+      expect(host.closest(".room-chat-panel")).toBeNull()
+      expect(screen.getByTestId("interaction-chat").contains(host)).toBe(false)
+      // A Room App is a large visual surface, like screen share.
+      expect(stage).toHaveStyle({ width: "75%" })
+
+      // Room conversation remains selected and rendered beside the App.
+      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+      expect(
+        screen.getByPlaceholderText("Message the room or @ an Agent…")
+      ).toBeInTheDocument()
+
+      const iframe = screen.getByTestId("room-app-iframe")
+      expect(iframe).toHaveAttribute(
+        "src",
+        expect.stringContaining("/shared-canvas")
+      )
+      expect(iframe).toHaveAttribute("sandbox", "allow-scripts")
+    })
+
+    it("closes the Room App back to the participant Stage", async () => {
+      renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      const host = await screen.findByTestId("room-app-host")
+      expect(screen.getByTestId("room-app-iframe")).toHaveAttribute(
+        "src",
+        expect.stringContaining("/tiny-arena")
+      )
+
+      fireEvent.click(within(host).getByRole("button", { name: "Close" }))
+
+      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
+      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+
+    it("keeps the App open while the conversation switches between Room and Task", async () => {
+      renderAppRoom({ messages: [taskRequestMessage] })
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const host = await screen.findByTestId("room-app-host")
+
+      fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
+      expect(
+        screen.getByTestId("interaction-tab-task-task-live")
+      ).toHaveAttribute("aria-selected", "true")
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+
+      fireEvent.click(screen.getByTestId("interaction-tab-room"))
+      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(
+        screen.getByPlaceholderText("Message the room or @ an Agent…")
+      ).toBeInTheDocument()
+    })
+
+    it("switches Canvas to Arena without a duplicate iframe or MessagePort", async () => {
+      renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const canvasIframe = screen.getByTestId(
+        "room-app-iframe"
+      ) as HTMLIFrameElement
+      loadAppIframe(canvasIframe)
+      expect(channels).toHaveLength(1)
+      const canvasPort = channels[0].port1
+
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+
+      const iframes = screen.getAllByTestId("room-app-iframe")
+      expect(iframes).toHaveLength(1)
+      // A clean unmount/remount, not one iframe re-pointed at a second App.
+      expect(iframes[0]).not.toBe(canvasIframe)
+      expect(iframes[0]).toHaveAttribute(
+        "src",
+        expect.stringContaining("/tiny-arena")
+      )
+      expect(canvasPort.close).toHaveBeenCalled()
+
+      loadAppIframe(iframes[0] as HTMLIFrameElement)
+      expect(channels).toHaveLength(2)
+      expect(screen.getAllByTestId("room-app-iframe")).toHaveLength(1)
+    })
+
+    it("leaves the App when the Stage switches back to Screen or Live View", async () => {
+      renderAppRoom({
+        resolvedRoomType: "screenshare",
+        messages: [taskRequestMessage],
+        participants: [
+          {
+            peerId: "local-peer",
+            name: "Alice",
+            kind: "human",
+            room: "test-room",
+            muteState: false,
+            screenShareEnabled: false,
+            screenShareStream: null,
+          },
+          {
+            peerId: "publisher-a",
+            name: "Bob",
+            kind: "human",
+            room: "test-room",
+            screenShareEnabled: true,
+            screenShareStream: {} as MediaStream,
+          },
+        ],
+        taskLiveViews: { "task-live": taskLiveViewSnapshot },
+      })
+
+      // The Task Live View is the selected Task's surface, as before.
+      fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(await screen.findByTestId("room-app-host")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId("stage-view-live-view"))
+      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(screen.getByTestId("task-live-view")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
       expect(screen.getByTestId("room-app-host")).toBeInTheDocument()
-    )
+
+      fireEvent.click(screen.getByTestId("stage-view-screen"))
+      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(document.querySelector("video")).toBeInTheDocument()
+      // The Task conversation scope is untouched by Stage switching.
+      expect(
+        screen.getByTestId("interaction-tab-task-task-live")
+      ).toHaveAttribute("aria-selected", "true")
+    })
   })
 
   it("uses the intentional two-row mobile header layout with a truncating Room id", () => {
@@ -1402,7 +1624,7 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     )
     vi.mocked(trackAnalyticsEvent).mockClear()
     fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
-    expect(screen.getByTestId("task-live-view-switcher")).toBeInTheDocument()
+    expect(screen.getByTestId("stage-switcher")).toBeInTheDocument()
     expect(screen.queryByTestId("task-live-view")).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "Live View" }))
     expect(screen.getByTestId("task-live-view")).toBeInTheDocument()

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -920,10 +920,13 @@ export default function RoomContent({
           <div className="relative flex flex-1 flex-col overflow-hidden">
             {/* The Stage entry: curated Room Apps plus the existing Screen /
                 Live View preference. Stage selection is independent from the
-                conversation scope selected in the right pane. */}
+                conversation scope selected in the right pane, and each Stage
+                choice appears on its own availability — a Room App is a third
+                Stage surface, so Screen no longer requires a Live View (and
+                the reverse) to be offered. */}
             {(roomApps.length > 0 ||
-              (activeScreenShares.length > 0 &&
-                Boolean(activeTaskLiveView))) && (
+              activeScreenShares.length > 0 ||
+              Boolean(activeTaskLiveView)) && (
               <div
                 role="tablist"
                 aria-label="Stage"
@@ -951,41 +954,41 @@ export default function RoomContent({
                     </button>
                   )
                 })}
-                {activeScreenShares.length > 0 && activeTaskLiveView && (
-                  <>
-                    <button
-                      type="button"
-                      data-testid="stage-view-screen"
-                      onClick={() => {
-                        setStageView("screen")
-                        setActiveRoomAppId(null)
-                      }}
-                      aria-pressed={stageView === "screen" && !activeRoomApp}
-                      className={`shrink-0 rounded px-2 py-1 text-xs ${
-                        stageView === "screen" && !activeRoomApp
-                          ? "bg-blue-600 text-white"
-                          : "text-gray-400 hover:bg-gray-800"
-                      }`}
-                    >
-                      Screen
-                    </button>
-                    <button
-                      type="button"
-                      data-testid="stage-view-live-view"
-                      onClick={() => {
-                        setStageView("live-view")
-                        setActiveRoomAppId(null)
-                      }}
-                      aria-pressed={stageView === "live-view" && !activeRoomApp}
-                      className={`shrink-0 rounded px-2 py-1 text-xs ${
-                        stageView === "live-view" && !activeRoomApp
-                          ? "bg-blue-600 text-white"
-                          : "text-gray-400 hover:bg-gray-800"
-                      }`}
-                    >
-                      Live View
-                    </button>
-                  </>
+                {activeScreenShares.length > 0 && (
+                  <button
+                    type="button"
+                    data-testid="stage-view-screen"
+                    onClick={() => {
+                      setStageView("screen")
+                      setActiveRoomAppId(null)
+                    }}
+                    aria-pressed={stageView === "screen" && !activeRoomApp}
+                    className={`shrink-0 rounded px-2 py-1 text-xs ${
+                      stageView === "screen" && !activeRoomApp
+                        ? "bg-blue-600 text-white"
+                        : "text-gray-400 hover:bg-gray-800"
+                    }`}
+                  >
+                    Screen
+                  </button>
+                )}
+                {activeTaskLiveView && (
+                  <button
+                    type="button"
+                    data-testid="stage-view-live-view"
+                    onClick={() => {
+                      setStageView("live-view")
+                      setActiveRoomAppId(null)
+                    }}
+                    aria-pressed={stageView === "live-view" && !activeRoomApp}
+                    className={`shrink-0 rounded px-2 py-1 text-xs ${
+                      stageView === "live-view" && !activeRoomApp
+                        ? "bg-blue-600 text-white"
+                        : "text-gray-400 hover:bg-gray-800"
+                    }`}
+                  >
+                    Live View
+                  </button>
                 )}
               </div>
             )}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -223,9 +223,9 @@ export default function RoomContent({
         : [],
     [roomAppsEnabled]
   )
-  const activeRoomApp = roomApps.find(
-    (app) => activeRoomAppId === app.id && activeInteraction === `app:${app.id}`
-  )
+  // Conversation scope and visual Stage are independent selections: an active
+  // Room App lives on the Stage and never replaces the Room/Task conversation.
+  const activeRoomApp = roomApps.find((app) => activeRoomAppId === app.id)
   const roomAppParticipants = projectRoomAppParticipants(
     participants.map((participant) => ({
       participantId:
@@ -331,27 +331,21 @@ export default function RoomContent({
   }, [activeInteraction, effectiveLocalParticipantId, taskProjections])
 
   useEffect(() => {
-    const isRoomAppInteraction =
-      activeInteraction.startsWith("app:") &&
-      roomApps.some((app) => activeInteraction === `app:${app.id}`)
+    // A conversation scope is only ever "room" or a known Task. The Stage
+    // selection (screen share, Live View, Room App) is stored separately.
     if (
       activeInteraction !== "room" &&
-      !taskProjections.some((task) => task.requestId === activeInteraction) &&
-      !isRoomAppInteraction
+      !taskProjections.some((task) => task.requestId === activeInteraction)
     )
       setActiveInteraction("room")
-  }, [activeInteraction, roomApps, taskProjections])
+  }, [activeInteraction, taskProjections])
 
   useEffect(() => {
-    if (
-      activeRoomAppId &&
-      (!roomApps.some((app) => app.id === activeRoomAppId) ||
-        activeInteraction !== `app:${activeRoomAppId}`)
-    ) {
+    // Only catalog availability controls an open App; changing the conversation
+    // scope or the Stage view must not tear down its iframe/MessagePort.
+    if (activeRoomAppId && !roomApps.some((app) => app.id === activeRoomAppId))
       setActiveRoomAppId(null)
-      if (activeInteraction.startsWith("app:")) setActiveInteraction("room")
-    }
-  }, [activeInteraction, activeRoomAppId, roomApps])
+  }, [activeRoomAppId, roomApps])
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
@@ -458,9 +452,11 @@ export default function RoomContent({
   }, [])
 
   useEffect(() => {
-    setSplitRatio(activeScreenShares.length > 0 ? 75 : 50)
+    // A Room App is a large visual surface like screen share, so it gets the
+    // wide Stage rather than a conversation-sized pane.
+    setSplitRatio(activeScreenShares.length > 0 || activeRoomApp ? 75 : 50)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeScreenShares.length > 0])
+  }, [activeScreenShares.length > 0, Boolean(activeRoomApp)])
 
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
@@ -911,6 +907,7 @@ export default function RoomContent({
         className="room-content flex flex-1 flex-col overflow-hidden md:flex-row"
       >
         <div
+          data-testid="room-stage"
           className="room-panel room-participants-panel flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
@@ -921,38 +918,91 @@ export default function RoomContent({
             getLocalRoomAuth={getLocalRoomAuth}
           />
           <div className="relative flex flex-1 flex-col overflow-hidden">
-            {activeScreenShares.length > 0 && activeTaskLiveView && (
+            {/* The Stage entry: curated Room Apps plus the existing Screen /
+                Live View preference. Stage selection is independent from the
+                conversation scope selected in the right pane. */}
+            {(roomApps.length > 0 ||
+              (activeScreenShares.length > 0 &&
+                Boolean(activeTaskLiveView))) && (
               <div
-                data-testid="task-live-view-switcher"
-                className="z-10 flex flex-none gap-1 border-b border-gray-800 bg-gray-950/80 p-2"
+                role="tablist"
+                aria-label="Stage"
+                data-testid="stage-switcher"
+                className="scrollbar-thin z-10 flex flex-none gap-1 overflow-x-auto border-b border-gray-800 bg-gray-950/80 p-2"
               >
-                <button
-                  type="button"
-                  onClick={() => setStageView("screen")}
-                  aria-pressed={stageView === "screen"}
-                  className={`rounded px-2 py-1 text-xs ${
-                    stageView === "screen"
-                      ? "bg-blue-600 text-white"
-                      : "text-gray-400 hover:bg-gray-800"
-                  }`}
-                >
-                  Screen
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setStageView("live-view")}
-                  aria-pressed={stageView === "live-view"}
-                  className={`rounded px-2 py-1 text-xs ${
-                    stageView === "live-view"
-                      ? "bg-blue-600 text-white"
-                      : "text-gray-400 hover:bg-gray-800"
-                  }`}
-                >
-                  Live View
-                </button>
+                {roomApps.map((app) => {
+                  const selected = activeRoomAppId === app.id
+                  return (
+                    <button
+                      key={app.id}
+                      type="button"
+                      aria-pressed={selected}
+                      data-testid={`stage-app-${app.id}`}
+                      onClick={() =>
+                        setActiveRoomAppId(selected ? null : app.id)
+                      }
+                      className={`shrink-0 rounded px-2 py-1 text-xs ${
+                        selected
+                          ? "bg-blue-600 text-white"
+                          : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
+                      }`}
+                    >
+                      {app.label}
+                    </button>
+                  )
+                })}
+                {activeScreenShares.length > 0 && activeTaskLiveView && (
+                  <>
+                    <button
+                      type="button"
+                      data-testid="stage-view-screen"
+                      onClick={() => {
+                        setStageView("screen")
+                        setActiveRoomAppId(null)
+                      }}
+                      aria-pressed={stageView === "screen" && !activeRoomApp}
+                      className={`shrink-0 rounded px-2 py-1 text-xs ${
+                        stageView === "screen" && !activeRoomApp
+                          ? "bg-blue-600 text-white"
+                          : "text-gray-400 hover:bg-gray-800"
+                      }`}
+                    >
+                      Screen
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="stage-view-live-view"
+                      onClick={() => {
+                        setStageView("live-view")
+                        setActiveRoomAppId(null)
+                      }}
+                      aria-pressed={stageView === "live-view" && !activeRoomApp}
+                      className={`shrink-0 rounded px-2 py-1 text-xs ${
+                        stageView === "live-view" && !activeRoomApp
+                          ? "bg-blue-600 text-white"
+                          : "text-gray-400 hover:bg-gray-800"
+                      }`}
+                    >
+                      Live View
+                    </button>
+                  </>
+                )}
               </div>
             )}
-            {activeScreenShares.length > 0 ? (
+            {activeRoomApp && roomAppSelf ? (
+              // Keyed per App: switching Apps unmounts the previous host, which
+              // closes its MessagePort, instead of reusing one iframe/instance.
+              <RoomAppHost
+                key={activeRoomApp.id}
+                app={activeRoomApp}
+                appInstanceId={roomAppInstanceId(roomName, activeRoomApp.id)}
+                self={roomAppSelf}
+                participants={roomAppParticipants}
+                subscribe={subscribeRoomAppMessages}
+                send={sendRoomAppMessage}
+                onClose={() => setActiveRoomAppId(null)}
+              />
+            ) : activeScreenShares.length > 0 ? (
               <>
                 <div
                   className={
@@ -1034,7 +1084,10 @@ export default function RoomContent({
                 onInteract={handleLiveViewInteracted}
               />
             ) : (
-              <div className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start justify-center gap-2 overflow-y-auto p-3">
+              <div
+                data-testid="room-stage-participants"
+                className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start justify-center gap-2 overflow-y-auto p-3"
+              >
                 {participants.map((p) => (
                   <div
                     key={p.peerId}
@@ -1146,26 +1199,6 @@ export default function RoomContent({
                 )}
               </button>
             ))}
-            {roomApps.map((app) => (
-              <button
-                key={app.id}
-                type="button"
-                role="tab"
-                aria-selected={activeInteraction === `app:${app.id}`}
-                data-testid={`interaction-tab-app-${app.id}`}
-                onClick={() => {
-                  setActiveRoomAppId(app.id)
-                  setActiveInteraction(`app:${app.id}`)
-                }}
-                className={`flex max-w-52 shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition ${
-                  activeInteraction === `app:${app.id}`
-                    ? "bg-blue-600 text-white"
-                    : "text-gray-400 hover:bg-gray-800 hover:text-gray-200"
-                }`}
-              >
-                <span className="truncate">{app.label}</span>
-              </button>
-            ))}
           </div>
           <div
             data-testid="interaction-content"
@@ -1190,42 +1223,29 @@ export default function RoomContent({
                 })}
               </div>
             )}
+            {/* The conversation pane always renders the selected Room/Task
+                conversation; an active Room App lives on the Stage instead. */}
             <div data-testid="interaction-chat" className="min-h-0 flex-1">
-              {activeRoomApp && roomAppSelf ? (
-                <RoomAppHost
-                  app={activeRoomApp}
-                  appInstanceId={roomAppInstanceId(roomName, activeRoomApp.id)}
-                  self={roomAppSelf}
-                  participants={roomAppParticipants}
-                  subscribe={subscribeRoomAppMessages}
-                  send={sendRoomAppMessage}
-                  onClose={() => {
-                    setActiveRoomAppId(null)
-                    setActiveInteraction("room")
-                  }}
-                />
-              ) : (
-                <TextChatCard
-                  key={activeInteraction}
-                  room={roomName}
-                  nickName={nickName}
-                  messages={interactionMessages}
-                  attachments={interactionAttachments}
-                  participants={participants}
-                  pendingFiles={activeTask ? [] : pendingFiles}
-                  onSendText={wrappedSendText}
-                  onSendFile={wrappedSendFile}
-                  onSendTaskFile={wrappedSendTaskFile}
-                  onSendAction={sendActionMessage}
-                  localParticipantId={effectiveLocalParticipantId}
-                  onCollabRespond={handleCollabRespond}
-                  onReadArtifact={handleReadArtifact}
-                  onCollabResult={handleCollabResult}
-                  onPermissionRespond={handlePermissionResponse}
-                  taskAvailable={!activeTaskUnavailable}
-                  taskRequestId={activeTask?.requestId}
-                />
-              )}
+              <TextChatCard
+                key={activeInteraction}
+                room={roomName}
+                nickName={nickName}
+                messages={interactionMessages}
+                attachments={interactionAttachments}
+                participants={participants}
+                pendingFiles={activeTask ? [] : pendingFiles}
+                onSendText={wrappedSendText}
+                onSendFile={wrappedSendFile}
+                onSendTaskFile={wrappedSendTaskFile}
+                onSendAction={sendActionMessage}
+                localParticipantId={effectiveLocalParticipantId}
+                onCollabRespond={handleCollabRespond}
+                onReadArtifact={handleReadArtifact}
+                onCollabResult={handleCollabResult}
+                onPermissionRespond={handlePermissionResponse}
+                taskAvailable={!activeTaskUnavailable}
+                taskRequestId={activeTask?.requestId}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #367
Refs #361
Refs #344

Production dogfood showed that selecting Shared Canvas / Tiny Arena replaced the right-hand Room/Task conversation pane: the large left Stage stayed idle, the App was cramped into the conversation column, and Room chat disappeared. This is the narrow placement correction — the #356 bridge, transport, sandbox, catalog and Lab fixtures are all untouched.

## State model

One `app:<id>` interaction value used to imply both "which App is open" and "which conversation is selected". They are now two independent selections:

```text
conversation scope (existing interaction tablist, unchanged)
  room | taskRequestId

visual Stage (new, narrow)
  participants | screen | live view | active Room App
```

- `activeInteraction` only ever holds `room` or a Task request id; the `app:*` values and the App tabs in the right pane are gone.
- `activeRoomAppId` (existing state) now independently owns "an App is open on the Stage", resolved against the curated catalog only.
- An open App survives conversation switching: Room ↔ Task no longer unmounts the iframe or closes its MessagePort. Only `Close`, or the catalog losing the App (e.g. `ROOM_APPS_ENABLED` off), tears it down.
- Screen / Live View remain the same `stageView` preference they were; selecting either also dismisses an open App, so the Stage always shows one thing.

## Behavior

Desktop:

```text
┌───────────────────────────────┬──────────────────────────┐
│ Shared Canvas / Arena /       │ Room | Task A | Task B   │
│ screen share / Live View /    │                          │
│ participants (Stage, 75%)     │ conversation + composer  │
└───────────────────────────────┴──────────────────────────┘
```

- The App mounts in the existing left Stage seam through the unchanged `RoomAppHost`; the right pane always renders `TextChatCard` for the selected Room/Task conversation.
- An active App gets the wide Stage (75%), the same treatment screen share already had, instead of a conversation-sized pane.
- Entry: a small `Stage` switcher row with the two curated catalog Apps plus the existing Screen / Live View buttons when both exist. No registry, marketplace, manifest, SDK, or generic navigation — it is the same curated catalog, rendered as buttons.
- Close returns the Stage to the participant grid, with the conversation scope untouched.

Mobile: no new navigation framework. The App is Stage content rather than conversation content, so in the existing stacked responsive layout it owns the full-width Stage pane instead of the conversation pane; Room/Task conversation stays reachable below it exactly as before. Real iOS/touch smoke remains under #361.

## Changed files

- `app/src/components/RoomContent.tsx` — Stage placement, independent Stage state, curated Stage switcher, conversation pane always renders chat.
- `app/src/components/RoomContent.test.tsx` — the outdated "App tab in the interaction pane" test is replaced by Stage-placement coverage.

Rebased onto current `cf-sfu` (`3c2894a`, which includes #365 and #366). The one conflict with #365 was in the right-pane body: #365's new `onSendTaskFile` prop is preserved alongside the App removal.

## Tests

New coverage (all in `RoomContent.test.tsx`):

1. the App mounts inside the Stage (`room-stage`, `.room-participants-panel`), is not conversation content (`.room-chat-panel` / `interaction-chat` do not contain it), and the Stage takes 75% on desktop;
2. Room chat stays selected and rendered (composer present) while the App is active;
3. the App stays mounted while the conversation scope switches Room ↔ Task, and the previous host instance is reused rather than remounted;
4. Close unmounts the host and returns the Stage to the participant grid;
5. Canvas → Arena leaves exactly one iframe, a genuinely new element, with the previous MessagePort closed and a fresh channel for the new App;
6. Screen share and Task Live View still render on the Stage, and switching the Stage to either leaves the App; the Task conversation scope is unaffected.

Mutation-checked: dropping the per-App `key` fails test 5; removing the Stage widening fails test 1.

Regression: the existing screen-share switcher test now targets the renamed `stage-switcher` testid (the row is no longer Live-View-only); its behavior assertions are unchanged. `RoomAppHost.test.tsx` (port ownership, cleanup, lane forwarding) is untouched and green.

```
prettier --check .                       pass
yarn lint --max-warnings 0               pass
yarn type-check                          pass
yarn docs:check                          pass
yarn test                                823 passed / 89 files
yarn cf-build                            pass
git diff --check                         clean
```

## Must-not-change checklist

Unchanged: #356 protocol and MessagePort handshake; iframe `sandbox="allow-scripts"`; curated catalog URLs/origins; reliable/realtime DataChannels; SFU; payload/rate guards; `ROOM_APPS_ENABLED` gating (no catalog entry when off); Lab Shared Canvas / Tiny Arena; Task Live View protocol and components; screen-share transport; #363 composer/attachment work; Poll / legacy Whiteboard/Games.

No registry, marketplace, manifest, SDK, plugin navigation, or mobile navigation framework was added.
