### PR TITLE
fix(room): compact Agent cards become presence cards (identity + one bounded action row)

### DIFF
--- a/app/src/components/UserCard.compactAgent.test.tsx
+++ b/app/src/components/UserCard.compactAgent.test.tsx
@@ -1,0 +1,150 @@
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import UserCard from "./UserCard"
+
+/**
+ * #348: compact participant cards are presence cards, not capability
+ * dashboards. A compact Agent card must keep the same fixed footprint as a
+ * compact Human card, so the old stacked Agent badge / activity / VOICE /
+ * TASK rows are gone: identity (kind glyph) rides the name line, activity is
+ * a restrained avatar indicator, and Voice + Task share ONE bounded,
+ * non-wrapping action row.
+ *
+ * jsdom cannot measure pixels, so these tests pin the structural invariant
+ * that makes overflow impossible: a single fixed-height row with nowrap, and
+ * no more stacked blocks than a compact Human card has.
+ */
+
+afterEach(cleanup)
+
+function agentCard(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Pi",
+    kind: "agent" as const,
+    room: "room",
+    peerId: "agent-pi",
+    compact: true,
+    voiceAvailable: true,
+    voiceEnabled: false,
+    onToggleAgentVoice: vi.fn(),
+    onStartTask: vi.fn(),
+    activity: "using_tools" as const,
+    ...overrides,
+  }
+}
+
+function compactShell(): HTMLElement {
+  const shell = document.querySelector(".participant-card-shell--compact")
+  expect(shell).toBeTruthy()
+  return shell as HTMLElement
+}
+
+/** Visible stacked blocks of the compact card (audio is layout-invisible). */
+function stackedBlocks(shell: HTMLElement): Element[] {
+  const card = shell.firstElementChild as HTMLElement
+  return Array.from(card.children).filter((el) => el.tagName !== "AUDIO")
+}
+
+describe("compact Agent card density (#348)", () => {
+  it("keeps a fully loaded Agent inside one bounded, non-wrapping action row", () => {
+    const { getByTestId, getByRole } = render(<UserCard {...agentCard()} />)
+
+    const row = getByTestId("compact-agent-controls")
+    const voice = getByRole("button", { name: "Enable voice for Pi" })
+    const task = getByRole("button", { name: "Start task with Pi" })
+
+    // VOICE and TASK share exactly one parent row: they can never restack.
+    expect(voice.parentElement).toBe(row)
+    expect(task.parentElement).toBe(row)
+    expect(row).toHaveClass("flex-nowrap")
+    expect(row).not.toHaveClass("flex-wrap")
+    // The fixed row height bounds what the action row can add to the card.
+    expect(row).toHaveClass("h-6")
+
+    // No wrapping container survives anywhere in the compact card.
+    expect(compactShell().querySelectorAll(".flex-wrap").length).toBe(0)
+  })
+
+  it("does not stack more visible rows than a compact Human card", () => {
+    const human = render(
+      <UserCard
+        name="Hannah"
+        kind="human"
+        room="room"
+        peerId="local-peer"
+        compact
+        onMuteSelf={vi.fn()}
+      />
+    )
+    const humanBlocks = stackedBlocks(compactShell())
+    human.unmount()
+
+    render(<UserCard {...agentCard()} />)
+    const agentBlocks = stackedBlocks(compactShell())
+
+    // avatar + identity line + ONE action row, exactly like the compact Human
+    // card (avatar + name + self actions). Agent-only controls no longer add a
+    // further block — that extra block is what pushed TASK below the shell.
+    expect(agentBlocks.map((el) => el.tagName)).toEqual(
+      humanBlocks.map((el) => el.tagName)
+    )
+    expect(agentBlocks.length).toBe(3)
+  })
+
+  it("keeps Agent identity and activity out of the vertical control stack", () => {
+    const { getByTestId } = render(<UserCard {...agentCard()} />)
+
+    const kind = getByTestId("compact-agent-kind")
+    expect(kind).toHaveAccessibleName("Agent")
+    // Identity rides the truncated name line instead of its own badge row.
+    expect(kind.closest("p")).toBeTruthy()
+    expect(kind.closest('[data-testid="compact-agent-controls"]')).toBeNull()
+
+    const activity = getByTestId("agent-activity")
+    expect(activity).toHaveAccessibleName("Using tools")
+    expect(activity.getAttribute("title")).toBe("Using tools")
+    // Activity is a compact avatar indicator with a tooltip, not a text row.
+    expect(activity.closest(".participant-card__avatar")).toBeTruthy()
+    expect(
+      activity.closest('[data-testid="compact-agent-controls"]')
+    ).toBeNull()
+  })
+
+  it("keeps compact Voice and Task clickable in the shared action row", () => {
+    const props = agentCard()
+    const { getByRole } = render(<UserCard {...props} />)
+
+    fireEvent.click(getByRole("button", { name: "Enable voice for Pi" }))
+    expect(props.onToggleAgentVoice).toHaveBeenCalledWith("agent-pi", true)
+
+    fireEvent.click(getByRole("button", { name: "Start task with Pi" }))
+    expect(props.onStartTask).toHaveBeenCalledWith("agent-pi", "Pi")
+  })
+
+  it("keeps the enabled Voice state on the same single icon row", () => {
+    const { getByRole, getByTestId } = render(
+      <UserCard {...agentCard({ voiceEnabled: true })} />
+    )
+
+    const voice = getByRole("button", { name: "Mute Pi" })
+    const row = getByTestId("compact-agent-controls")
+    expect(voice.parentElement).toBe(row)
+    expect(row).toHaveClass("flex-nowrap")
+  })
+
+  it("omits the action row entirely for an Agent without controls", () => {
+    const { queryByTestId } = render(
+      <UserCard
+        {...agentCard({
+          voiceAvailable: false,
+          onStartTask: undefined,
+          activity: undefined,
+        })}
+      />
+    )
+
+    expect(queryByTestId("compact-agent-controls")).toBeNull()
+    expect(queryByTestId("agent-activity")).toBeNull()
+  })
+})

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -19,6 +19,57 @@ interface UserCardProps extends UserInfo {
   onStartTask?: (peerId: string, name: string) => void
 }
 
+/**
+ * #348 compact Agent cards are presence cards, not capability dashboards.
+ * The Voice/Task controls are icon-sized so the single bounded action row
+ * always fits the shared compact footprint; the accessible VOICE/TASK labels
+ * live on the buttons themselves.
+ */
+function CompactMicIcon({ off = false }: { off?: boolean }) {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      fill="currentColor"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {off ? (
+        <>
+          <path d="M13 8c0 .564-.094 1.107-.266 1.613l-.814-.814A4.02 4.02 0 0 0 12 8V7a.5.5 0 0 1 1 0v1zm-5 4c.818 0 1.578-.245 2.212-.667l.718.719a4.973 4.973 0 0 1-2.43.923V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 1 0v1a4 4 0 0 0 4 4zm3-9v4.879l-1-1V3a2 2 0 0 0-3.997-.118l-.845-.845A3.001 3.001 0 0 1 11 3z" />
+          <path d="m9.486 10.607-.748-.748A2 2 0 0 1 6 8v-.878l-1-1V8a3 3 0 0 0 4.486 2.607zm-7.84-9.253 12 12 .708-.708-12-12-.708.708z" />
+        </>
+      ) : (
+        <>
+          <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z" />
+          <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0v5zM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3z" />
+        </>
+      )}
+    </svg>
+  )
+}
+
+function CompactTaskIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <rect x="2.75" y="2.75" width="10.5" height="10.5" rx="2.5" />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m5.9 8.2 1.5 1.5 3-3.3"
+      />
+    </svg>
+  )
+}
+
 function UserCard(user: UserCardProps) {
   const audioRef = useRef<HTMLAudioElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)
@@ -89,61 +140,74 @@ function UserCard(user: UserCardProps) {
                 </svg>
               </span>
             )}
+            {/* #348: agent activity is a restrained avatar indicator, never a
+                stacked text row. The label stays available as a tooltip. */}
+            {user.kind === "agent" && user.activity && (
+              <span
+                data-testid="agent-activity"
+                role="img"
+                aria-label={agentActivityLabel(user.activity)}
+                title={agentActivityLabel(user.activity)}
+                className="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-gray-900/90"
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-blue-300" />
+              </span>
+            )}
           </div>
           <p className="mt-1.5 min-w-0 max-w-full truncate text-center text-xs text-white">
+            {user.kind === "agent" && (
+              <span
+                data-testid="compact-agent-kind"
+                role="img"
+                aria-label="Agent"
+                title="Agent"
+                className="mr-0.5"
+              >
+                🤖
+              </span>
+            )}
             {displayName}
           </p>
-          {user.kind === "agent" && (
-            <span className="participant-card__kind mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
-              🤖 Agent
-            </span>
-          )}
-          {user.kind === "agent" && (
-            <div
-              data-testid="compact-agent-controls"
-              className="mt-1 flex max-w-full flex-wrap items-center justify-center gap-1"
-            >
-              {user.activity && (
-                <span
-                  data-testid="agent-activity"
-                  className="max-w-full truncate text-[9px] text-blue-200/80"
-                >
-                  {agentActivityLabel(user.activity)}…
-                </span>
-              )}
-              {user.voiceAvailable && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    user.onToggleAgentVoice?.(user.peerId, !user.voiceEnabled)
-                  }
-                  title={
-                    user.voiceEnabled
-                      ? `Mute ${user.name}`
-                      : `Enable voice for ${user.name}`
-                  }
-                  aria-label={
-                    user.voiceEnabled
-                      ? `Mute ${user.name}`
-                      : `Enable voice for ${user.name}`
-                  }
-                  className="participant-card__voice-button participant-card__voice-button--compact min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  {user.voiceEnabled ? "VOICE ●" : "VOICE"}
-                </button>
-              )}
-              {!isSelf && user.onStartTask && (
-                <button
-                  type="button"
-                  onClick={() => user.onStartTask?.(user.peerId, user.name)}
-                  aria-label={`Start task with ${user.name}`}
-                  className="min-h-6 rounded-full border border-blue-400/60 px-2 text-[9px] text-blue-200 hover:bg-blue-500/20"
-                >
-                  TASK
-                </button>
-              )}
-            </div>
-          )}
+          {user.kind === "agent" &&
+            (user.voiceAvailable || (!isSelf && user.onStartTask)) && (
+              <div
+                data-testid="compact-agent-controls"
+                className="mt-1 flex h-6 flex-nowrap items-center justify-center gap-1"
+              >
+                {user.voiceAvailable && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      user.onToggleAgentVoice?.(user.peerId, !user.voiceEnabled)
+                    }
+                    title={
+                      user.voiceEnabled
+                        ? `Mute ${user.name}`
+                        : `Enable voice for ${user.name}`
+                    }
+                    aria-label={
+                      user.voiceEnabled
+                        ? `Mute ${user.name}`
+                        : `Enable voice for ${user.name}`
+                    }
+                    className="participant-card__voice-button participant-card__voice-button--compact disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <CompactMicIcon off={!user.voiceEnabled} />
+                  </button>
+                )}
+                {!isSelf && user.onStartTask && (
+                  <button
+                    type="button"
+                    onClick={() => user.onStartTask?.(user.peerId, user.name)}
+                    title={`Start task with ${user.name}`}
+                    aria-label={`Start task with ${user.name}`}
+                    className="participant-card__task-button participant-card__task-button--compact"
+                  >
+                    <CompactTaskIcon />
+                  </button>
+                )}
+              </div>
+            )}
           {isSelf && (
             <div className="mt-1 flex gap-1">
               <button

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -602,6 +602,41 @@ html {
   color: #64748b !important;
 }
 
+/*
+ * #348: in the compact participant strip the Agent Voice/Task controls are
+ * icon-sized toggles. The shared voice-button min-width (3.8rem) is wider than
+ * the whole compact card content box, which is what forced the old action row
+ * to wrap and push TASK below the card shell. Keep both controls at one fixed
+ * 1.5rem target inside the single non-wrapping action row.
+ */
+.participant-card__voice-button--compact,
+.participant-card__task-button--compact {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  place-items: center;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 0.4rem !important;
+}
+
+.participant-card__task-button--compact {
+  border: 1px solid rgba(96, 165, 250, 0.55);
+  background: rgba(30, 58, 138, 0.24) !important;
+  color: #bfdbfe !important;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.participant-card__task-button--compact:hover,
+.participant-card__task-button--compact:focus-visible {
+  border-color: rgba(147, 197, 253, 0.9);
+  background: rgba(37, 99, 235, 0.32) !important;
+  outline: none;
+}
+
 .participant-card__self-action {
   display: grid;
   width: 1.55rem;


### PR DESCRIPTION
Closes #348

## Root cause

Compact participant cards are fixed `8rem` shells with an `84px` width (`RoomContent` passes `w-[84px]`), so the card content box is only 66px.

The compact Agent card stacked **four** visible blocks there: avatar / name / `🤖 Agent` badge / activity + VOICE + TASK. Two independent overflows followed:

1. the blocks themselves already exceeded the shell height;
2. the shared `.participant-card__voice-button { min-width: 3.8rem }` (60.8px) is almost the whole 66px content box, so the `flex-wrap` action row from #351 could never fit VOICE + TASK on one line.

Measured on the base commit, compact Agent with `kind=agent` + `voiceAvailable` + `onStartTask` + `activity`, at the production 84px width:

```
cardHeight       128
overflowY         20
row height        61   (three stacked lines)
row bottom       -19.25 below the card shell   ← the reported TASK protrusion
child tops        106.25 / 123.75 / 151.75      ← stacked, not one row
```

## Change

Reduce the compact Agent hierarchy (no new wrapping, no taller strip, no hidden capability):

```
┌──────────────┐
│   (avatar)   │   activity = small avatar indicator (title + aria-label)
│  🤖 pi-mac…  │   identity rides the truncated name line
│   🔊    ◇    │   ONE bounded h-6, flex-nowrap row of 1.5rem icon toggles
└──────────────┘
```

- `app/src/components/UserCard.tsx` — compact-only: kind glyph inline on the name line, activity as an avatar badge, Voice/Task as icon toggles in a single `h-6 flex-nowrap` row keeping their existing `aria-label` / `title` / click semantics. Full-size card untouched.
- `app/src/styles/tailwind.css` — `.participant-card__voice-button--compact` / `.participant-card__task-button--compact`: fixed 1.5rem targets that drop the shared 3.8rem voice-button min-width which forced the wrap. Base and full-size rules unchanged.
- `app/src/components/UserCard.compactAgent.test.tsx` — focused regression: one bounded non-wrapping row, VOICE and TASK share exactly one parent, kind/activity add no vertical control row, no `.flex-wrap` anywhere in the compact card, and no more stacked blocks than a compact Human card. jsdom cannot measure pixels, so the structural invariant is pinned instead.

No RoomContent state/lifecycle, screen-share, Voice transport, Task semantics, Agent Runtime, SFU or participant-protocol change.

## Verification

Same measurement after the change (Chromium, production 84px width):

```
             shellW  shellH  overflowY  overflowX  blocks  row height  row top shared
human          84      128       0          0        3        -            -
agent          84      128       0          0        3       24          yes
agent(voice●)  84      128       0          0        3       24          yes
```

- `yarn prettier --check .` ✅
- `yarn lint --max-warnings 0` ✅
- `yarn type-check` ✅
- `yarn test` ✅ 90 files / 831 tests
- `yarn cf-build` ✅ OpenNext build complete (the 36 `Failed to copy` lines for ESM markdown packages are pre-existing upstream noise — the same 36 appear in the successful cf-sfu `55bd262` deploy log)
- `git diff --check` ✅

Acceptance: same outer height for Human/Agent compact cards (1), every control inside the shell for the fully loaded Agent (2, 3), no horizontal overflow (4), Voice/Task clickable + accessible (5, 6), Agent identity visible (7), activity available non-disruptively (8), strip layout unchanged (9), full card unchanged (10).