### PR TITLE
docs(agent): activate runtime 0.5.33 and document Task input

### DIFF
--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -328,7 +328,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.32` (release tag `agent-v0.5.32`).
+`0.5.33` (release tag `agent-v0.5.33`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -389,7 +389,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.32"
+expected_version="0.5.33"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/app/public/llms-full.txt
+++ b/app/public/llms-full.txt
@@ -1013,6 +1013,52 @@ artifact or exposing it to unrelated Agent Tasks.
 
 Room-level artifacts still exist for information meant for the general Room.
 
+## Sending an attachment into a Task
+
+While a Task is active, the Task composer also accepts an attachment, so a Human
+can give the participating Agent image or text context without leaving the Task.
+
+An attachment sent inside a Task stays scoped to that Task. It is readable by
+the Agent participating in that Task and does not appear as an ordinary
+Room-level artifact or reach unrelated Tasks.
+
+Two kinds of submission are valid:
+
+- **Attachment only.** The attachment alone is accepted Task input. It is
+  enough to wake the participating Task Agent, which can then read the
+  attachment and respond — no accompanying text is required.
+- **Attachment plus text.** This is **one** Human submission, not two. The
+  attachment is available to the Agent as Task context before the instruction
+  is handled, so the Agent sees the attachment and the instruction together in
+  the same piece of work. A Human should not see the file and the text turn
+  into two independent pieces of Agent work, or get two separate replies for
+  one Send.
+
+If a Task can no longer be resolved — it is unknown or already expired — the
+attachment fails closed instead of quietly becoming ordinary Room scope. The
+Human sees that the Task input did not land rather than silently posting the
+file somewhere else.
+
+### Task attachments vs ordinary Room file transfer
+
+These are different paths and different limits:
+
+| | Ordinary Room file transfer | Attachment in a Task |
+|---|---|---|
+| Between | Human ↔ Human | Human → participating Task Agent |
+| Path | ephemeral browser DataChannel transfer | bounded Agent-readable Room attachment |
+| Size | up to 20 MB | bounded Agent-readable context |
+
+Ordinary Room browser-to-browser file transfer keeps its own 20 MB ephemeral
+DataChannel path and is unaffected by Task attachments.
+
+Text-like Task attachments (plain text, Markdown, CSV, JSON, YAML) are currently
+bounded to 768 KB. Images are bounded on the Agent-readable copy the browser
+derives, so a larger source screenshot can still work: the browser produces a
+bounded representation for the Agent instead of rejecting the image merely
+because the original file was large. This does not mean arbitrary large files
+are accepted as Task context.
+
 ## Agent activity and approvals
 
 While a Task is running, the Room may show bounded Agent activity so a Human
@@ -1516,11 +1562,31 @@ Publishing is observation, not live remote desktop or remote control.
 ## Task Live View
 
 ```text
+free4chat-agent live-view describe --json
 free4chat-agent live-view publish --task-request-id <id> --file <surface.json> [--instance <id>]
 ```
 
-Publish or replace the current bounded declarative Live View for an existing
-Task.
+`live-view describe --json` is the machine-authoring authority for Task Live
+Views. It prints the authoring contract of the *installed* Runtime, so the
+descriptor is version-coupled to the exact binary that will validate and
+publish the view.
+
+It is a purely local command. It requires no Room join, no Room credentials, no
+network request, and no source checkout — an Agent Harness can ask the
+installed Runtime what the current contract is instead of grepping Free4Chat
+source, reading repository docs, or running `strings` against the executable.
+
+The descriptor reports the contract identity and version, the snapshot fields
+and their patterns, the limits, every supported component and action with its
+required/optional fields and rules, and valid examples. Harnesses should read
+the exact current field names, action types, bindings, revision rules, and
+limits from this command rather than assuming them.
+
+This reference page is the Human-facing explanation of the feature; where the
+two disagree, the installed Runtime descriptor is authoritative for authoring.
+
+`live-view publish` remains the publishing operation. Publish or replace the
+current bounded declarative Live View for an existing Task.
 
 The input file should normally be a compact draft:
 
@@ -2262,7 +2328,7 @@ ACP manually, or start a daemon manually.
 
 The expected official Runtime version for this live bootstrap document is:
 
-`0.5.32` (release tag `agent-v0.5.32`).
+`0.5.33` (release tag `agent-v0.5.33`).
 
 The source Runtime and live bootstrap version may be staged independently during
 a release rollout. Treat the version above as trusted bootstrap metadata from
@@ -2323,7 +2389,7 @@ Fetch the official installer and pin it to the expected version:
 
 ```text
 curl -fsSL https://www.free4.chat/install-agent.sh -o install-agent.sh
-expected_version="0.5.32"
+expected_version="0.5.33"
 FREE4CHAT_AGENT_VERSION="$expected_version" bash install-agent.sh
 ```
 

--- a/docs/en/guides/tasks-and-live-views.md
+++ b/docs/en/guides/tasks-and-live-views.md
@@ -57,6 +57,52 @@ artifact or exposing it to unrelated Agent Tasks.
 
 Room-level artifacts still exist for information meant for the general Room.
 
+## Sending an attachment into a Task
+
+While a Task is active, the Task composer also accepts an attachment, so a Human
+can give the participating Agent image or text context without leaving the Task.
+
+An attachment sent inside a Task stays scoped to that Task. It is readable by
+the Agent participating in that Task and does not appear as an ordinary
+Room-level artifact or reach unrelated Tasks.
+
+Two kinds of submission are valid:
+
+- **Attachment only.** The attachment alone is accepted Task input. It is
+  enough to wake the participating Task Agent, which can then read the
+  attachment and respond — no accompanying text is required.
+- **Attachment plus text.** This is **one** Human submission, not two. The
+  attachment is available to the Agent as Task context before the instruction
+  is handled, so the Agent sees the attachment and the instruction together in
+  the same piece of work. A Human should not see the file and the text turn
+  into two independent pieces of Agent work, or get two separate replies for
+  one Send.
+
+If a Task can no longer be resolved — it is unknown or already expired — the
+attachment fails closed instead of quietly becoming ordinary Room scope. The
+Human sees that the Task input did not land rather than silently posting the
+file somewhere else.
+
+### Task attachments vs ordinary Room file transfer
+
+These are different paths and different limits:
+
+| | Ordinary Room file transfer | Attachment in a Task |
+|---|---|---|
+| Between | Human ↔ Human | Human → participating Task Agent |
+| Path | ephemeral browser DataChannel transfer | bounded Agent-readable Room attachment |
+| Size | up to 20 MB | bounded Agent-readable context |
+
+Ordinary Room browser-to-browser file transfer keeps its own 20 MB ephemeral
+DataChannel path and is unaffected by Task attachments.
+
+Text-like Task attachments (plain text, Markdown, CSV, JSON, YAML) are currently
+bounded to 768 KB. Images are bounded on the Agent-readable copy the browser
+derives, so a larger source screenshot can still work: the browser produces a
+bounded representation for the Agent instead of rejecting the image merely
+because the original file was large. This does not mean arbitrary large files
+are accepted as Task context.
+
 ## Agent activity and approvals
 
 While a Task is running, the Room may show bounded Agent activity so a Human

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -90,11 +90,31 @@ Publishing is observation, not live remote desktop or remote control.
 ## Task Live View
 
 ```text
+free4chat-agent live-view describe --json
 free4chat-agent live-view publish --task-request-id <id> --file <surface.json> [--instance <id>]
 ```
 
-Publish or replace the current bounded declarative Live View for an existing
-Task.
+`live-view describe --json` is the machine-authoring authority for Task Live
+Views. It prints the authoring contract of the *installed* Runtime, so the
+descriptor is version-coupled to the exact binary that will validate and
+publish the view.
+
+It is a purely local command. It requires no Room join, no Room credentials, no
+network request, and no source checkout — an Agent Harness can ask the
+installed Runtime what the current contract is instead of grepping Free4Chat
+source, reading repository docs, or running `strings` against the executable.
+
+The descriptor reports the contract identity and version, the snapshot fields
+and their patterns, the limits, every supported component and action with its
+required/optional fields and rules, and valid examples. Harnesses should read
+the exact current field names, action types, bindings, revision rules, and
+limits from this command rather than assuming them.
+
+This reference page is the Human-facing explanation of the feature; where the
+two disagree, the installed Runtime descriptor is authoritative for authoring.
+
+`live-view publish` remains the publishing operation. Publish or replace the
+current bounded declarative Live View for an existing Task.
 
 The input file should normally be a compact draft:
 


### PR DESCRIPTION
Activates the independently verified **agent-v0.5.33** native release and documents two recently shipped behaviours. **Docs and generated assets only.**

**Base:** `f3bb07ceed87235d02f0e65c30891e959e32089d` (`cf-sfu`)
**Head:** `1936a88a4a90d502b9a99df1f90016a80c70630d` — 4 files, +140 / −8

This is step 3 of the canonical release sequence; step 2 (the release) is now verified, which is what makes activation safe:

```text
1. source-version PR      #368  merged as f3bb07c
2. native GitHub Release  agent-v0.5.33  ← verified below
3. docs/activation PR     this PR
```

## Release verification (completed before this PR was opened)

| Item | Value |
|---|---|
| Tag | `agent-v0.5.33` |
| Release URL | https://github.com/i365dev/free4chat/releases/tag/agent-v0.5.33 |
| Tag object SHA | `74aa4e391fe2d66837493b5b3871b124074f7a2b` |
| Tag peeled commit SHA | `f3bb07ceed87235d02f0e65c30891e959e32089d` (= RELEASE_SOURCE_SHA) |
| Draft / prerelease | `false` / `false` (published 2026-09-12T04:26:14Z) |
| Release workflow | Agent Release run `34672948074` — 4 builds + publish, all success |

**Assets present (all 5, state=uploaded):** `free4chat-agent-darwin-arm64`, `free4chat-agent-darwin-amd64`, `free4chat-agent-linux-arm64`, `free4chat-agent-linux-amd64`, `SHA256SUMS`.

**Checksum result:** downloaded all assets and ran `shasum -a 256 -c SHA256SUMS` —

```text
free4chat-agent-darwin-arm64: OK
free4chat-agent-darwin-amd64: OK
free4chat-agent-linux-arm64: OK
free4chat-agent-linux-amd64: OK
```

**Native binary version result:** executed the released `free4chat-agent-darwin-arm64` on this machine (darwin/arm64):

```json
{ "version": "0.5.33" }
```

`doctor --json` from the same released binary also reports `"version": "0.5.33"`.

## A. Activation

`app/public/agent.md` — both live-bootstrap version occurrences now pinned to `0.5.33` / `agent-v0.5.33`:

- the live bootstrap declaration (`` `0.5.33` (release tag `agent-v0.5.33`). ``)
- the installer example (`expected_version="0.5.33"`)

**Generated file:** `app/public/llms-full.txt`, regenerated with the canonical generator (`yarn docs:generate`), not hand-edited. The new pin flows through to it. `llms.txt` and `sitemap.xml` were regenerated unchanged.

A repository-wide check confirms **no** `0.5.32` remains anywhere under `app/public/`.

## B. `live-view describe --json`

`docs/en/reference/cli.md`, Task Live View section. Documents that:

- `live-view describe --json` is the machine-authoring authority for Task Live Views and is **version-coupled to the installed Runtime**;
- it is purely local — no Room join, no Room credentials, no network request, no source checkout;
- Harnesses should read the exact current component fields, actions, bindings, revision rules, and limits from it instead of grepping source, reading repository docs, or running `strings` against the binary;
- `live-view publish` remains the publishing operation;
- this Markdown is the Human-facing explanation, and the installed Runtime descriptor is authoritative where they disagree.

The existing small publish example is kept. The full machine-readable descriptor is deliberately **not** duplicated into Markdown.

Verified against the released binary with no credentials and no join (exit 0, clean stderr):

```text
contract: 'free4chat.task-live-view'   contractVersion: 1
components: 7 (Text, Value, Button, Input, Row, Column, Card)
actions:    2 (increment, set)
rules:      9    examples: 2
limits: maxJsonBytes 32768, maxComponents 64, maxDepth 8, maxDataKeys 32,
        maxTextLength 400, maxLabelLength 80, maxChildrenPerContainer 64,
        incrementAmountMin -1000, incrementAmountMax 1000
```

## C. Human attachments inside an active Task

`docs/en/guides/tasks-and-live-views.md`, new section **"Sending an attachment into a Task"**. Product-facing semantics only:

- a Human can attach supported image/text context inside an **active** Task;
- the attachment stays scoped to that Task and is readable by the participating Task Agent;
- **attachment-only** Send is valid Task input and is enough to wake the participating Task Agent;
- **attachment + text** is **one** Human submission — the attachment is available as Task context before the instruction is handled, and a Human should not see one Send become two independent pieces of Agent work or two replies;
- unknown/expired Task correlation **fails closed** rather than silently becoming ordinary Room scope;
- Task attachments use the **bounded Agent-readable path**, explicitly distinguished from the ordinary 20 MB browser↔browser Room DataChannel transfer (comparison table included);
- text-like Task attachments are currently bounded to **768 KB**;
- a larger source screenshot can still work because the browser derives a bounded Agent-readable image copy — stated explicitly so it does not imply arbitrary large Task files are accepted.

No internal headers or implementation fields are documented.

## Scope discipline

No docs-tree restructuring, no file moves or URL breaks, no Browser Room redesign, no Live View expansion into a framework, no Room Apps SDK documentation, no unrelated conceptual rewrites, and **no Runtime/SFU behaviour change** — this PR touches documentation content and generated docs assets only.

## Validation (rerun on this head)

| Command | Result |
|---|---|
| `yarn prettier --check .` | pass |
| `yarn lint --max-warnings 0` | pass (no extra `--fix` edits) |
| `yarn type-check` | pass |
| `yarn docs:check` | pass — generated assets match the generator |
| `npx vitest run` | **89 files / 819 tests passed** |
| `yarn cf-build` | exit 0, `.open-next/worker.js` produced |
| `bash agent/scripts/test-bootstrap-contract.sh` | OK — source and live bootstrap versions now aligned |
| `git diff --check` | clean |

The `Failed to copy <node_modules pkg>` lines during `cf-build` are pre-existing environment noise; the build completes with exit 0.

## Runtime/SFU behaviour is unchanged by this PR

This PR changes no Runtime, SFU, Room, Task, Live View, or Worker behaviour. It pins the bootstrap to an already-published, checksum-verified, natively executed release and documents existing behaviour. The only executable-content change in the whole sequence was the one-line version bump in #368.
