### PR TITLE
ux(room-app): keep launched App sessions resident across Stage switches (#371)

### DIFF
--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -29,6 +29,7 @@ import type { Message } from "@common/types"
 import { trackAnalyticsEvent } from "@common/utils"
 
 import RoomContent from "./RoomContent"
+import { roomAppInstanceId } from "../common/roomApp"
 import { RoomSession } from "../do/RoomSession"
 import type { RoomRecord, RoomState } from "../room/types"
 
@@ -1126,12 +1127,16 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     expect(screen.queryByText("Connect local Runtime")).not.toBeInTheDocument()
   })
 
-  describe("Room App Stage placement", () => {
+  describe("Room App Stage placement and residency", () => {
     class TestPort {
       onmessage: ((event: MessageEvent) => void) | null = null
       postMessage = vi.fn()
       start = vi.fn()
       close = vi.fn()
+
+      emit(data: unknown) {
+        this.onmessage?.({ data } as MessageEvent)
+      }
     }
 
     let channels: { port1: TestPort; port2: TestPort }[] = []
@@ -1145,20 +1150,29 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       }
     }
 
+    const localParticipant = {
+      peerId: "local-peer",
+      name: "Alice",
+      kind: "human",
+      room: "test-room",
+      muteState: false,
+    }
+
+    const remoteScreenShare = {
+      peerId: "publisher-a",
+      name: "Bob",
+      kind: "human",
+      room: "test-room",
+      screenShareEnabled: true,
+      screenShareStream: {} as MediaStream,
+    }
+
     function renderAppRoom(overrides: Record<string, unknown> = {}) {
       mockUseSfuChatRoom.mockReturnValue({
         ...baseHookReturn,
         connectionStatus: "connected",
         roomAppsEnabled: true,
-        participants: [
-          {
-            peerId: "local-peer",
-            name: "Alice",
-            kind: "human",
-            room: "test-room",
-            muteState: false,
-          },
-        ],
+        participants: [localParticipant],
         ...overrides,
       })
       return render(
@@ -1174,33 +1188,60 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       return frameWindow
     }
 
+    /** Answers the bootstrap so the host forwards live App messages. */
+    function completeHandshake(
+      frameWindow: { postMessage: ReturnType<typeof vi.fn> },
+      appId: string,
+      port: TestPort
+    ) {
+      const bootstrap = frameWindow.postMessage.mock.calls[0][0]
+      act(() => {
+        port.emit({
+          type: "ready",
+          appInstanceId: roomAppInstanceId("test-room", appId),
+          handshakeToken: bootstrap.handshakeToken,
+        })
+      })
+    }
+
+    const slot = (appId: string) => screen.getByTestId(`room-app-slot-${appId}`)
+    const slotHidden = (appId: string) =>
+      slot(appId).className.includes("hidden")
+    const slotIframe = (appId: string) =>
+      within(slot(appId)).getByTestId("room-app-iframe") as HTMLIFrameElement
+    const slotHost = (appId: string) =>
+      within(slot(appId)).getByTestId("room-app-host")
+
     beforeEach(() => {
       channels = []
       vi.stubGlobal("MessageChannel", TestMessageChannel)
     })
 
-    it("mounts the active Room App on the visual Stage while the Room conversation stays", async () => {
+    it("mounts a first launch on the visual Stage while the Room conversation stays", async () => {
       renderAppRoom()
 
-      // Conversation scope starts on Room; the Stage starts on participants.
+      // Nothing is resident before the first launch, and the Stage idles on
+      // participants.
+      expect(screen.queryByTestId("room-app-iframe")).toBeNull()
+      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
       expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
         "aria-selected",
         "true"
       )
-      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
 
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
 
       const host = await screen.findByTestId("room-app-host")
       const stage = screen.getByTestId("room-stage")
       expect(stage.contains(host)).toBe(true)
-      // The App is Stage content, never conversation content: the same
-      // structure keeps it out of the stacked mobile conversation pane.
+      // Stage content, never conversation content: the same structure keeps it
+      // out of the stacked mobile conversation pane.
       expect(host.closest(".room-participants-panel")).not.toBeNull()
       expect(host.closest(".room-chat-panel")).toBeNull()
       expect(screen.getByTestId("interaction-chat").contains(host)).toBe(false)
       // A Room App is a large visual surface, like screen share.
       expect(stage).toHaveStyle({ width: "75%" })
+      expect(screen.queryByTestId("room-stage-participants")).toBeNull()
 
       // Room conversation remains selected and rendered beside the App.
       expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
@@ -1211,35 +1252,19 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
         screen.getByPlaceholderText("Message the room or @ an Agent…")
       ).toBeInTheDocument()
 
-      const iframe = screen.getByTestId("room-app-iframe")
+      // One launch means one iframe and one MessagePort.
+      expect(screen.getAllByTestId("room-app-iframe")).toHaveLength(1)
+      const iframe = slotIframe("shared-canvas")
       expect(iframe).toHaveAttribute(
         "src",
         expect.stringContaining("/shared-canvas")
       )
       expect(iframe).toHaveAttribute("sandbox", "allow-scripts")
+      loadAppIframe(iframe)
+      expect(channels).toHaveLength(1)
     })
 
-    it("closes the Room App back to the participant Stage", async () => {
-      renderAppRoom()
-
-      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
-      const host = await screen.findByTestId("room-app-host")
-      expect(screen.getByTestId("room-app-iframe")).toHaveAttribute(
-        "src",
-        expect.stringContaining("/tiny-arena")
-      )
-
-      fireEvent.click(within(host).getByRole("button", { name: "Close" }))
-
-      expect(screen.queryByTestId("room-app-host")).toBeNull()
-      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
-      expect(screen.getByTestId("interaction-tab-room")).toHaveAttribute(
-        "aria-selected",
-        "true"
-      )
-    })
-
-    it("keeps the App open while the conversation switches between Room and Task", async () => {
+    it("keeps the resident App while the conversation switches between Room and Task", async () => {
       renderAppRoom({ messages: [taskRequestMessage] })
 
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
@@ -1262,56 +1287,219 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       ).toBeInTheDocument()
     })
 
-    it("switches Canvas to Arena without a duplicate iframe or MessagePort", async () => {
+    it("launches once and reuses the same iframe and MessagePort when hidden and shown again", async () => {
+      const send = vi.fn(() => false)
+      renderAppRoom({ sendRoomAppMessage: send })
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      expect(channels).toHaveLength(1)
+
+      // Hide by toggling the Stage entry off.
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+
+      // Show it again: same host, same session, no new MessagePort.
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(false)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+      // Visibility is presentation only: it never becomes host traffic.
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it("treats visual Close as Hide and restores the same session on reopen", async () => {
+      renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      const iframe = slotIframe("tiny-arena")
+      loadAppIframe(iframe)
+      expect(channels).toHaveLength(1)
+
+      fireEvent.click(
+        within(slotHost("tiny-arena")).getByRole("button", { name: "Close" })
+      )
+
+      // The Stage returns to participants; the session stays resident.
+      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
+      expect(slotHidden("tiny-arena")).toBe(true)
+      expect(slotIframe("tiny-arena")).toBe(iframe)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      expect(slotHidden("tiny-arena")).toBe(false)
+      expect(slotIframe("tiny-arena")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+    })
+
+    it("keeps Canvas resident while Arena is shown and restores the same Canvas iframe", async () => {
       renderAppRoom()
 
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
-      const canvasIframe = screen.getByTestId(
-        "room-app-iframe"
-      ) as HTMLIFrameElement
+      const canvasIframe = slotIframe("shared-canvas")
       loadAppIframe(canvasIframe)
-      expect(channels).toHaveLength(1)
       const canvasPort = channels[0].port1
+      expect(channels).toHaveLength(1)
 
       fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
 
-      const iframes = screen.getAllByTestId("room-app-iframe")
-      expect(iframes).toHaveLength(1)
-      // A clean unmount/remount, not one iframe re-pointed at a second App.
-      expect(iframes[0]).not.toBe(canvasIframe)
-      expect(iframes[0]).toHaveAttribute(
-        "src",
-        expect.stringContaining("/tiny-arena")
-      )
-      expect(canvasPort.close).toHaveBeenCalled()
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(slotHidden("tiny-arena")).toBe(false)
+      // Both sessions exist; Canvas was hidden, not destroyed.
+      expect(screen.getAllByTestId("room-app-iframe")).toHaveLength(2)
+      expect(screen.getAllByTestId("room-app-host")).toHaveLength(2)
+      expect(slotIframe("shared-canvas")).toBe(canvasIframe)
+      expect(canvasPort.close).not.toHaveBeenCalled()
 
-      loadAppIframe(iframes[0] as HTMLIFrameElement)
+      const arenaIframe = slotIframe("tiny-arena")
+      loadAppIframe(arenaIframe)
       expect(channels).toHaveLength(2)
-      expect(screen.getAllByTestId("room-app-iframe")).toHaveLength(1)
+
+      // Back to Canvas: the exact same iframe/port/App-local state.
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(false)
+      expect(slotIframe("shared-canvas")).toBe(canvasIframe)
+      expect(canvasPort.close).not.toHaveBeenCalled()
+      expect(channels).toHaveLength(2)
+      // Arena stays resident behind it.
+      expect(slotHidden("tiny-arena")).toBe(true)
+      expect(slotIframe("tiny-arena")).toBe(arenaIframe)
+    })
+
+    it("keeps both Humans' resident Canvas sessions when both hide and reopen", async () => {
+      const humanHook = (name: string) => ({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [{ ...localParticipant, name }],
+      })
+      mockUseSfuChatRoom.mockImplementation((_room: unknown, nick: unknown) =>
+        humanHook(nick === "Alice" ? "Alice" : "Bob")
+      )
+      const alice = render(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+      const bob = render(
+        <RoomContent roomName="test-room" nickName="Bob" roomType="audio" />
+      )
+      const aliceView = within(alice.container)
+      const bobView = within(bob.container)
+
+      fireEvent.click(aliceView.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(bobView.getByTestId("stage-app-shared-canvas"))
+      const aliceIframe = aliceView.getByTestId(
+        "room-app-iframe"
+      ) as HTMLIFrameElement
+      const bobIframe = bobView.getByTestId(
+        "room-app-iframe"
+      ) as HTMLIFrameElement
+      loadAppIframe(aliceIframe)
+      loadAppIframe(bobIframe)
+      expect(channels).toHaveLength(2)
+
+      // Both Humans hide Canvas for this browser session.
+      fireEvent.click(aliceView.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(bobView.getByTestId("stage-app-shared-canvas"))
+      expect(
+        aliceView.getByTestId("room-app-slot-shared-canvas").className
+      ).toContain("hidden")
+      expect(
+        bobView.getByTestId("room-app-slot-shared-canvas").className
+      ).toContain("hidden")
+      // Neither resident session was destroyed, so an incumbent Canvas can
+      // still answer the bounded canonical bootstrap when it is reopened.
+      for (const channel of channels)
+        expect(channel.port1.close).not.toHaveBeenCalled()
+
+      // Reopening restores the same iframes and sessions on both browsers.
+      fireEvent.click(aliceView.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(bobView.getByTestId("stage-app-shared-canvas"))
+      expect(aliceView.getByTestId("room-app-iframe")).toBe(aliceIframe)
+      expect(bobView.getByTestId("room-app-iframe")).toBe(bobIframe)
+      expect(channels).toHaveLength(2)
+    })
+
+    it("keeps a hidden App's session live without adding outbound traffic", async () => {
+      let listener: ((message: unknown) => void) | undefined
+      const subscribe = vi.fn((next: (message: unknown) => void) => {
+        listener = next
+        return () => undefined
+      })
+      const send = vi.fn(() => true)
+      renderAppRoom({
+        subscribeRoomAppMessages: subscribe,
+        sendRoomAppMessage: send,
+      })
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const frameWindow = loadAppIframe(slotIframe("shared-canvas"))
+      completeHandshake(frameWindow, "shared-canvas", channels[0].port1)
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(true)
+
+      // A hidden resident App still receives the bounded logical messages it
+      // needs to preserve and reconcile its own state.
+      const payload = { type: "stroke", points: [[1, 2]] }
+      act(() => {
+        listener?.({
+          protocolVersion: 1,
+          appInstanceId: roomAppInstanceId("test-room", "shared-canvas"),
+          lane: "reliable",
+          sourceParticipantId: "other-human",
+          payload,
+        })
+      })
+      expect(channels[0].port1.postMessage).toHaveBeenCalledWith({
+        type: "reliable",
+        appInstanceId: roomAppInstanceId("test-room", "shared-canvas"),
+        sourceParticipantId: "other-human",
+        payload,
+      })
+      // Hiding is never host traffic: no heartbeat was introduced.
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it("hides the App when the Stage switches back to Screen or Live View", async () => {
+      renderAppRoom({
+        resolvedRoomType: "screenshare",
+        messages: [taskRequestMessage],
+        participants: [localParticipant, remoteScreenShare],
+        taskLiveViews: { "task-live": taskLiveViewSnapshot },
+      })
+
+      fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+
+      fireEvent.click(screen.getByTestId("stage-view-live-view"))
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(screen.getByTestId("task-live-view")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(false)
+
+      fireEvent.click(screen.getByTestId("stage-view-screen"))
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(document.querySelector("video")).toBeInTheDocument()
+      // The Task conversation scope is untouched by Stage switching, and the
+      // App session survived both switches.
+      expect(
+        screen.getByTestId("interaction-tab-task-task-live")
+      ).toHaveAttribute("aria-selected", "true")
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
     })
 
     it("offers Screen while an App is open even without a Task Live View", async () => {
       renderAppRoom({
         resolvedRoomType: "screenshare",
-        participants: [
-          {
-            peerId: "local-peer",
-            name: "Alice",
-            kind: "human",
-            room: "test-room",
-            muteState: false,
-            screenShareEnabled: false,
-            screenShareStream: null,
-          },
-          {
-            peerId: "publisher-a",
-            name: "Bob",
-            kind: "human",
-            room: "test-room",
-            screenShareEnabled: true,
-            screenShareStream: {} as MediaStream,
-          },
-        ],
+        participants: [localParticipant, remoteScreenShare],
       })
 
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
@@ -1321,7 +1509,7 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       // Screen is a Stage surface in its own right: it must stay reachable
       // while an App is open, with no Live View sharing the switcher.
       fireEvent.click(screen.getByTestId("stage-view-screen"))
-      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(slotHidden("shared-canvas")).toBe(true)
       expect(document.querySelector("video")).toBeInTheDocument()
     })
 
@@ -1338,55 +1526,71 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
 
       // Live View is likewise reachable on its own availability.
       fireEvent.click(screen.getByTestId("stage-view-live-view"))
-      expect(screen.queryByTestId("room-app-host")).toBeNull()
+      expect(slotHidden("tiny-arena")).toBe(true)
       expect(screen.getByTestId("task-live-view")).toBeInTheDocument()
     })
 
-    it("leaves the App when the Stage switches back to Screen or Live View", async () => {
-      renderAppRoom({
-        resolvedRoomType: "screenshare",
-        messages: [taskRequestMessage],
-        participants: [
-          {
-            peerId: "local-peer",
-            name: "Alice",
-            kind: "human",
-            room: "test-room",
-            muteState: false,
-            screenShareEnabled: false,
-            screenShareStream: null,
-          },
-          {
-            peerId: "publisher-a",
-            name: "Bob",
-            kind: "human",
-            room: "test-room",
-            screenShareEnabled: true,
-            screenShareStream: {} as MediaStream,
-          },
-        ],
-        taskLiveViews: { "task-live": taskLiveViewSnapshot },
-      })
+    it("keeps hidden App slots non-interactive", async () => {
+      renderAppRoom()
 
-      // The Task Live View is the selected Task's surface, as before.
-      fireEvent.click(screen.getByTestId("interaction-tab-task-task-live"))
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
-      expect(await screen.findByTestId("room-app-host")).toBeInTheDocument()
-
-      fireEvent.click(screen.getByTestId("stage-view-live-view"))
-      expect(screen.queryByTestId("room-app-host")).toBeNull()
-      expect(screen.getByTestId("task-live-view")).toBeInTheDocument()
-
       fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
-      expect(screen.getByTestId("room-app-host")).toBeInTheDocument()
 
-      fireEvent.click(screen.getByTestId("stage-view-screen"))
-      expect(screen.queryByTestId("room-app-host")).toBeNull()
-      expect(document.querySelector("video")).toBeInTheDocument()
-      // The Task conversation scope is untouched by Stage switching.
-      expect(
-        screen.getByTestId("interaction-tab-task-task-live")
-      ).toHaveAttribute("aria-selected", "true")
+      // display:none removes the hidden host from hit-testing and tab order;
+      // inert + aria-hidden state the intent explicitly.
+      const hidden = slot("shared-canvas")
+      expect(hidden.className).toContain("hidden")
+      expect(hidden).toHaveAttribute("aria-hidden", "true")
+      expect(hidden).toHaveAttribute("inert")
+
+      const visible = slot("tiny-arena")
+      expect(visible.className).not.toContain("hidden")
+      expect(visible).toHaveAttribute("aria-hidden", "false")
+      expect(visible).not.toHaveAttribute("inert")
+    })
+
+    it("tears resident hosts down when the catalog removes them", async () => {
+      const view = renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      loadAppIframe(slotIframe("shared-canvas"))
+      loadAppIframe(slotIframe("tiny-arena"))
+      expect(channels).toHaveLength(2)
+
+      // ROOM_APPS_ENABLED off / catalog entry gone.
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: false,
+        participants: [localParticipant],
+      })
+      view.rerender(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("room-app-slot-shared-canvas")).toBeNull()
+      )
+      expect(screen.queryByTestId("room-app-slot-tiny-arena")).toBeNull()
+      expect(channels[0].port1.close).toHaveBeenCalledTimes(1)
+      expect(channels[1].port1.close).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId("room-stage-participants")).toBeInTheDocument()
+    })
+
+    it("closes every resident MessagePort exactly once when the Room unmounts", async () => {
+      const view = renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+      loadAppIframe(slotIframe("shared-canvas"))
+      loadAppIframe(slotIframe("tiny-arena"))
+      expect(channels).toHaveLength(2)
+
+      view.unmount()
+
+      expect(channels[0].port1.close).toHaveBeenCalledTimes(1)
+      expect(channels[1].port1.close).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1549,7 +1549,51 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect(visible).not.toHaveAttribute("inert")
     })
 
-    it("tears resident hosts down when the catalog removes them", async () => {
+    it("keeps resident hosts across an ordinary transport reconnect", async () => {
+      const view = renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      expect(channels).toHaveLength(1)
+
+      // Ordinary SFU/media reconnect: useSfuChatRoom drops the exposed flag
+      // while it rebuilds the App DataChannels. That is not a catalog removal.
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "reconnecting",
+        roomAppsEnabled: false,
+        participants: [localParticipant],
+      })
+      view.rerender(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+
+      // The App is hidden while the transport is unavailable, but its host and
+      // MessagePort stay resident.
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+
+      // Reconnect succeeds: same host, same Stage selection.
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant],
+      })
+      view.rerender(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+
+      expect(slotHidden("shared-canvas")).toBe(false)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+    })
+
+    it("tears resident hosts down on a stable disable, closing each port once", async () => {
       const view = renderAppRoom()
 
       fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
@@ -1558,7 +1602,8 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       loadAppIframe(slotIframe("tiny-arena"))
       expect(channels).toHaveLength(2)
 
-      // ROOM_APPS_ENABLED off / catalog entry gone.
+      // ROOM_APPS_ENABLED off while the Room stays connected: a real disable,
+      // not a reconnect.
       mockUseSfuChatRoom.mockReturnValue({
         ...baseHookReturn,
         connectionStatus: "connected",

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -127,6 +127,8 @@ export default function RoomContent({
   const [taskError, setTaskError] = useState("")
   const [activeInteraction, setActiveInteraction] = useState("room")
   const [activeRoomAppId, setActiveRoomAppId] = useState<string | null>(null)
+  // Browser-local resident App sessions, bounded by the curated catalog size.
+  const [launchedRoomAppIds, setLaunchedRoomAppIds] = useState<string[]>([])
   const [stageView, setStageView] = useState<"screen" | "live-view">("screen")
   const taskLiveViewState = useRef(new Map())
   const observedLiveViewKeys = useRef(new Set<string>())
@@ -239,6 +241,19 @@ export default function RoomContent({
   const roomAppSelf = roomAppParticipants.find(
     (participant) => participant.participantId === effectiveLocalParticipantId
   )
+  // Hosts are mounted on first launch and then stay resident for this browser's
+  // Room session: Stage navigation only changes which one is visible, so an App
+  // never loses its iframe/MessagePort/App-local state to visual navigation.
+  const residentRoomApps = useMemo(
+    () =>
+      launchedRoomAppIds.flatMap((id) => {
+        const app = roomApps.find((candidate) => candidate.id === id)
+        return app ? [app] : []
+      }),
+    [launchedRoomAppIds, roomApps]
+  )
+  const visibleRoomApp =
+    activeRoomApp && roomAppSelf ? activeRoomApp : undefined
   const activeTask = taskProjections.find(
     (task) => task.requestId === activeInteraction
   )
@@ -341,11 +356,28 @@ export default function RoomContent({
   }, [activeInteraction, taskProjections])
 
   useEffect(() => {
-    // Only catalog availability controls an open App; changing the conversation
-    // scope or the Stage view must not tear down its iframe/MessagePort.
+    // Only catalog availability controls a resident App host; changing the
+    // conversation scope, the Stage view, or hiding an App must not tear down
+    // its iframe/MessagePort. Losing the catalog entry (including
+    // ROOM_APPS_ENABLED turning off) does, and is the one host teardown path
+    // besides unmounting the Room itself.
     if (activeRoomAppId && !roomApps.some((app) => app.id === activeRoomAppId))
       setActiveRoomAppId(null)
+    setLaunchedRoomAppIds((previous) => {
+      const next = previous.filter((id) =>
+        roomApps.some((app) => app.id === id)
+      )
+      return next.length === previous.length ? previous : next
+    })
   }, [activeRoomAppId, roomApps])
+
+  const launchRoomApp = useCallback((appId: string) => {
+    setLaunchedRoomAppIds((previous) =>
+      previous.includes(appId)
+        ? previous
+        : [...previous, appId].slice(-ROOM_APP_MAX_INSTANCES)
+    )
+  }, [])
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
@@ -454,9 +486,9 @@ export default function RoomContent({
   useEffect(() => {
     // A Room App is a large visual surface like screen share, so it gets the
     // wide Stage rather than a conversation-sized pane.
-    setSplitRatio(activeScreenShares.length > 0 || activeRoomApp ? 75 : 50)
+    setSplitRatio(activeScreenShares.length > 0 || visibleRoomApp ? 75 : 50)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeScreenShares.length > 0, Boolean(activeRoomApp)])
+  }, [activeScreenShares.length > 0, Boolean(visibleRoomApp)])
 
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
@@ -941,9 +973,16 @@ export default function RoomContent({
                       type="button"
                       aria-pressed={selected}
                       data-testid={`stage-app-${app.id}`}
-                      onClick={() =>
-                        setActiveRoomAppId(selected ? null : app.id)
-                      }
+                      onClick={() => {
+                        if (selected) {
+                          // Hide, do not destroy: the resident host keeps its
+                          // iframe, MessagePort and App-local state.
+                          setActiveRoomAppId(null)
+                          return
+                        }
+                        launchRoomApp(app.id)
+                        setActiveRoomAppId(app.id)
+                      }}
                       className={`shrink-0 rounded px-2 py-1 text-xs ${
                         selected
                           ? "bg-blue-600 text-white"
@@ -962,9 +1001,9 @@ export default function RoomContent({
                       setStageView("screen")
                       setActiveRoomAppId(null)
                     }}
-                    aria-pressed={stageView === "screen" && !activeRoomApp}
+                    aria-pressed={stageView === "screen" && !visibleRoomApp}
                     className={`shrink-0 rounded px-2 py-1 text-xs ${
-                      stageView === "screen" && !activeRoomApp
+                      stageView === "screen" && !visibleRoomApp
                         ? "bg-blue-600 text-white"
                         : "text-gray-400 hover:bg-gray-800"
                     }`}
@@ -980,9 +1019,9 @@ export default function RoomContent({
                       setStageView("live-view")
                       setActiveRoomAppId(null)
                     }}
-                    aria-pressed={stageView === "live-view" && !activeRoomApp}
+                    aria-pressed={stageView === "live-view" && !visibleRoomApp}
                     className={`shrink-0 rounded px-2 py-1 text-xs ${
-                      stageView === "live-view" && !activeRoomApp
+                      stageView === "live-view" && !visibleRoomApp
                         ? "bg-blue-600 text-white"
                         : "text-gray-400 hover:bg-gray-800"
                     }`}
@@ -992,66 +1031,128 @@ export default function RoomContent({
                 )}
               </div>
             )}
-            {activeRoomApp && roomAppSelf ? (
-              // Keyed per App: switching Apps unmounts the previous host, which
-              // closes its MessagePort, instead of reusing one iframe/instance.
-              <RoomAppHost
-                key={activeRoomApp.id}
-                app={activeRoomApp}
-                appInstanceId={roomAppInstanceId(roomName, activeRoomApp.id)}
-                self={roomAppSelf}
-                participants={roomAppParticipants}
-                subscribe={subscribeRoomAppMessages}
-                send={sendRoomAppMessage}
-                onClose={() => setActiveRoomAppId(null)}
-              />
-            ) : activeScreenShares.length > 0 ? (
-              <>
-                <div
-                  className={
-                    showTaskLiveView ? "hidden" : "flex min-h-0 flex-1"
-                  }
-                >
-                  {activeShare && (
-                    <ScreenShareViewer
-                      key={activeShare.peerId}
-                      stream={activeShare.screenShareStream!}
-                      name={activeShare.name}
+            {/* Resident App hosts: every launched App stays mounted for this
+                browser Room session. Stage navigation only toggles visibility,
+                so hiding one never destroys its iframe or MessagePort. Hidden
+                slots are display:none + inert + aria-hidden, which keeps them
+                out of hit-testing, focus and the accessibility tree while they
+                keep receiving the bounded App messages. */}
+            {roomAppSelf &&
+              residentRoomApps.map((app) => {
+                const visible = visibleRoomApp?.id === app.id
+                return (
+                  <div
+                    key={app.id}
+                    data-testid={`room-app-slot-${app.id}`}
+                    aria-hidden={!visible}
+                    inert={!visible}
+                    className={
+                      visible ? "flex min-h-0 flex-1 flex-col" : "hidden"
+                    }
+                  >
+                    <RoomAppHost
+                      app={app}
+                      appInstanceId={roomAppInstanceId(roomName, app.id)}
+                      self={roomAppSelf}
+                      participants={roomAppParticipants}
+                      subscribe={subscribeRoomAppMessages}
+                      send={sendRoomAppMessage}
+                      onClose={() => setActiveRoomAppId(null)}
+                    />
+                  </div>
+                )
+              })}
+            {!visibleRoomApp &&
+              (activeScreenShares.length > 0 ? (
+                <>
+                  <div
+                    className={
+                      showTaskLiveView ? "hidden" : "flex min-h-0 flex-1"
+                    }
+                  >
+                    {activeShare && (
+                      <ScreenShareViewer
+                        key={activeShare.peerId}
+                        stream={activeShare.screenShareStream!}
+                        name={activeShare.name}
+                      />
+                    )}
+                  </div>
+                  {showTaskLiveView && activeTaskLiveView && (
+                    <TaskLiveView
+                      key={activeTask!.requestId}
+                      snapshot={activeTaskLiveView}
+                      stateStore={taskLiveViewState}
+                      onVisible={handleLiveViewVisible}
+                      onInteract={handleLiveViewInteracted}
                     />
                   )}
-                </div>
-                {showTaskLiveView && activeTaskLiveView && (
-                  <TaskLiveView
-                    key={activeTask!.requestId}
-                    snapshot={activeTaskLiveView}
-                    stateStore={taskLiveViewState}
-                    onVisible={handleLiveViewVisible}
-                    onInteract={handleLiveViewInteracted}
-                  />
-                )}
-                <div className="room-participant-strip scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-gray-800 p-2">
+                  <div className="room-participant-strip scrollbar-thin flex flex-none flex-row gap-2 overflow-x-auto border-t border-gray-800 p-2">
+                    {participants.map((p) => (
+                      <div
+                        key={p.peerId}
+                        className={`flex-shrink-0 rounded-xl transition-all ${
+                          p.screenShareEnabled &&
+                          p.peerId !== LOCAL_PEER_ID &&
+                          p.peerId === activeSharePeerId
+                            ? "ring-2 ring-blue-400"
+                            : ""
+                        } ${
+                          p.screenShareEnabled && p.peerId !== LOCAL_PEER_ID
+                            ? "cursor-pointer"
+                            : ""
+                        }`}
+                        onClick={() => {
+                          if (
+                            p.screenShareEnabled &&
+                            p.peerId !== LOCAL_PEER_ID
+                          ) {
+                            setActiveSharePeerId(p.peerId)
+                          }
+                        }}
+                      >
+                        <UserCard
+                          peerId={p.peerId}
+                          name={p.name}
+                          kind={p.kind}
+                          room={p.room}
+                          muteState={p.muteState}
+                          audioStream={p.audioStream}
+                          screenShareStream={p.screenShareStream}
+                          screenShareEnabled={p.screenShareEnabled}
+                          onMuteSelf={muteSelf}
+                          onToggleScreenShare={wrappedToggleScreenShare}
+                          screenshareAllowed={screenshareAllowed}
+                          voiceAvailable={
+                            p.voiceAvailable && agentVoiceMediaAvailable
+                          }
+                          voiceEnabled={p.voiceEnabled}
+                          onToggleAgentVoice={toggleAgentVoice}
+                          onStartTask={handleStartTask}
+                          className="w-[84px]"
+                          compact
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : showTaskLiveView && activeTaskLiveView ? (
+                <TaskLiveView
+                  key={activeTask!.requestId}
+                  snapshot={activeTaskLiveView}
+                  stateStore={taskLiveViewState}
+                  onVisible={handleLiveViewVisible}
+                  onInteract={handleLiveViewInteracted}
+                />
+              ) : (
+                <div
+                  data-testid="room-stage-participants"
+                  className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start justify-center gap-2 overflow-y-auto p-3"
+                >
                   {participants.map((p) => (
                     <div
                       key={p.peerId}
-                      className={`flex-shrink-0 rounded-xl transition-all ${
-                        p.screenShareEnabled &&
-                        p.peerId !== LOCAL_PEER_ID &&
-                        p.peerId === activeSharePeerId
-                          ? "ring-2 ring-blue-400"
-                          : ""
-                      } ${
-                        p.screenShareEnabled && p.peerId !== LOCAL_PEER_ID
-                          ? "cursor-pointer"
-                          : ""
-                      }`}
-                      onClick={() => {
-                        if (
-                          p.screenShareEnabled &&
-                          p.peerId !== LOCAL_PEER_ID
-                        ) {
-                          setActiveSharePeerId(p.peerId)
-                        }
-                      }}
+                      className="flex flex-col items-center gap-1"
                     >
                       <UserCard
                         peerId={p.peerId}
@@ -1064,62 +1165,19 @@ export default function RoomContent({
                         screenShareEnabled={p.screenShareEnabled}
                         onMuteSelf={muteSelf}
                         onToggleScreenShare={wrappedToggleScreenShare}
-                        screenshareAllowed={screenshareAllowed}
                         voiceAvailable={
                           p.voiceAvailable && agentVoiceMediaAvailable
                         }
                         voiceEnabled={p.voiceEnabled}
                         onToggleAgentVoice={toggleAgentVoice}
                         onStartTask={handleStartTask}
-                        className="w-[84px]"
-                        compact
+                        screenshareAllowed={screenshareAllowed}
+                        className="w-40 flex-none"
                       />
                     </div>
                   ))}
                 </div>
-              </>
-            ) : showTaskLiveView && activeTaskLiveView ? (
-              <TaskLiveView
-                key={activeTask!.requestId}
-                snapshot={activeTaskLiveView}
-                stateStore={taskLiveViewState}
-                onVisible={handleLiveViewVisible}
-                onInteract={handleLiveViewInteracted}
-              />
-            ) : (
-              <div
-                data-testid="room-stage-participants"
-                className="room-participants-grid scrollbar-thin flex h-full flex-wrap content-start items-start justify-center gap-2 overflow-y-auto p-3"
-              >
-                {participants.map((p) => (
-                  <div
-                    key={p.peerId}
-                    className="flex flex-col items-center gap-1"
-                  >
-                    <UserCard
-                      peerId={p.peerId}
-                      name={p.name}
-                      kind={p.kind}
-                      room={p.room}
-                      muteState={p.muteState}
-                      audioStream={p.audioStream}
-                      screenShareStream={p.screenShareStream}
-                      screenShareEnabled={p.screenShareEnabled}
-                      onMuteSelf={muteSelf}
-                      onToggleScreenShare={wrappedToggleScreenShare}
-                      voiceAvailable={
-                        p.voiceAvailable && agentVoiceMediaAvailable
-                      }
-                      voiceEnabled={p.voiceEnabled}
-                      onToggleAgentVoice={toggleAgentVoice}
-                      onStartTask={handleStartTask}
-                      screenshareAllowed={screenshareAllowed}
-                      className="w-40 flex-none"
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
+              ))}
 
             {floatingReactions.map((r) => (
               <div

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -213,18 +213,20 @@ export default function RoomContent({
   )
   const effectiveLocalParticipantId =
     localParticipantId ?? getLocalRoomAuth()?.participantId
-  const roomApps = useMemo(
+  // The validated curated catalog is stable while the Room content is mounted.
+  // `roomAppsEnabled` is not a pure catalog/kill-switch signal: it also drops
+  // while an ordinary SFU/media reconnect rebuilds the App DataChannels, and
+  // that transient false must never be mistaken for a catalog removal.
+  const curatedRoomApps = useMemo(
     () =>
-      roomAppsEnabled
-        ? experimentalRoomAppCatalog()
-            .filter(
-              (app) =>
-                validateRoomAppDefinition(app) && isRoomAppAllowlisted(app)
-            )
-            .slice(0, ROOM_APP_MAX_INSTANCES)
-        : [],
-    [roomAppsEnabled]
+      experimentalRoomAppCatalog()
+        .filter(
+          (app) => validateRoomAppDefinition(app) && isRoomAppAllowlisted(app)
+        )
+        .slice(0, ROOM_APP_MAX_INSTANCES),
+    []
   )
+  const roomApps = roomAppsEnabled ? curatedRoomApps : []
   // Conversation scope and visual Stage are independent selections: an active
   // Room App lives on the Stage and never replaces the Room/Task conversation.
   const activeRoomApp = roomApps.find((app) => activeRoomAppId === app.id)
@@ -244,13 +246,15 @@ export default function RoomContent({
   // Hosts are mounted on first launch and then stay resident for this browser's
   // Room session: Stage navigation only changes which one is visible, so an App
   // never loses its iframe/MessagePort/App-local state to visual navigation.
+  // Resident resolution uses the stable curated catalog, not the transient
+  // transport-readiness flag.
   const residentRoomApps = useMemo(
     () =>
       launchedRoomAppIds.flatMap((id) => {
-        const app = roomApps.find((candidate) => candidate.id === id)
+        const app = curatedRoomApps.find((candidate) => candidate.id === id)
         return app ? [app] : []
       }),
-    [launchedRoomAppIds, roomApps]
+    [curatedRoomApps, launchedRoomAppIds]
   )
   const visibleRoomApp =
     activeRoomApp && roomAppSelf ? activeRoomApp : undefined
@@ -356,20 +360,22 @@ export default function RoomContent({
   }, [activeInteraction, taskProjections])
 
   useEffect(() => {
-    // Only catalog availability controls a resident App host; changing the
-    // conversation scope, the Stage view, or hiding an App must not tear down
-    // its iframe/MessagePort. Losing the catalog entry (including
-    // ROOM_APPS_ENABLED turning off) does, and is the one host teardown path
-    // besides unmounting the Room itself.
-    if (activeRoomAppId && !roomApps.some((app) => app.id === activeRoomAppId))
-      setActiveRoomAppId(null)
+    // Resident hosts survive presentation changes and ordinary transport
+    // reconnects; they are torn down only when Room Apps are stably unavailable
+    // (the Room is connected/failed and the flag is still off, which covers
+    // ROOM_APPS_ENABLED being turned off) or when the curated catalog truly no
+    // longer offers the entry. Unmounting the Room closes them as well.
+    const stablyUnavailable =
+      !roomAppsEnabled &&
+      (connectionStatus === "connected" || connectionStatus === "failed")
+    const hostIsGone = (id: string) =>
+      stablyUnavailable || !curatedRoomApps.some((app) => app.id === id)
+    if (activeRoomAppId && hostIsGone(activeRoomAppId)) setActiveRoomAppId(null)
     setLaunchedRoomAppIds((previous) => {
-      const next = previous.filter((id) =>
-        roomApps.some((app) => app.id === id)
-      )
+      const next = previous.filter((id) => !hostIsGone(id))
       return next.length === previous.length ? previous : next
     })
-  }, [activeRoomAppId, roomApps])
+  }, [activeRoomAppId, connectionStatus, curatedRoomApps, roomAppsEnabled])
 
   const launchRoomApp = useCallback((appId: string) => {
     setLaunchedRoomAppIds((previous) =>


### PR DESCRIPTION
Closes #371
Refs #361
Refs #344

Production dogfood after #369 confirmed the Stage placement, then exposed the remaining host-lifecycle bug: Stage navigation unmounted `RoomAppHost`, so hiding Canvas for Arena / Screen / Live View destroyed its iframe, MessagePort and App-local state. Reopening started empty, and once every Human had switched away, no in-browser replica was left to serve Canvas's canonical bootstrap.

This makes App session lifetime a browser-Room-scoped concern and Stage navigation presentation-only. No protocol, transport, catalog, Lab or persistence change.

## State model

```text
activeConversation   room | taskRequestId                    (unchanged, #369)
activeStage          participants | screen | liveView | roomApp
                     (which App is *visible*)
launchedRoomApps     bounded browser-local set of App ids whose hosts stay mounted
```

- `activeRoomAppId` no longer decides whether a host exists. The first Stage entry click launches: mount `RoomAppHost`, add the App to `launchedRoomApps`, show it. `launchedRoomApps` is bounded by the existing `ROOM_APP_MAX_INSTANCES` and can never exceed the curated catalog the panel already slices.
- Render: one visibility slot per resident App (`room-app-slot-<id>`), each holding an unkeyed-by-visibility `RoomAppHost`. The active one gets `flex min-h-0 flex-1 flex-col`; the rest get `hidden` plus `inert` and `aria-hidden="true"`.
- Hide paths (Stage entry toggled off, the host's own Close button, switching to Screen / Live View) only clear `activeRoomAppId`. No unmount, no port close, no re-bootstrap, no new epoch.
- Re-showing a resident App renders the same `RoomAppHost` at the same position in the list, so React reuses the exact iframe element and MessagePort.
- Teardown boundary: the catalog losing an entry — which covers `ROOM_APPS_ENABLED` turning off — prunes `launchedRoomApps` and unmounts the host; unmounting `RoomContent` (leaving the Room) unmounts them all. Each `RoomAppHost` closes its own port exactly once in its existing cleanup.
- No generic reset was added. Per-App reset stays App-owned: Canvas already has *Clear canvas*; a future game owns Ready/Restart.

## Hidden Apps: alive, but not interactive

Hidden slots are `display: none` (out of hit-testing and tab order) **and** `inert` + `aria-hidden="true"` (explicitly non-focusable and out of the accessibility tree). For browsers older than `inert` support, `display: none` alone already provides the non-interactivity guarantee.

Hidden hosts stay mounted and keep receiving the bounded logical App messages they already received, so a hidden Canvas remains a valid canonical-bootstrap incumbent and can reconcile. Nothing new is sent to keep them alive: visibility changes produce no host traffic, no heartbeat, no extra PeerConnection, and no DO/history/storage write. A hidden fixture with an animation loop simply keeps running client-side; any pause/resume optimisation stays a domain decision under Lab #13.

## Tests

`RoomContent.test.tsx` — the Stage describe block is now residency-focused (13 cases). The five #369 cases that asserted destroy-on-switch were replaced by their residency equivalents, the two Stage-entry availability cases from the #369 review are preserved, and the following were added:

1. first Canvas launch creates exactly one iframe and one MessagePort, and the Stage takes 75% while Room chat stays selected and rendered;
2. launch once → hide → show reuses the same iframe and the same port (no new channel, no outbound traffic);
3. visual Close is Hide: the Stage returns to participants, the host stays mounted, reopening restores the identical iframe/port;
4. Canvas → Arena leaves the Canvas iframe and port alive behind the visible Arena, and returning to Canvas restores the exact same Canvas iframe;
5. two RoomContent instances (Alice + Bob) both launch Canvas, both hide it, both reopen: neither resident session was destroyed and each gets its own iframe back — the production "both Humans hid Canvas" case;
6. a hidden App still receives a remote reliable payload through the resident port, and hiding produces no `send` traffic;
7. App → Screen / Live View hides the App, keeps the host and port, and leaves the Task conversation scope selected;
8. Screen-only and LiveView-only Stage entries stay reachable while an App is open (the #369 review cases, updated to residency assertions);
9. hidden slots are `hidden` + `inert` + `aria-hidden="true"`, the visible slot is not;
10. catalog removal (`ROOM_APPS_ENABLED` off) unmounts both resident hosts and closes both ports exactly once;
11. unmounting `RoomContent` closes every resident MessagePort exactly once;
12. Room ↔ Task conversation switching keeps the same resident host (from #369);
13. first-launch Stage placement (from #369).

Mutation-checked: rendering only the visible App (the old destroy-on-switch shape) fails 8 residency cases; dropping `inert`/`aria-hidden` fails exactly the non-interactive case.

`git diff -w` on `RoomContent.tsx` is 94 lines of real change; the raw diff is larger only because the existing Screen / Live View / participants branches moved one JSX level deeper.

## Verification

```
prettier --check .                       pass
yarn lint --max-warnings 0               pass
yarn type-check                          pass
yarn docs:check                          pass
yarn test                                831 passed / 89 files
yarn cf-build                            pass
git diff --check                         clean
```

## Non-goals / not changed

No Durable Object, Room history, database or external App persistence; no new host protocol (`suspend`/`resume`); no heartbeat; no new PeerConnection or realtime backend; no arbitrary URLs, SDK, registry, manifest, workspace/window manager or generic reset; #356 protocol, MessagePort handshake, iframe sandbox, catalog URLs, reliable/realtime lanes, payload/rate guards, SFU, Task Live View, Screen Share, #363 composer/attachments and the Lab fixtures are untouched. Tiny Arena's App-local first-open/reopen current-transform convergence is **not** touched here and remains Lab #13.
