### PR TITLE
feat(room-app): launch Whiteboard with discovery and product telemetry

### DIFF
--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -4,6 +4,9 @@
     <loc>https://www.free4.chat/</loc>
   </url>
   <url>
+    <loc>https://www.free4.chat/apps/whiteboard</loc>
+  </url>
+  <url>
     <loc>https://www.free4.chat/temporary-chat-room</loc>
   </url>
   <url>

--- a/app/scripts/generate-docs-assets.mjs
+++ b/app/scripts/generate-docs-assets.mjs
@@ -28,6 +28,7 @@ const PUBLIC_DIR = join(appRoot, "public")
 /** Sitemap URLs that exist independently of the docs library, in order. */
 const BASE_SITEMAP_PATHS = [
   "/",
+  "/apps/whiteboard",
   "/temporary-chat-room",
   "/ai-agent-room",
   "/multi-agent-collaboration",

--- a/app/src/__tests__/discovery/copy-accuracy.test.ts
+++ b/app/src/__tests__/discovery/copy-accuracy.test.ts
@@ -70,3 +70,18 @@ describe("/ai-agent-room copy accuracy", () => {
     expect(source).toMatch(/resident/i)
   })
 })
+
+describe("/apps/whiteboard copy accuracy", () => {
+  const source = read("src/pages/apps/whiteboard.tsx")
+
+  it("states the V1 collaboration, mobile, and temporary-state boundaries", () => {
+    expect(source).toMatch(/Excalidraw-powered drawing and editing/)
+    expect(source).toMatch(/without an account or sign-up/)
+    expect(source).toMatch(/voice, text, and file sharing/)
+    expect(source).toMatch(/touch input/)
+    expect(source).toMatch(/does not\s+save a permanent board/)
+    expect(source).toMatch(/replica disappears or reloads/)
+    expect(source).toMatch(/Image and file import is not supported/)
+    expect(source).not.toMatch(/Agent/)
+  })
+})

--- a/app/src/__tests__/discovery/crawl-surface.test.ts
+++ b/app/src/__tests__/discovery/crawl-surface.test.ts
@@ -56,6 +56,7 @@ describe("sitemap.xml", () => {
     expect(new Set(locs)).toEqual(
       new Set([
         "https://www.free4.chat/",
+        "https://www.free4.chat/apps/whiteboard",
         "https://www.free4.chat/temporary-chat-room",
         "https://www.free4.chat/ai-agent-room",
         "https://www.free4.chat/multi-agent-collaboration",

--- a/app/src/__tests__/discovery/pages-cta.test.tsx
+++ b/app/src/__tests__/discovery/pages-cta.test.tsx
@@ -1,9 +1,13 @@
 import type { ReactElement } from "react"
 
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+const router = vi.hoisted(() => ({ push: vi.fn() }))
+vi.mock("next/router", () => ({ useRouter: () => router }))
+
 import AiAgentRoomPage from "../../pages/ai-agent-room"
+import WhiteboardPage from "../../pages/apps/whiteboard"
 import MultiAgentCollaborationPage from "../../pages/multi-agent-collaboration"
 import PrivacyPage from "../../pages/privacy"
 import TemporaryChatRoomPage from "../../pages/temporary-chat-room"
@@ -81,4 +85,37 @@ describe("Discovery pages — CTA analytics", () => {
       unmount()
     }
   )
+})
+
+describe("Whiteboard direct Room CTA", () => {
+  it("saves a generated nickname and opens a generated Room with Whiteboard selected", () => {
+    const track = vi.fn()
+    const zarazTrack = vi.fn()
+    ;(window as unknown as { umami: { track: typeof track } }).umami = {
+      track,
+    }
+    ;(window as unknown as { zaraz: { track: typeof zarazTrack } }).zaraz = {
+      track: zarazTrack,
+    }
+    window.localStorage.removeItem("rooms")
+    router.push.mockClear()
+
+    render(<WhiteboardPage />)
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Whiteboard Room" })
+    )
+
+    expect(track).toHaveBeenCalledWith("DiscoveryCtaClicked", {
+      page: "whiteboard",
+    })
+    const savedRooms = JSON.parse(
+      window.localStorage.getItem("rooms") ?? "[]"
+    ) as Array<{ roomName: string; nickName: string }>
+    expect(savedRooms).toHaveLength(1)
+    expect(savedRooms[0].roomName).toBeTruthy()
+    expect(savedRooms[0].nickName).toBeTruthy()
+    expect(router.push).toHaveBeenCalledWith(
+      `/room?id=${encodeURIComponent(savedRooms[0].roomName)}&app=whiteboard`
+    )
+  })
 })

--- a/app/src/__tests__/discovery/pages-seo.test.tsx
+++ b/app/src/__tests__/discovery/pages-seo.test.tsx
@@ -25,8 +25,12 @@ vi.mock("../../components/DiscoveryPageLayout", () => ({
     />
   ),
 }))
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
 
 import AiAgentRoomPage from "../../pages/ai-agent-room"
+import WhiteboardPage from "../../pages/apps/whiteboard"
 import MultiAgentCollaborationPage from "../../pages/multi-agent-collaboration"
 import PrivacyPage from "../../pages/privacy"
 import TemporaryChatRoomPage from "../../pages/temporary-chat-room"
@@ -48,6 +52,11 @@ const PAGES: Array<{
     path: "/multi-agent-collaboration",
   },
   { name: "privacy", Component: PrivacyPage, path: "/privacy" },
+  {
+    name: "apps/whiteboard",
+    Component: WhiteboardPage,
+    path: "/apps/whiteboard",
+  },
 ]
 
 function renderStub(Component: () => ReactElement) {

--- a/app/src/__tests__/pages/room.test.tsx
+++ b/app/src/__tests__/pages/room.test.tsx
@@ -27,4 +27,13 @@ describe("Room page", () => {
     expect(source).toMatch(/setNickName\(generateParticipantName\(\)\)/)
     expect(source).toMatch(/setNickName\(room\.nickName\)/)
   })
+
+  it("passes only a curated production App id from the app query to RoomContent", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/pages/room.tsx"),
+      "utf-8"
+    )
+    expect(source).toContain("resolveProductionRoomAppId(router.query.app)")
+    expect(source).toContain("initialRoomAppId={initialRoomAppId ?? undefined}")
+  })
 })

--- a/app/src/common/roomApp.test.ts
+++ b/app/src/common/roomApp.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   ROOM_APP_CATALOG,
+  ROOM_APP_LOCAL_CATALOG,
   ROOM_APP_MAX_PAYLOAD_BYTES,
   decodeRoomAppClientMessage,
   decodeRoomAppEnvelope,
@@ -11,10 +12,34 @@ import {
   projectRoomAppParticipants,
   roomAppRateGuard,
   roomAppInstanceId,
+  resolveProductionRoomAppId,
   validateRoomAppDefinition,
 } from "./roomApp"
 
 describe("Room App Phase 0 bridge contract", () => {
+  it("exposes only Whiteboard in production and keeps Phase-0 apps local", () => {
+    expect(ROOM_APP_CATALOG).toEqual([
+      {
+        id: "whiteboard",
+        label: "Whiteboard",
+        url: "https://room-apps.free4.chat/whiteboard",
+        origin: "https://room-apps.free4.chat",
+      },
+    ])
+    expect(ROOM_APP_LOCAL_CATALOG.map((app) => app.id)).toEqual([
+      "shared-canvas",
+      "tiny-arena",
+    ])
+  })
+
+  it("resolves direct launch by exact curated production id only", () => {
+    expect(resolveProductionRoomAppId("whiteboard")).toBe("whiteboard")
+    expect(resolveProductionRoomAppId("shared-canvas")).toBeNull()
+    expect(resolveProductionRoomAppId("https://example.com/app")).toBeNull()
+    expect(resolveProductionRoomAppId(["whiteboard"])).toBeNull()
+    expect(resolveProductionRoomAppId("unknown")).toBeNull()
+  })
+
   it("accepts only curated app definitions and rejects arbitrary origins", () => {
     expect(
       validateRoomAppDefinition({
@@ -87,13 +112,13 @@ describe("Room App Phase 0 bridge contract", () => {
   })
 
   it("accepts only curated instances for the current Room", () => {
-    expect(isRoomAppInstanceForRoom("room-a", "shared-canvas:00000000")).toBe(
+    expect(isRoomAppInstanceForRoom("room-a", "whiteboard:00000000")).toBe(
       false
     )
     expect(
       isRoomAppInstanceForRoom(
         "room-a",
-        roomAppInstanceId("room-a", "shared-canvas")
+        roomAppInstanceId("room-a", "whiteboard")
       )
     ).toBe(true)
   })

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -16,22 +16,14 @@ export interface RoomAppDefinition {
   origin: string
 }
 
-// These are build-time curated fixture identities, not a user-controlled URL
-// loader. The Worker-side flag keeps the catalog hidden until the experiment is
-// deliberately enabled in an environment. Both fixtures share this origin
-// contract and may later be deployed under these paths without changing the
-// host/bridge protocol.
+// This is the user-visible production catalog, not a user-controlled URL
+// loader. The Worker-side flag keeps the catalog hidden until Room Apps are
+// deliberately enabled in an environment.
 export const ROOM_APP_CATALOG: readonly RoomAppDefinition[] = [
   {
-    id: "shared-canvas",
-    label: "Shared Canvas",
-    url: "https://room-apps.free4.chat/shared-canvas",
-    origin: "https://room-apps.free4.chat",
-  },
-  {
-    id: "tiny-arena",
-    label: "Tiny Arena",
-    url: "https://room-apps.free4.chat/tiny-arena",
+    id: "whiteboard",
+    label: "Whiteboard",
+    url: "https://room-apps.free4.chat/whiteboard",
     origin: "https://room-apps.free4.chat",
   },
 ]
@@ -254,6 +246,15 @@ export function isRoomAppAllowlisted(app: RoomAppDefinition): boolean {
         validateRoomAppDefinition(candidate)
     )
   )
+}
+
+/** Resolve a URL query value only to an exact, validated production App id. */
+export function resolveProductionRoomAppId(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const app = ROOM_APP_CATALOG.find((candidate) => candidate.id === value)
+  return app && validateRoomAppDefinition(app) && isRoomAppAllowlisted(app)
+    ? app.id
+    : null
 }
 
 export function projectRoomAppParticipants(

--- a/app/src/components/DiscoveryPageLayout.tsx
+++ b/app/src/components/DiscoveryPageLayout.tsx
@@ -24,6 +24,11 @@ export interface DiscoveryPageLayoutProps {
     /** Small, static destination bucket — never a URL or user-provided value. */
     analyticsTarget: "mcp-docs" | "bring-agent" | "github"
   }
+  /** Optional action CTA for a page that creates a Room before navigation. */
+  primaryCta?: {
+    label: string
+    onClick: () => void
+  }
 }
 
 export default function DiscoveryPageLayout({
@@ -34,7 +39,10 @@ export default function DiscoveryPageLayout({
   h1,
   children,
   secondaryCta,
+  primaryCta,
 }: DiscoveryPageLayoutProps) {
+  const primaryCtaClassName =
+    "group flex items-center justify-center rounded-none border border-emerald-300/60 bg-emerald-500 px-5 py-3 font-mono text-sm font-bold uppercase tracking-widest text-black transition hover:bg-emerald-400 focus:outline-none focus:ring focus:ring-emerald-300"
   return (
     <div className="flex min-h-screen flex-col font-mono text-emerald-100">
       <SeoHead title={title} description={description} path={path} />
@@ -53,15 +61,28 @@ export default function DiscoveryPageLayout({
             {children}
           </div>
           <div className="mt-10 flex flex-wrap items-center gap-4">
-            <Link
-              href="/"
-              onClick={() =>
-                trackAnalyticsEvent("DiscoveryCtaClicked", { page: ctaId })
-              }
-              className="group flex items-center justify-center rounded-none border border-emerald-300/60 bg-emerald-500 px-5 py-3 font-mono text-sm font-bold uppercase tracking-widest text-black transition hover:bg-emerald-400 focus:outline-none focus:ring focus:ring-emerald-300"
-            >
-              Open a room
-            </Link>
+            {primaryCta ? (
+              <button
+                type="button"
+                onClick={() => {
+                  trackAnalyticsEvent("DiscoveryCtaClicked", { page: ctaId })
+                  primaryCta.onClick()
+                }}
+                className={primaryCtaClassName}
+              >
+                {primaryCta.label}
+              </button>
+            ) : (
+              <Link
+                href="/"
+                onClick={() =>
+                  trackAnalyticsEvent("DiscoveryCtaClicked", { page: ctaId })
+                }
+                className={primaryCtaClassName}
+              >
+                Open a room
+              </Link>
+            )}
             {secondaryCta && (
               <Link
                 href={secondaryCta.href}

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -30,9 +30,9 @@ class TestMessageChannel {
 }
 
 const app = {
-  id: "shared-canvas",
-  label: "Shared Canvas",
-  url: "https://room-apps.free4.chat/shared-canvas",
+  id: "whiteboard",
+  label: "Whiteboard",
+  url: "https://room-apps.free4.chat/whiteboard",
   origin: "https://room-apps.free4.chat",
 } as const
 
@@ -55,17 +55,19 @@ afterEach(() => {
 describe("RoomAppHost", () => {
   it("sandboxes an allowlisted App and establishes an owned MessagePort", () => {
     vi.stubGlobal("MessageChannel", TestMessageChannel)
+    const onReady = vi.fn()
     const onClose = vi.fn()
     const subscribe = vi.fn(() => () => undefined)
     const send = vi.fn(() => true)
     const rendered = render(
       <RoomAppHost
         app={app}
-        appInstanceId="shared-canvas:room"
+        appInstanceId="whiteboard:room"
         self={self}
         participants={participants}
         subscribe={subscribe}
         send={send}
+        onReady={onReady}
         onClose={onClose}
       />
     )
@@ -84,7 +86,7 @@ describe("RoomAppHost", () => {
     expect(targetOrigin).toBe("*")
     expect(bootstrap).toMatchObject({
       type: "room-app-bootstrap",
-      appInstanceId: "shared-canvas:room",
+      appInstanceId: "whiteboard:room",
     })
     expect(bootstrap).not.toHaveProperty("token")
     expect(bootstrap).not.toHaveProperty("participantToken")
@@ -94,18 +96,28 @@ describe("RoomAppHost", () => {
     act(() => {
       lastChannel!.port1.emit({
         type: "ready",
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         handshakeToken: bootstrap.handshakeToken,
       })
     })
     expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "ready",
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         self,
         participants,
       })
     )
+    expect(onReady).toHaveBeenCalledTimes(1)
+    expect(onReady).toHaveBeenCalledWith("whiteboard")
+    act(() => {
+      lastChannel!.port1.emit({
+        type: "ready",
+        appInstanceId: "whiteboard:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+    })
+    expect(onReady).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -121,7 +133,7 @@ describe("RoomAppHost", () => {
     render(
       <RoomAppHost
         app={app}
-        appInstanceId="shared-canvas:room"
+        appInstanceId="whiteboard:room"
         self={self}
         participants={participants}
         subscribe={() => () => undefined}
@@ -136,7 +148,7 @@ describe("RoomAppHost", () => {
     const bootstrap = frameWindow.postMessage.mock.calls[0][0]
     const port = lastChannel!.port1
     act(() => {
-      port.emit({ type: "bogus", appInstanceId: "shared-canvas:room" })
+      port.emit({ type: "bogus", appInstanceId: "whiteboard:room" })
     })
     expect(port.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", error: "unsupported_message" })
@@ -152,16 +164,16 @@ describe("RoomAppHost", () => {
     act(() => {
       port.emit({
         type: "ready",
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         handshakeToken: bootstrap.handshakeToken,
       })
       port.emit({
         type: "sendReliable",
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         payload: { type: "stroke", points: [[1, 2]] },
       })
     })
-    expect(send).toHaveBeenCalledWith("reliable", "shared-canvas:room", {
+    expect(send).toHaveBeenCalledWith("reliable", "whiteboard:room", {
       type: "stroke",
       points: [[1, 2]],
     })
@@ -177,7 +189,7 @@ describe("RoomAppHost", () => {
     const { rerender } = render(
       <RoomAppHost
         app={app}
-        appInstanceId="shared-canvas:room"
+        appInstanceId="whiteboard:room"
         self={self}
         participants={participants}
         subscribe={subscribe}
@@ -193,12 +205,12 @@ describe("RoomAppHost", () => {
     act(() => {
       lastChannel!.port1.emit({
         type: "ready",
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         handshakeToken: bootstrap.handshakeToken,
       })
       listener?.({
         protocolVersion: 1,
-        appInstanceId: "shared-canvas:room",
+        appInstanceId: "whiteboard:room",
         lane: "realtime",
         sourceParticipantId: "human-b",
         payload: { type: "cursor", x: 2 },
@@ -206,14 +218,14 @@ describe("RoomAppHost", () => {
     })
     expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
       type: "realtime",
-      appInstanceId: "shared-canvas:room",
+      appInstanceId: "whiteboard:room",
       sourceParticipantId: "human-b",
       payload: { type: "cursor", x: 2 },
     })
     rerender(
       <RoomAppHost
         app={app}
-        appInstanceId="shared-canvas:room"
+        appInstanceId="whiteboard:room"
         self={self}
         participants={[self]}
         subscribe={subscribe}

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -26,6 +26,7 @@ interface RoomAppHostProps {
     payload: Record<string, unknown>
   ) => boolean
   onClose: () => void
+  onReady?: (appId: string) => void
 }
 
 function handshakeToken(): string {
@@ -44,11 +45,13 @@ export default function RoomAppHost({
   subscribe,
   send,
   onClose,
+  onReady,
 }: RoomAppHostProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const portRef = useRef<MessagePort | null>(null)
   const tokenRef = useRef(handshakeToken())
   const readyRef = useRef(false)
+  const readyNotifiedRef = useRef(false)
   const previousParticipantsRef = useRef<RoomAppParticipantProjection[]>([])
   const sendRef = useRef(send)
   sendRef.current = send
@@ -91,6 +94,10 @@ export default function RoomAppHost({
         }
         readyRef.current = true
         setReady(true)
+        if (!readyNotifiedRef.current) {
+          readyNotifiedRef.current = true
+          onReady?.(app.id)
+        }
         const projected = projectRoomAppParticipants(participants)
         previousParticipantsRef.current = projected
         post({
@@ -118,7 +125,7 @@ export default function RoomAppHost({
       app.origin === window.location.origin ? app.origin : "*",
       [channel.port2]
     )
-  }, [app.origin, appInstanceId, participants, post, self])
+  }, [app.id, app.origin, appInstanceId, onReady, participants, post, self])
 
   useEffect(() => {
     if (!validateRoomAppDefinition(app) || !isRoomAppAllowlisted(app)) {

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1212,6 +1212,58 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     const slotHost = (appId: string) =>
       within(slot(appId)).getByTestId("room-app-host")
 
+    it("includes the curated production App id in copied Whiteboard Room links", async () => {
+      vi.stubEnv("NODE_ENV", "production")
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { writeText } })
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant],
+      })
+
+      render(
+        <RoomContent
+          roomName="test-room"
+          nickName="Alice"
+          roomType="audio"
+          initialRoomAppId="whiteboard"
+        />
+      )
+
+      await waitFor(() =>
+        expect(screen.getByTestId("stage-app-whiteboard")).toHaveAttribute(
+          "aria-pressed",
+          "true"
+        )
+      )
+      fireEvent.click(screen.getByRole("button", { name: "Copy link" }))
+
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/room?id=test-room&app=whiteboard`
+      )
+    })
+
+    it("keeps copied ordinary Room links unchanged", () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { writeText } })
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        participants: [localParticipant],
+      })
+
+      render(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+      fireEvent.click(screen.getByRole("button", { name: "Copy link" }))
+
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/room?id=test-room`
+      )
+    })
+
     beforeEach(() => {
       channels = []
       vi.stubGlobal("MessageChannel", TestMessageChannel)

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1215,6 +1215,11 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
     beforeEach(() => {
       channels = []
       vi.stubGlobal("MessageChannel", TestMessageChannel)
+      vi.stubEnv("NODE_ENV", "development")
+    })
+
+    afterEach(() => {
+      vi.unstubAllEnvs()
     })
 
     it("mounts a first launch on the visual Stage while the Room conversation stays", async () => {
@@ -1636,6 +1641,128 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
 
       expect(channels[0].port1.close).toHaveBeenCalledTimes(1)
       expect(channels[1].port1.close).toHaveBeenCalledTimes(1)
+    })
+
+    it("direct-launches Whiteboard once and measures only ready Human sharing", async () => {
+      vi.stubEnv("NODE_ENV", "production")
+      const analyticsSpy = vi.mocked(trackAnalyticsEvent)
+      analyticsSpy.mockClear()
+      const remoteAgent = {
+        peerId: "agent-peer",
+        name: "Pi",
+        kind: "agent",
+        room: "test-room",
+      }
+      const remoteHuman = {
+        peerId: "human-b",
+        name: "Bob",
+        kind: "human",
+        room: "test-room",
+        muteState: false,
+      }
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant, remoteAgent],
+      })
+      const view = render(
+        <RoomContent
+          roomName="test-room"
+          nickName="Alice"
+          roomType="audio"
+          initialRoomAppId="whiteboard"
+        />
+      )
+
+      const whiteboardButton = await screen.findByTestId("stage-app-whiteboard")
+      expect(whiteboardButton).toHaveAttribute("aria-pressed", "true")
+      const iframe = within(
+        screen.getByTestId("room-app-slot-whiteboard")
+      ).getByTestId("room-app-iframe") as HTMLIFrameElement
+      const frameWindow = loadAppIframe(iframe)
+      expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+        "RoomAppMounted",
+        expect.anything()
+      )
+
+      completeHandshake(frameWindow, "whiteboard", channels[0].port1)
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith("RoomAppMounted", {
+        app: "whiteboard",
+      })
+      expect(trackAnalyticsEvent).not.toHaveBeenCalledWith(
+        "RoomAppSharedSession",
+        expect.anything()
+      )
+
+      // The Agent does not satisfy the Human shared-use milestone. A late
+      // second Human does, after Whiteboard is already ready.
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant, remoteAgent, remoteHuman],
+      })
+      view.rerender(
+        <RoomContent
+          roomName="test-room"
+          nickName="Alice"
+          roomType="audio"
+          initialRoomAppId="whiteboard"
+        />
+      )
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith("RoomAppSharedSession", {
+        app: "whiteboard",
+        participantsBucket: "2-3",
+      })
+
+      // Manual Stage hide/show and an ordinary transport reconnect keep the
+      // same resident iframe/MessagePort; initial launch is not repeated.
+      fireEvent.click(whiteboardButton)
+      expect(
+        screen.getByTestId("room-app-slot-whiteboard").className
+      ).toContain("hidden")
+      fireEvent.click(whiteboardButton)
+      expect(screen.getByTestId("room-app-iframe")).toBe(iframe)
+
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "reconnecting",
+        roomAppsEnabled: false,
+        participants: [localParticipant, remoteAgent, remoteHuman],
+      })
+      view.rerender(
+        <RoomContent
+          roomName="test-room"
+          nickName="Alice"
+          roomType="audio"
+          initialRoomAppId="whiteboard"
+        />
+      )
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant, remoteAgent, remoteHuman],
+      })
+      view.rerender(
+        <RoomContent
+          roomName="test-room"
+          nickName="Alice"
+          roomType="audio"
+          initialRoomAppId="whiteboard"
+        />
+      )
+      expect(screen.getByTestId("room-app-iframe")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(
+        analyticsSpy.mock.calls.filter(([event]) => event === "RoomAppMounted")
+      ).toHaveLength(1)
+      expect(
+        analyticsSpy.mock.calls.filter(
+          ([event]) => event === "RoomAppSharedSession"
+        )
+      ).toHaveLength(1)
     })
   })
 

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -17,6 +17,7 @@ import { buildAgentInvitePrompt } from "../common/agentInvite"
 import {
   experimentalRoomAppCatalog,
   isRoomAppAllowlisted,
+  resolveProductionRoomAppId,
   ROOM_APP_MAX_INSTANCES,
   projectRoomAppParticipants,
   roomAppInstanceId,
@@ -772,11 +773,13 @@ export default function RoomContent({
 
   const copyRoomLink = () => {
     if (typeof window !== "undefined") {
+      const productionAppId = resolveProductionRoomAppId(activeRoomAppId)
       const url =
         window.location.origin +
         "/room?id=" +
         encodeURIComponent(roomName) +
-        (resolvedRoomType === "screenshare" ? "&type=screenshare" : "")
+        (resolvedRoomType === "screenshare" ? "&type=screenshare" : "") +
+        (productionAppId ? `&app=${encodeURIComponent(productionAppId)}` : "")
       navigator.clipboard.writeText(url)
       trackAnalyticsEvent("InviteLinkCopied", {
         surface: "room",

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -114,10 +114,12 @@ export default function RoomContent({
   roomName,
   nickName,
   roomType,
+  initialRoomAppId,
 }: {
   roomName: string
   nickName: string
   roomType: "audio" | "screenshare"
+  initialRoomAppId?: string
 }) {
   const router = useRouter()
   const [roomLinkCopied, setRoomLinkCopied] = useState(false)
@@ -129,6 +131,9 @@ export default function RoomContent({
   const [activeRoomAppId, setActiveRoomAppId] = useState<string | null>(null)
   // Browser-local resident App sessions, bounded by the curated catalog size.
   const [launchedRoomAppIds, setLaunchedRoomAppIds] = useState<string[]>([])
+  const [readyRoomAppIds, setReadyRoomAppIds] = useState<string[]>([])
+  const initialRoomAppLaunchAttemptedRef = useRef(false)
+  const whiteboardSharedSessionTrackedRef = useRef(false)
   const [stageView, setStageView] = useState<"screen" | "live-view">("screen")
   const taskLiveViewState = useRef(new Map())
   const observedLiveViewKeys = useRef(new Set<string>())
@@ -256,6 +261,13 @@ export default function RoomContent({
       }),
     [curatedRoomApps, launchedRoomAppIds]
   )
+  const humanParticipantCount = roomAppParticipants.filter(
+    (participant) => participant.kind === "human"
+  ).length
+  const whiteboardResident = residentRoomApps.some(
+    (app) => app.id === "whiteboard"
+  )
+  const whiteboardReady = readyRoomAppIds.includes("whiteboard")
   const visibleRoomApp =
     activeRoomApp && roomAppSelf ? activeRoomApp : undefined
   const activeTask = taskProjections.find(
@@ -384,6 +396,49 @@ export default function RoomContent({
         : [...previous, appId].slice(-ROOM_APP_MAX_INSTANCES)
     )
   }, [])
+
+  useEffect(() => {
+    setReadyRoomAppIds((previous) => {
+      const next = previous.filter((id) => launchedRoomAppIds.includes(id))
+      return next.length === previous.length ? previous : next
+    })
+  }, [launchedRoomAppIds])
+
+  useEffect(() => {
+    if (
+      initialRoomAppLaunchAttemptedRef.current ||
+      !initialRoomAppId ||
+      !roomAppsEnabled
+    )
+      return
+    initialRoomAppLaunchAttemptedRef.current = true
+    if (!curatedRoomApps.some((app) => app.id === initialRoomAppId)) return
+    launchRoomApp(initialRoomAppId)
+    setActiveRoomAppId(initialRoomAppId)
+  }, [curatedRoomApps, initialRoomAppId, launchRoomApp, roomAppsEnabled])
+
+  const handleRoomAppReady = useCallback((appId: string) => {
+    setReadyRoomAppIds((previous) =>
+      previous.includes(appId) ? previous : [...previous, appId]
+    )
+    if (appId === "whiteboard")
+      trackAnalyticsEvent("RoomAppMounted", { app: "whiteboard" })
+  }, [])
+
+  useEffect(() => {
+    if (
+      whiteboardSharedSessionTrackedRef.current ||
+      !whiteboardResident ||
+      !whiteboardReady ||
+      humanParticipantCount < 2
+    )
+      return
+    whiteboardSharedSessionTrackedRef.current = true
+    trackAnalyticsEvent("RoomAppSharedSession", {
+      app: "whiteboard",
+      participantsBucket: participantsBucket(humanParticipantCount),
+    })
+  }, [humanParticipantCount, whiteboardReady, whiteboardResident])
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
 
@@ -1063,6 +1118,7 @@ export default function RoomContent({
                       participants={roomAppParticipants}
                       subscribe={subscribeRoomAppMessages}
                       send={sendRoomAppMessage}
+                      onReady={handleRoomAppReady}
                       onClose={() => setActiveRoomAppId(null)}
                     />
                   </div>

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -270,7 +270,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
   })
 
   it("dispatches reliable and realtime Room App messages on the shared transport", async () => {
-    const appInstanceId = roomAppInstanceId("room-app", "shared-canvas")
+    const appInstanceId = roomAppInstanceId("room-app", "whiteboard")
     fetchMock.mockImplementation(
       (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === "string" ? input : input.toString()
@@ -407,7 +407,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
   })
 
   it("subscribes to remote Room App lanes, tags the bound sender, retries, and cleans up", async () => {
-    const appInstanceId = roomAppInstanceId("remote-app-room", "shared-canvas")
+    const appInstanceId = roomAppInstanceId("remote-app-room", "whiteboard")
     let dataChannelNewCalls = 0
     let remoteFailureCount = 0
     fetchMock.mockImplementation(
@@ -545,7 +545,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
       realtime.emit("message", {
         data: JSON.stringify({
           protocolVersion: 1,
-          appInstanceId: "shared-canvas:deadbeef",
+          appInstanceId: "whiteboard:deadbeef",
           lane: "realtime",
           payload: { type: "cursor" },
         }),

--- a/app/src/pages/apps/whiteboard.tsx
+++ b/app/src/pages/apps/whiteboard.tsx
@@ -1,0 +1,53 @@
+import { useRouter } from "next/router"
+
+import {
+  generateParticipantName,
+  generateRoomName,
+} from "../../common/cosmicNames"
+import { saveRoomToLocalStorage } from "../../common/utils"
+import DiscoveryPageLayout from "../../components/DiscoveryPageLayout"
+
+export default function WhiteboardPage() {
+  const router = useRouter()
+
+  const openWhiteboardRoom = () => {
+    const roomName = generateRoomName()
+    const nickName = generateParticipantName()
+    saveRoomToLocalStorage(roomName, nickName)
+    void router.push(`/room?id=${encodeURIComponent(roomName)}&app=whiteboard`)
+  }
+
+  return (
+    <DiscoveryPageLayout
+      title="Online Whiteboard — No-Sign-Up Collaborative Whiteboard | Free4Chat"
+      description="Draw together on an Excalidraw-powered whiteboard in a temporary Free4Chat Room. No account or sign-up; share one link and collaborate by voice, text, and files."
+      path="/apps/whiteboard"
+      ctaId="whiteboard"
+      primaryCta={{
+        label: "Open Whiteboard Room",
+        onClick: openWhiteboardRoom,
+      }}
+      h1="A collaborative whiteboard you can open and share instantly"
+    >
+      <p>
+        Whiteboard brings Excalidraw-powered drawing and editing into a
+        temporary Free4Chat Room. Start without an account or sign-up, then
+        invite another person with the Room link.
+      </p>
+
+      <h2>Work together in the Room</h2>
+      <p>
+        Keep the board beside the Room&apos;s voice, text, and file sharing. The
+        Whiteboard supports touch input on phones and tablets as well as a mouse
+        or trackpad.
+      </p>
+
+      <h2>Temporary by design</h2>
+      <p>
+        Whiteboard V1 keeps board state in active browser replicas; it does not
+        save a permanent board. If every browser replica disappears or reloads,
+        the board may reset. Image and file import is not supported in V1.
+      </p>
+    </DiscoveryPageLayout>
+  )
+}

--- a/app/src/pages/room.tsx
+++ b/app/src/pages/room.tsx
@@ -5,6 +5,7 @@ import Head from "next/head"
 import { useRouter } from "next/router"
 
 import { generateParticipantName } from "../common/cosmicNames"
+import { resolveProductionRoomAppId } from "../common/roomApp"
 import {
   saveRoomToLocalStorage,
   gtagEvent,
@@ -20,6 +21,7 @@ export default function Room() {
   const router = useRouter()
   const roomId = router.query.id as string
   const roomTypeParam = router.query.type as string | undefined
+  const initialRoomAppId = resolveProductionRoomAppId(router.query.app)
   const [roomName, setRoomName] = useState<string>("")
   const [nickName, setNickName] = useState<string>("")
   const [roomType, setRoomType] = useState<"audio" | "screenshare">("audio")
@@ -150,6 +152,7 @@ export default function Room() {
           roomName={roomName}
           nickName={nickName}
           roomType={roomType}
+          initialRoomAppId={initialRoomAppId ?? undefined}
         />
       )}
     </div>


### PR DESCRIPTION
## What

Expose Whiteboard as the only user-visible production Room App, add direct Room launch, publish a crawlable /apps/whiteboard product page, and emit two bounded host-owned product events.

## Why

References i365dev/free4chat#375 and #346. Whiteboard is the first real production Room App; Shared Canvas and Tiny Arena remain local regression fixtures while their Lab/Cloudflare cleanup stays deferred to free4chat-extension-lab#24.

## How

- Production catalog now contains only Whiteboard at https://room-apps.free4.chat/whiteboard. ROOM_APP_MAX_INSTANCES remains unchanged; the Phase-0 catalog entries remain available in the local fixture catalog.
- The Room route accepts only an exact validated production App id. The Whiteboard CTA generates a cosmic Room name and participant nickname, saves them through the existing localStorage helper, and navigates to /room?id=<generated-room>&app=whiteboard.
- Adds /apps/whiteboard with existing canonical/OG metadata behavior and generated sitemap coverage. Copy describes Excalidraw editing, temporary state, touch support, and V1 import limits; it makes no Agent support claim.
- DiscoveryCtaClicked carries only page=whiteboard. RoomAppMounted fires once per resident App session after the MessagePort ready handshake. RoomAppSharedSession fires at most once per browser Room session after readiness and at least two Human participants, with the existing low-cardinality participantsBucket.
- Existing Room App host contract was sufficient; the Lab Whiteboard uses the same v1 bootstrap, MessagePort ready handshake, participant projection, and reliable/realtime lanes.

Exact base SHA: 3f555d080fb0395b88d254bc42ea8f756c5182a2
Exact head SHA: 5a5d812210f8d998643dd916e7a0d298c0ef73ef

Changed files:
- app/src/common/roomApp.ts and app/src/common/roomApp.test.ts
- app/src/components/RoomAppHost.tsx, RoomAppHost.test.tsx, RoomContent.tsx, and RoomContent.test.tsx
- app/src/components/DiscoveryPageLayout.tsx
- app/src/pages/room.tsx and app/src/pages/apps/whiteboard.tsx
- app/src/hooks/useSfuChatRoom.test.tsx
- app/src/__tests__/pages/room.test.tsx
- app/src/__tests__/discovery/copy-accuracy.test.ts, crawl-surface.test.ts, pages-cta.test.tsx, and pages-seo.test.tsx
- app/scripts/generate-docs-assets.mjs and app/public/sitemap.xml

Room App wire protocol, Room transport, and core state ownership are unchanged. Phase-0 fixture source/workers were not deleted.

## Testing

- Prettier check passed for changed files.
- ESLint src and TypeScript type-check passed.
- docs:check passed.
- Full Vitest passed: 90 files, 845 tests.
- cf-build completed successfully and emitted the OpenNext Worker. OpenNext logged Durable Object binding and package-copy warnings before exiting successfully.
- Playwright browser smoke confirmed the landing page renders, the CTA navigates directly to a generated Whiteboard Room URL, and the page remains usable at 390px width. The standalone Next server did not include the SFU Worker/Turnstile backend, so the connected Room Stage could not be verified in that browser session; direct Stage launch, ready gating, and reconnect residency are covered by RoomContent/RoomAppHost tests.
