### PR TITLE
feat(room-app): add bounded authenticated reliable unicast

### DIFF
--- a/app/src/common/roomApp.test.ts
+++ b/app/src/common/roomApp.test.ts
@@ -6,11 +6,15 @@ import {
   ROOM_APP_MAX_PAYLOAD_BYTES,
   decodeRoomAppClientMessage,
   decodeRoomAppEnvelope,
+  decodeRoomAppUnicastEnvelope,
+  decodeRoomAppUnicastResult,
+  encodeRoomAppUnicastRequest,
   encodeRoomAppEnvelope,
   isRoomAppInstanceForRoom,
   isRoomAppAllowlisted,
   projectRoomAppParticipants,
   roomAppRateGuard,
+  roomAppUnicastRateGuard,
   roomAppInstanceId,
   resolveProductionRoomAppId,
   validateRoomAppDefinition,
@@ -109,6 +113,83 @@ describe("Room App Phase 0 bridge contract", () => {
         "shared-canvas:abc123"
       )
     ).toBeNull()
+    expect(
+      decodeRoomAppClientMessage(
+        {
+          type: "sendReliableTo",
+          appInstanceId: "shared-canvas:abc123",
+          targetParticipantId: "human-b",
+          payload: { type: "private" },
+        },
+        "shared-canvas:abc123"
+      )
+    ).toEqual({
+      type: "sendReliableTo",
+      appInstanceId: "shared-canvas:abc123",
+      targetParticipantId: "human-b",
+      payload: { type: "private" },
+    })
+    expect(
+      decodeRoomAppClientMessage(
+        {
+          type: "sendReliableTo",
+          appInstanceId: "shared-canvas:abc123",
+          targetParticipantId: "bad target",
+          payload: { type: "private" },
+        },
+        "shared-canvas:abc123"
+      )
+    ).toBeNull()
+  })
+
+  it("bounds reliable unicast requests and accepts only current-room deliveries/results", () => {
+    const appInstanceId = roomAppInstanceId("room-a", "whiteboard")
+    const encoded = encodeRoomAppUnicastRequest({
+      requestId: "request_1",
+      targetParticipantId: "human-b",
+      appInstanceId,
+      payload: { type: "secret", word: "otter" },
+    })
+    expect(JSON.parse(encoded!)).toMatchObject({
+      type: "room-app-unicast",
+      requestId: "request_1",
+      targetParticipantId: "human-b",
+      appInstanceId,
+      payload: { word: "otter" },
+    })
+    expect(
+      encodeRoomAppUnicastRequest({
+        requestId: "request_1",
+        targetParticipantId: "human-b",
+        appInstanceId,
+        payload: { word: "界".repeat(ROOM_APP_MAX_PAYLOAD_BYTES) },
+      })
+    ).toBeNull()
+
+    const delivery = {
+      type: "room-app-unicast",
+      protocolVersion: 1,
+      appInstanceId,
+      sourceParticipantId: "human-a",
+      payload: { word: "otter" },
+    }
+    expect(decodeRoomAppUnicastEnvelope(delivery, "room-a")).toMatchObject({
+      sourceParticipantId: "human-a",
+      payload: { word: "otter" },
+    })
+    expect(decodeRoomAppUnicastEnvelope(delivery, "room-b")).toBeNull()
+    expect(
+      decodeRoomAppUnicastResult(
+        {
+          type: "room-app-unicast-result",
+          requestId: "request_1",
+          appInstanceId,
+          ok: false,
+          error: "target_unavailable",
+        },
+        "room-a"
+      )
+    ).toMatchObject({ ok: false, error: "target_unavailable" })
   })
 
   it("accepts only curated instances for the current Room", () => {
@@ -145,5 +226,16 @@ describe("Room App Phase 0 bridge contract", () => {
     const guard = roomAppRateGuard()
     expect(guard.allow("realtime", 200_000, 1000)).toBe(true)
     expect(guard.allow("reliable", 100_000, 2001)).toBe(true)
+  })
+
+  it("bounds unicast message count and bytes per sender window", () => {
+    const guard = roomAppUnicastRateGuard()
+    for (let index = 0; index < 10; index += 1)
+      expect(guard.allow(1, 1000)).toBe(true)
+    expect(guard.allow(1, 1000)).toBe(false)
+    expect(guard.allow(1, 2001)).toBe(true)
+    const bytesGuard = roomAppUnicastRateGuard()
+    expect(bytesGuard.allow(64 * 1024, 1000)).toBe(true)
+    expect(bytesGuard.allow(1, 1000)).toBe(false)
   })
 })

--- a/app/src/common/roomApp.test.ts
+++ b/app/src/common/roomApp.test.ts
@@ -118,6 +118,7 @@ describe("Room App Phase 0 bridge contract", () => {
         {
           type: "sendReliableTo",
           appInstanceId: "shared-canvas:abc123",
+          requestId: "guess-1",
           targetParticipantId: "human-b",
           payload: { type: "private" },
         },
@@ -126,6 +127,7 @@ describe("Room App Phase 0 bridge contract", () => {
     ).toEqual({
       type: "sendReliableTo",
       appInstanceId: "shared-canvas:abc123",
+      requestId: "guess-1",
       targetParticipantId: "human-b",
       payload: { type: "private" },
     })
@@ -134,7 +136,20 @@ describe("Room App Phase 0 bridge contract", () => {
         {
           type: "sendReliableTo",
           appInstanceId: "shared-canvas:abc123",
+          requestId: "guess-1",
           targetParticipantId: "bad target",
+          payload: { type: "private" },
+        },
+        "shared-canvas:abc123"
+      )
+    ).toBeNull()
+    expect(
+      decodeRoomAppClientMessage(
+        {
+          type: "sendReliableTo",
+          appInstanceId: "shared-canvas:abc123",
+          requestId: "contains spaces",
+          targetParticipantId: "human-b",
           payload: { type: "private" },
         },
         "shared-canvas:abc123"

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -78,6 +78,7 @@ export type RoomAppUnicastError =
   | "invalid_target"
   | "target_unavailable"
   | "rate_limited"
+  | "duplicate_request_id"
   | "delivery_failed"
 
 export interface RoomAppUnicastResult {
@@ -124,6 +125,7 @@ export type RoomAppHostMessage =
         | "payload_too_large"
         | "delivery_unavailable"
         | "too_many_pending"
+        | "duplicate_request_id"
     }
 
 export type RoomAppClientMessage =
@@ -140,6 +142,7 @@ export type RoomAppClientMessage =
   | {
       type: "sendReliableTo"
       appInstanceId: string
+      requestId: string
       targetParticipantId: string
       payload: Record<string, unknown>
     }
@@ -245,12 +248,14 @@ export function decodeRoomAppClientMessage(
       handshakeToken: value.handshakeToken,
     }
   if (value.type === "sendReliableTo") {
+    if (!isValidRoomAppRequestId(value.requestId)) return null
     if (!isValidRoomAppParticipantId(value.targetParticipantId)) return null
     const payload = validateRoomAppPayload(value.payload)
     if (!payload.ok) return null
     return {
       type: "sendReliableTo",
       appInstanceId,
+      requestId: value.requestId,
       targetParticipantId: value.targetParticipantId,
       payload: payload.payload,
     }

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -6,6 +6,8 @@ export const ROOM_APP_MAX_INSTANCES = 2
 export const ROOM_APP_RELIABLE_MESSAGES_PER_SECOND = 20
 export const ROOM_APP_REALTIME_MESSAGES_PER_SECOND = 60
 export const ROOM_APP_BYTES_PER_SECOND = 256 * 1024
+export const ROOM_APP_UNICAST_MESSAGES_PER_SECOND = 10
+export const ROOM_APP_UNICAST_BYTES_PER_SECOND = 64 * 1024
 
 export type RoomAppLane = "reliable" | "realtime"
 
@@ -63,6 +65,28 @@ export interface RoomAppTransportEnvelope {
   payload: Record<string, unknown>
 }
 
+export interface RoomAppUnicastEnvelope {
+  protocolVersion: typeof ROOM_APP_PROTOCOL_VERSION
+  appInstanceId: string
+  sourceParticipantId: string
+  payload: Record<string, unknown>
+}
+
+export type RoomAppUnicastError =
+  | "invalid_request"
+  | "app_unavailable"
+  | "invalid_target"
+  | "target_unavailable"
+  | "rate_limited"
+  | "delivery_failed"
+
+export interface RoomAppUnicastResult {
+  requestId: string
+  appInstanceId: string
+  ok: boolean
+  error?: RoomAppUnicastError
+}
+
 type RoomAppWireEnvelope = Omit<RoomAppTransportEnvelope, "sourceParticipantId">
 
 export type RoomAppHostMessage =
@@ -85,9 +109,21 @@ export type RoomAppHostMessage =
       payload: Record<string, unknown>
     }
   | {
+      type: "unicast"
+      appInstanceId: string
+      sourceParticipantId: string
+      payload: Record<string, unknown>
+    }
+  | ({ type: "unicast_result" } & RoomAppUnicastResult)
+  | {
       type: "error"
       appInstanceId: string
-      error: "unsupported_message" | "rate_limited" | "payload_too_large"
+      error:
+        | "unsupported_message"
+        | "rate_limited"
+        | "payload_too_large"
+        | "delivery_unavailable"
+        | "too_many_pending"
     }
 
 export type RoomAppClientMessage =
@@ -101,9 +137,30 @@ export type RoomAppClientMessage =
       appInstanceId: string
       payload: Record<string, unknown>
     }
+  | {
+      type: "sendReliableTo"
+      appInstanceId: string
+      targetParticipantId: string
+      payload: Record<string, unknown>
+    }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+export function isValidRoomAppParticipantId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[A-Za-z0-9][A-Za-z0-9:_-]{0,127}$/.test(value)
+  )
+}
+
+export function isValidRoomAppRequestId(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{1,64}$/.test(value)
+}
+
+export function isValidRoomAppInstanceId(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9:-]{0,95}$/.test(value)
 }
 
 export function serializedRoomAppBytes(value: unknown): number | null {
@@ -130,7 +187,7 @@ export function encodeRoomAppEnvelope(
   envelope: Omit<RoomAppWireEnvelope, "protocolVersion">
 ): string | null {
   const payload = validateRoomAppPayload(envelope.payload)
-  if (!payload.ok || !/^[a-z0-9][a-z0-9:-]{0,95}$/.test(envelope.appInstanceId))
+  if (!payload.ok || !isValidRoomAppInstanceId(envelope.appInstanceId))
     return null
   const full: RoomAppWireEnvelope = {
     protocolVersion: ROOM_APP_PROTOCOL_VERSION,
@@ -157,7 +214,7 @@ export function decodeRoomAppEnvelope(
   if (
     parsed.protocolVersion !== ROOM_APP_PROTOCOL_VERSION ||
     typeof parsed.appInstanceId !== "string" ||
-    !/^[a-z0-9][a-z0-9:-]{0,95}$/.test(parsed.appInstanceId) ||
+    !isValidRoomAppInstanceId(parsed.appInstanceId) ||
     (parsed.lane !== "reliable" && parsed.lane !== "realtime")
   )
     return null
@@ -187,6 +244,17 @@ export function decodeRoomAppClientMessage(
       appInstanceId,
       handshakeToken: value.handshakeToken,
     }
+  if (value.type === "sendReliableTo") {
+    if (!isValidRoomAppParticipantId(value.targetParticipantId)) return null
+    const payload = validateRoomAppPayload(value.payload)
+    if (!payload.ok) return null
+    return {
+      type: "sendReliableTo",
+      appInstanceId,
+      targetParticipantId: value.targetParticipantId,
+      payload: payload.payload,
+    }
+  }
   if (value.type !== "sendReliable" && value.type !== "sendRealtime")
     return null
   const payload = validateRoomAppPayload(value.payload)
@@ -195,6 +263,94 @@ export function decodeRoomAppClientMessage(
     type: value.type,
     appInstanceId,
     payload: payload.payload,
+  }
+}
+
+export function encodeRoomAppUnicastRequest(input: {
+  requestId: string
+  targetParticipantId: string
+  appInstanceId: string
+  payload: unknown
+}): string | null {
+  if (
+    !isValidRoomAppRequestId(input.requestId) ||
+    !isValidRoomAppParticipantId(input.targetParticipantId) ||
+    !isValidRoomAppInstanceId(input.appInstanceId)
+  )
+    return null
+  const payload = validateRoomAppPayload(input.payload)
+  if (!payload.ok) return null
+  const request = {
+    type: "room-app-unicast",
+    requestId: input.requestId,
+    targetParticipantId: input.targetParticipantId,
+    appInstanceId: input.appInstanceId,
+    payload: payload.payload,
+  }
+  const bytes = serializedRoomAppBytes(request)
+  if (bytes === null || bytes > ROOM_APP_MAX_PAYLOAD_BYTES) return null
+  return JSON.stringify(request)
+}
+
+export function decodeRoomAppUnicastEnvelope(
+  value: unknown,
+  roomName: string
+): RoomAppUnicastEnvelope | null {
+  if (
+    !isRecord(value) ||
+    value.type !== "room-app-unicast" ||
+    value.protocolVersion !== ROOM_APP_PROTOCOL_VERSION ||
+    typeof value.appInstanceId !== "string" ||
+    !isRoomAppInstanceForRoom(roomName, value.appInstanceId) ||
+    !isValidRoomAppParticipantId(value.sourceParticipantId)
+  )
+    return null
+  const payload = validateRoomAppPayload(value.payload)
+  if (!payload.ok) return null
+  const envelope = {
+    protocolVersion: ROOM_APP_PROTOCOL_VERSION,
+    appInstanceId: value.appInstanceId,
+    sourceParticipantId: value.sourceParticipantId,
+    payload: payload.payload,
+  }
+  const bytes = serializedRoomAppBytes(envelope)
+  if (bytes === null || bytes > ROOM_APP_MAX_PAYLOAD_BYTES) return null
+  return envelope
+}
+
+export function decodeRoomAppUnicastResult(
+  value: unknown,
+  roomName: string
+): RoomAppUnicastResult | null {
+  if (
+    !isRecord(value) ||
+    value.type !== "room-app-unicast-result" ||
+    !isValidRoomAppRequestId(value.requestId) ||
+    typeof value.appInstanceId !== "string" ||
+    !isRoomAppInstanceForRoom(roomName, value.appInstanceId) ||
+    typeof value.ok !== "boolean"
+  )
+    return null
+  if (value.ok)
+    return {
+      requestId: value.requestId,
+      appInstanceId: value.appInstanceId,
+      ok: true,
+    }
+  const errors: readonly RoomAppUnicastError[] = [
+    "invalid_request",
+    "app_unavailable",
+    "invalid_target",
+    "target_unavailable",
+    "rate_limited",
+    "delivery_failed",
+  ]
+  if (!errors.includes(value.error as RoomAppUnicastError)) return null
+  return {
+    requestId: value.requestId,
+    appInstanceId: value.appInstanceId,
+    ok: false,
+    error: value.error as RoomAppUnicastError,
   }
 }
 
@@ -302,6 +458,24 @@ export function roomAppRateGuard() {
       )
         return false
       samples.push({ at: now, bytes })
+      return true
+    },
+  }
+}
+
+export function roomAppUnicastRateGuard() {
+  const events: Array<{ at: number; bytes: number }> = []
+  return {
+    allow(bytes: number, now = Date.now()): boolean {
+      const windowStart = now - 1000
+      while (events.length > 0 && events[0].at <= windowStart) events.shift()
+      const totalBytes = events.reduce((sum, sample) => sum + sample.bytes, 0)
+      if (
+        events.length >= ROOM_APP_UNICAST_MESSAGES_PER_SECOND ||
+        totalBytes + bytes > ROOM_APP_UNICAST_BYTES_PER_SECOND
+      )
+        return false
+      events.push({ at: now, bytes })
       return true
     },
   }

--- a/app/src/common/roomApp.ts
+++ b/app/src/common/roomApp.ts
@@ -119,8 +119,13 @@ export type RoomAppHostMessage =
   | {
       type: "error"
       appInstanceId: string
+      error: "unsupported_message" | "rate_limited"
+    }
+  | {
+      type: "error"
+      appInstanceId: string
+      requestId: string
       error:
-        | "unsupported_message"
         | "rate_limited"
         | "payload_too_large"
         | "delivery_unavailable"

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import RoomAppHost from "./RoomAppHost"
 import type {
   RoomAppParticipantProjection,
+  RoomAppUnicastEnvelope,
+  RoomAppUnicastResult,
   RoomAppTransportEnvelope,
 } from "../common/roomApp"
 
@@ -59,6 +61,14 @@ describe("RoomAppHost", () => {
     const onClose = vi.fn()
     const subscribe = vi.fn(() => () => undefined)
     const send = vi.fn(() => true)
+    const sendUnicast = vi.fn(
+      (
+        _requestId: string,
+        _targetParticipantId: string,
+        _appInstanceId: string,
+        _payload: Record<string, unknown>
+      ) => "sent" as const
+    )
     const rendered = render(
       <RoomAppHost
         app={app}
@@ -68,6 +78,9 @@ describe("RoomAppHost", () => {
         subscribe={subscribe}
         send={send}
         onReady={onReady}
+        subscribeUnicast={() => () => undefined}
+        subscribeUnicastResults={() => () => undefined}
+        sendUnicast={sendUnicast}
         onClose={onClose}
       />
     )
@@ -130,6 +143,7 @@ describe("RoomAppHost", () => {
   it("rejects malformed or wrong-instance messages and forwards bounded lanes", () => {
     vi.stubGlobal("MessageChannel", TestMessageChannel)
     const send = vi.fn(() => true)
+    const sendUnicast = vi.fn(() => "sent" as const)
     render(
       <RoomAppHost
         app={app}
@@ -138,6 +152,9 @@ describe("RoomAppHost", () => {
         participants={participants}
         subscribe={() => () => undefined}
         send={send}
+        subscribeUnicast={() => () => undefined}
+        subscribeUnicastResults={() => () => undefined}
+        sendUnicast={sendUnicast}
         onClose={() => undefined}
       />
     )
@@ -177,15 +194,47 @@ describe("RoomAppHost", () => {
       type: "stroke",
       points: [[1, 2]],
     })
+    act(() => {
+      port.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        targetParticipantId: "human-b",
+        payload: { type: "private", word: "otter" },
+      })
+    })
+    expect(sendUnicast).toHaveBeenCalledWith(
+      expect.any(String),
+      "human-b",
+      "whiteboard:room",
+      { type: "private", word: "otter" }
+    )
   })
 
   it("forwards remote lanes and emits participant lifecycle changes", () => {
     vi.stubGlobal("MessageChannel", TestMessageChannel)
     let listener: ((message: RoomAppTransportEnvelope) => void) | undefined
+    let unicastListener: ((message: RoomAppUnicastEnvelope) => void) | undefined
+    let resultListener: ((result: RoomAppUnicastResult) => void) | undefined
     const subscribe = vi.fn((next: typeof listener) => {
       listener = next
       return () => undefined
     })
+    const subscribeUnicast = vi.fn((next: typeof unicastListener) => {
+      unicastListener = next
+      return () => undefined
+    })
+    const subscribeUnicastResults = vi.fn((next: typeof resultListener) => {
+      resultListener = next
+      return () => undefined
+    })
+    const sendUnicast = vi.fn(
+      (
+        _requestId: string,
+        _targetParticipantId: string,
+        _appInstanceId: string,
+        _payload: Record<string, unknown>
+      ) => "sent" as const
+    )
     const { rerender } = render(
       <RoomAppHost
         app={app}
@@ -194,6 +243,9 @@ describe("RoomAppHost", () => {
         participants={participants}
         subscribe={subscribe}
         send={() => true}
+        subscribeUnicast={subscribeUnicast}
+        subscribeUnicastResults={subscribeUnicastResults}
+        sendUnicast={sendUnicast}
         onClose={() => undefined}
       />
     )
@@ -208,6 +260,12 @@ describe("RoomAppHost", () => {
         appInstanceId: "whiteboard:room",
         handshakeToken: bootstrap.handshakeToken,
       })
+      lastChannel!.port1.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        targetParticipantId: "human-b",
+        payload: { type: "secret", word: "otter" },
+      })
       listener?.({
         protocolVersion: 1,
         appInstanceId: "whiteboard:room",
@@ -215,12 +273,48 @@ describe("RoomAppHost", () => {
         sourceParticipantId: "human-b",
         payload: { type: "cursor", x: 2 },
       })
+      unicastListener?.({
+        protocolVersion: 1,
+        appInstanceId: "whiteboard:room",
+        sourceParticipantId: "human-b",
+        payload: { type: "secret", word: "otter" },
+      })
+    })
+    const requestId = sendUnicast.mock.calls[0][0]
+    act(() => {
+      resultListener?.({
+        requestId: "another-request",
+        appInstanceId: "whiteboard:room",
+        ok: true,
+      })
+    })
+    expect(lastChannel!.port1.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "unicast_result" })
+    )
+    act(() => {
+      resultListener?.({
+        requestId,
+        appInstanceId: "whiteboard:room",
+        ok: true,
+      })
     })
     expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
       type: "realtime",
       appInstanceId: "whiteboard:room",
       sourceParticipantId: "human-b",
       payload: { type: "cursor", x: 2 },
+    })
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
+      type: "unicast",
+      appInstanceId: "whiteboard:room",
+      sourceParticipantId: "human-b",
+      payload: { type: "secret", word: "otter" },
+    })
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
+      type: "unicast_result",
+      requestId,
+      appInstanceId: "whiteboard:room",
+      ok: true,
     })
     rerender(
       <RoomAppHost
@@ -230,6 +324,9 @@ describe("RoomAppHost", () => {
         participants={[self]}
         subscribe={subscribe}
         send={() => true}
+        subscribeUnicast={subscribeUnicast}
+        subscribeUnicastResults={subscribeUnicastResults}
+        sendUnicast={sendUnicast}
         onClose={() => undefined}
       />
     )

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -220,7 +220,95 @@ describe("RoomAppHost", () => {
     expect(port.postMessage).toHaveBeenCalledWith({
       type: "error",
       appInstanceId: "whiteboard:room",
+      requestId: "private_request_1",
       error: "duplicate_request_id",
+    })
+  })
+
+  it("correlates host-local unicast rejection without changing broadcast errors", () => {
+    vi.stubGlobal("MessageChannel", TestMessageChannel)
+    let resultListener: ((result: RoomAppUnicastResult) => void) | undefined
+    const subscribeUnicastResults = vi.fn((next: typeof resultListener) => {
+      resultListener = next
+      return () => undefined
+    })
+    const send = vi.fn(() => false)
+    const sendUnicast = vi
+      .fn()
+      .mockReturnValueOnce("sent" as const)
+      .mockReturnValueOnce("rate_limited" as const)
+    render(
+      <RoomAppHost
+        app={app}
+        appInstanceId="whiteboard:room"
+        self={self}
+        participants={participants}
+        subscribe={() => () => undefined}
+        send={send}
+        subscribeUnicast={() => () => undefined}
+        subscribeUnicastResults={subscribeUnicastResults}
+        sendUnicast={sendUnicast}
+        onClose={() => undefined}
+      />
+    )
+    const iframe = screen.getByTestId("room-app-iframe") as HTMLIFrameElement
+    const frameWindow = { postMessage: vi.fn() }
+    Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+    fireEvent.load(iframe)
+    const bootstrap = frameWindow.postMessage.mock.calls[0][0]
+    const port = lastChannel!.port1
+    act(() => {
+      port.emit({
+        type: "ready",
+        appInstanceId: "whiteboard:room",
+        handshakeToken: bootstrap.handshakeToken,
+      })
+      port.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        requestId: "req-A",
+        targetParticipantId: "human-b",
+        payload: { type: "secret", word: "otter" },
+      })
+      port.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        requestId: "req-B",
+        targetParticipantId: "human-c",
+        payload: { type: "secret", word: "fox" },
+      })
+      port.emit({
+        type: "sendReliable",
+        appInstanceId: "whiteboard:room",
+        payload: { type: "stroke" },
+      })
+    })
+
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "error",
+      appInstanceId: "whiteboard:room",
+      requestId: "req-B",
+      error: "rate_limited",
+    })
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "error",
+      appInstanceId: "whiteboard:room",
+      error: "rate_limited",
+    })
+    expect(sendUnicast).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      resultListener?.({
+        requestId: "req-A",
+        appInstanceId: "whiteboard:room",
+        ok: true,
+      })
+    })
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "unicast_result",
+      requestId: "req-A",
+      appInstanceId: "whiteboard:room",
+      ok: true,
     })
   })
 

--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -198,16 +198,30 @@ describe("RoomAppHost", () => {
       port.emit({
         type: "sendReliableTo",
         appInstanceId: "whiteboard:room",
+        requestId: "private_request_1",
         targetParticipantId: "human-b",
         payload: { type: "private", word: "otter" },
       })
+      port.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        requestId: "private_request_1",
+        targetParticipantId: "human-b",
+        payload: { type: "private", word: "duplicate" },
+      })
     })
     expect(sendUnicast).toHaveBeenCalledWith(
-      expect.any(String),
+      "private_request_1",
       "human-b",
       "whiteboard:room",
       { type: "private", word: "otter" }
     )
+    expect(sendUnicast).toHaveBeenCalledTimes(1)
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "error",
+      appInstanceId: "whiteboard:room",
+      error: "duplicate_request_id",
+    })
   })
 
   it("forwards remote lanes and emits participant lifecycle changes", () => {
@@ -263,8 +277,16 @@ describe("RoomAppHost", () => {
       lastChannel!.port1.emit({
         type: "sendReliableTo",
         appInstanceId: "whiteboard:room",
+        requestId: "secret_for_bob",
         targetParticipantId: "human-b",
         payload: { type: "secret", word: "otter" },
+      })
+      lastChannel!.port1.emit({
+        type: "sendReliableTo",
+        appInstanceId: "whiteboard:room",
+        requestId: "secret_for_carol",
+        targetParticipantId: "human-c",
+        payload: { type: "secret", word: "fox" },
       })
       listener?.({
         protocolVersion: 1,
@@ -280,7 +302,20 @@ describe("RoomAppHost", () => {
         payload: { type: "secret", word: "otter" },
       })
     })
-    const requestId = sendUnicast.mock.calls[0][0]
+    expect(sendUnicast).toHaveBeenNthCalledWith(
+      1,
+      "secret_for_bob",
+      "human-b",
+      "whiteboard:room",
+      { type: "secret", word: "otter" }
+    )
+    expect(sendUnicast).toHaveBeenNthCalledWith(
+      2,
+      "secret_for_carol",
+      "human-c",
+      "whiteboard:room",
+      { type: "secret", word: "fox" }
+    )
     act(() => {
       resultListener?.({
         requestId: "another-request",
@@ -293,7 +328,13 @@ describe("RoomAppHost", () => {
     )
     act(() => {
       resultListener?.({
-        requestId,
+        requestId: "secret_for_carol",
+        appInstanceId: "whiteboard:room",
+        ok: false,
+        error: "target_unavailable",
+      })
+      resultListener?.({
+        requestId: "secret_for_bob",
         appInstanceId: "whiteboard:room",
         ok: true,
       })
@@ -312,7 +353,14 @@ describe("RoomAppHost", () => {
     })
     expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
       type: "unicast_result",
-      requestId,
+      requestId: "secret_for_carol",
+      appInstanceId: "whiteboard:room",
+      ok: false,
+      error: "target_unavailable",
+    })
+    expect(lastChannel!.port1.postMessage).toHaveBeenCalledWith({
+      type: "unicast_result",
+      requestId: "secret_for_bob",
       appInstanceId: "whiteboard:room",
       ok: true,
     })

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -134,6 +134,14 @@ export default function RoomAppHost({
         for (const [requestId, createdAt] of pendingUnicastRequestsRef.current)
           if (now - createdAt > 60_000)
             pendingUnicastRequestsRef.current.delete(requestId)
+        if (pendingUnicastRequestsRef.current.has(message.requestId)) {
+          post({
+            type: "error",
+            appInstanceId,
+            error: "duplicate_request_id",
+          })
+          return
+        }
         if (pendingUnicastRequestsRef.current.size >= 32) {
           post({
             type: "error",
@@ -142,7 +150,7 @@ export default function RoomAppHost({
           })
           return
         }
-        const requestId = handshakeToken()
+        const requestId = message.requestId
         pendingUnicastRequestsRef.current.set(requestId, now)
         const result = sendUnicastRef.current(
           requestId,

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -9,6 +9,8 @@ import {
   type RoomAppDefinition,
   type RoomAppHostMessage,
   type RoomAppParticipantProjection,
+  type RoomAppUnicastEnvelope,
+  type RoomAppUnicastResult,
   type RoomAppTransportEnvelope,
 } from "../common/roomApp"
 
@@ -25,6 +27,18 @@ interface RoomAppHostProps {
     appInstanceId: string,
     payload: Record<string, unknown>
   ) => boolean
+  subscribeUnicast: (
+    listener: (message: RoomAppUnicastEnvelope) => void
+  ) => () => void
+  subscribeUnicastResults: (
+    listener: (result: RoomAppUnicastResult) => void
+  ) => () => void
+  sendUnicast: (
+    requestId: string,
+    targetParticipantId: string,
+    appInstanceId: string,
+    payload: Record<string, unknown>
+  ) => "sent" | "rate_limited" | "payload_too_large" | "delivery_unavailable"
   onClose: () => void
   onReady?: (appId: string) => void
 }
@@ -44,6 +58,9 @@ export default function RoomAppHost({
   participants,
   subscribe,
   send,
+  subscribeUnicast,
+  subscribeUnicastResults,
+  sendUnicast,
   onClose,
   onReady,
 }: RoomAppHostProps) {
@@ -55,6 +72,9 @@ export default function RoomAppHost({
   const previousParticipantsRef = useRef<RoomAppParticipantProjection[]>([])
   const sendRef = useRef(send)
   sendRef.current = send
+  const sendUnicastRef = useRef(sendUnicast)
+  sendUnicastRef.current = sendUnicast
+  const pendingUnicastRequestsRef = useRef(new Map<string, number>())
   const [ready, setReady] = useState(false)
   const [failed, setFailed] = useState(false)
 
@@ -109,6 +129,42 @@ export default function RoomAppHost({
         })
         return
       }
+      if (message.type === "sendReliableTo") {
+        const now = Date.now()
+        for (const [requestId, createdAt] of pendingUnicastRequestsRef.current)
+          if (now - createdAt > 60_000)
+            pendingUnicastRequestsRef.current.delete(requestId)
+        if (pendingUnicastRequestsRef.current.size >= 32) {
+          post({
+            type: "error",
+            appInstanceId,
+            error: "too_many_pending",
+          })
+          return
+        }
+        const requestId = handshakeToken()
+        pendingUnicastRequestsRef.current.set(requestId, now)
+        const result = sendUnicastRef.current(
+          requestId,
+          message.targetParticipantId,
+          appInstanceId,
+          message.payload
+        )
+        if (result !== "sent") {
+          pendingUnicastRequestsRef.current.delete(requestId)
+          post({
+            type: "error",
+            appInstanceId,
+            error:
+              result === "rate_limited"
+                ? "rate_limited"
+                : result === "payload_too_large"
+                ? "payload_too_large"
+                : "delivery_unavailable",
+          })
+        }
+        return
+      }
       const serializedBytes = serializedRoomAppBytes(message.payload)
       if (serializedBytes === null) return
       const lane = message.type === "sendReliable" ? "reliable" : "realtime"
@@ -128,6 +184,7 @@ export default function RoomAppHost({
   }, [app.id, app.origin, appInstanceId, onReady, participants, post, self])
 
   useEffect(() => {
+    const pendingUnicastRequests = pendingUnicastRequestsRef.current
     if (!validateRoomAppDefinition(app) || !isRoomAppAllowlisted(app)) {
       setFailed(true)
       return
@@ -136,6 +193,7 @@ export default function RoomAppHost({
       readyRef.current = false
       portRef.current?.close()
       portRef.current = null
+      pendingUnicastRequests.clear()
     }
   }, [app])
 
@@ -150,6 +208,31 @@ export default function RoomAppHost({
       })
     })
   }, [appInstanceId, post, subscribe])
+
+  useEffect(() => {
+    return subscribeUnicast((message) => {
+      if (!readyRef.current || message.appInstanceId !== appInstanceId) return
+      post({
+        type: "unicast",
+        appInstanceId,
+        sourceParticipantId: message.sourceParticipantId,
+        payload: message.payload,
+      })
+    })
+  }, [appInstanceId, post, subscribeUnicast])
+
+  useEffect(() => {
+    return subscribeUnicastResults((result) => {
+      if (
+        !readyRef.current ||
+        result.appInstanceId !== appInstanceId ||
+        !pendingUnicastRequestsRef.current.has(result.requestId)
+      )
+        return
+      pendingUnicastRequestsRef.current.delete(result.requestId)
+      post({ type: "unicast_result", ...result })
+    })
+  }, [appInstanceId, post, subscribeUnicastResults])
 
   useEffect(() => {
     const next = projectRoomAppParticipants(participants)

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -138,6 +138,7 @@ export default function RoomAppHost({
           post({
             type: "error",
             appInstanceId,
+            requestId: message.requestId,
             error: "duplicate_request_id",
           })
           return
@@ -146,6 +147,7 @@ export default function RoomAppHost({
           post({
             type: "error",
             appInstanceId,
+            requestId: message.requestId,
             error: "too_many_pending",
           })
           return
@@ -163,6 +165,7 @@ export default function RoomAppHost({
           post({
             type: "error",
             appInstanceId,
+            requestId,
             error:
               result === "rate_limited"
                 ? "rate_limited"

--- a/app/src/components/RoomContent.composeAttachment.test.tsx
+++ b/app/src/components/RoomContent.composeAttachment.test.tsx
@@ -64,6 +64,9 @@ const baseHookReturn = {
   roomAppsEnabled: false,
   sendRoomAppMessage: vi.fn(() => false),
   subscribeRoomAppMessages: vi.fn(() => () => undefined),
+  sendRoomAppUnicast: vi.fn(() => "delivery_unavailable"),
+  subscribeRoomAppUnicast: vi.fn(() => () => undefined),
+  subscribeRoomAppUnicastResults: vi.fn(() => () => undefined),
 }
 
 const ROOM_PARTICIPANTS = [

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -93,6 +93,9 @@ const baseHookReturn = {
   roomAppsEnabled: false,
   sendRoomAppMessage: vi.fn(() => false),
   subscribeRoomAppMessages: vi.fn(() => () => undefined),
+  sendRoomAppUnicast: vi.fn(() => "delivery_unavailable"),
+  subscribeRoomAppUnicast: vi.fn(() => () => undefined),
+  subscribeRoomAppUnicastResults: vi.fn(() => () => undefined),
 }
 
 const LATE_JOIN_EXPIRY = Date.now() + 365 * 24 * 60 * 60 * 1000

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -209,6 +209,9 @@ export default function RoomContent({
     roomAppsEnabled,
     sendRoomAppMessage,
     subscribeRoomAppMessages,
+    sendRoomAppUnicast,
+    subscribeRoomAppUnicast,
+    subscribeRoomAppUnicastResults,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
   })
@@ -1122,6 +1125,9 @@ export default function RoomContent({
                       subscribe={subscribeRoomAppMessages}
                       send={sendRoomAppMessage}
                       onReady={handleRoomAppReady}
+                      subscribeUnicast={subscribeRoomAppUnicast}
+                      subscribeUnicastResults={subscribeRoomAppUnicastResults}
+                      sendUnicast={sendRoomAppUnicast}
                       onClose={() => setActiveRoomAppId(null)}
                     />
                   </div>

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -5292,6 +5292,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       this.sendRoomAppUnicastResult(socket, message, false, "invalid_target")
       return
     }
+    if (message.targetParticipantId === sender.id) {
+      this.sendRoomAppUnicastResult(socket, message, false, "invalid_target")
+      return
+    }
     const payload = validateRoomAppPayload(message.payload)
     const requestBytes = serializedRoomAppBytes(message)
     if (

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -124,6 +124,18 @@ import {
   type TaskProjectionIndex,
 } from "./taskScope"
 import {
+  ROOM_APP_MAX_PAYLOAD_BYTES,
+  ROOM_APP_PROTOCOL_VERSION,
+  ROOM_APP_UNICAST_BYTES_PER_SECOND,
+  ROOM_APP_UNICAST_MESSAGES_PER_SECOND,
+  isRoomAppInstanceForRoom,
+  isValidRoomAppInstanceId,
+  isValidRoomAppParticipantId,
+  isValidRoomAppRequestId,
+  serializedRoomAppBytes,
+  validateRoomAppPayload,
+} from "../common/roomApp"
+import {
   createRuntimeProviderHandle,
   hashRuntimeProviderHandle,
   isRuntimeProviderClaimHash,
@@ -271,6 +283,7 @@ interface ConnectionAttachment {
   participantId: string
   token: string
   connectionNonce: string
+  roomAppUnicastRateSamples?: Array<{ at: number; bytes: number }>
 }
 
 interface AgentEventSocketAttachment {
@@ -720,6 +733,16 @@ type ClientMessage =
       requestId: string
       providerClaimHash: string
       reattachProofHash?: string
+    }
+  | {
+      // Ephemeral private Room App control-plane message. The Room derives
+      // sender identity from the authenticated WebSocket attachment and
+      // delivers only to the current target Human socket.
+      type: "room-app-unicast"
+      requestId: string
+      targetParticipantId: string
+      appInstanceId: string
+      payload: Record<string, unknown>
     }
 
 export class RoomSession extends DurableObject<RoomSessionEnv> {
@@ -5168,6 +5191,199 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return { attachment, data: btoa(binary) }
   }
 
+  private sendRoomAppUnicastResult(
+    socket: WebSocket,
+    message: Extract<ClientMessage, { type: "room-app-unicast" }>,
+    ok: boolean,
+    error?:
+      | "invalid_request"
+      | "app_unavailable"
+      | "invalid_target"
+      | "target_unavailable"
+      | "rate_limited"
+      | "delivery_failed"
+  ): void {
+    if (
+      !isValidRoomAppRequestId(message.requestId) ||
+      !isValidRoomAppInstanceId(message.appInstanceId)
+    )
+      return
+    try {
+      socket.send(
+        JSON.stringify({
+          type: "room-app-unicast-result",
+          requestId: message.requestId,
+          appInstanceId: message.appInstanceId,
+          ok,
+          ...(error ? { error } : {}),
+        })
+      )
+    } catch {
+      // Result delivery is best-effort and never changes Room state.
+    }
+  }
+
+  private consumeRoomAppUnicastBudget(
+    socket: WebSocket,
+    attachment: ConnectionAttachment,
+    bytes: number,
+    now: number
+  ): "allowed" | "rate_limited" | "delivery_failed" {
+    const windowStart = now - 1000
+    const samples = (attachment.roomAppUnicastRateSamples ?? [])
+      .slice(-ROOM_APP_UNICAST_MESSAGES_PER_SECOND)
+      .filter(
+        (sample) =>
+          Number.isSafeInteger(sample.at) &&
+          sample.at > windowStart &&
+          sample.at <= now &&
+          Number.isSafeInteger(sample.bytes) &&
+          sample.bytes >= 0 &&
+          sample.bytes <= ROOM_APP_MAX_PAYLOAD_BYTES
+      )
+    const totalBytes = samples.reduce((sum, sample) => sum + sample.bytes, 0)
+    if (
+      samples.length >= ROOM_APP_UNICAST_MESSAGES_PER_SECOND ||
+      totalBytes + bytes > ROOM_APP_UNICAST_BYTES_PER_SECOND
+    )
+      return "rate_limited"
+    try {
+      socket.serializeAttachment({
+        ...attachment,
+        roomAppUnicastRateSamples: [...samples, { at: now, bytes }],
+      } satisfies ConnectionAttachment)
+      return "allowed"
+    } catch {
+      // Fail closed if the bounded control-plane budget cannot survive socket
+      // hibernation. The attachment contains counters only, never payloads.
+      return "delivery_failed"
+    }
+  }
+
+  private async handleRoomAppUnicast(
+    socket: WebSocket,
+    attachment: ConnectionAttachment,
+    room: RoomRecord,
+    message: Extract<ClientMessage, { type: "room-app-unicast" }>
+  ): Promise<void> {
+    if (
+      !isValidRoomAppRequestId(message.requestId) ||
+      !isValidRoomAppInstanceId(message.appInstanceId)
+    )
+      return
+    if (
+      this.env.ROOM_APPS_ENABLED !== "true" ||
+      !isRoomAppInstanceForRoom(this.roomAnalyticsName(), message.appInstanceId)
+    ) {
+      this.sendRoomAppUnicastResult(socket, message, false, "app_unavailable")
+      return
+    }
+    const sender = room.participants[attachment.participantId]
+    if (
+      !sender ||
+      sender.kind !== "human" ||
+      !sender.connected ||
+      sender.connectionNonce !== attachment.connectionNonce
+    ) {
+      this.sendRoomAppUnicastResult(socket, message, false, "invalid_request")
+      return
+    }
+    if (!isValidRoomAppParticipantId(message.targetParticipantId)) {
+      this.sendRoomAppUnicastResult(socket, message, false, "invalid_target")
+      return
+    }
+    const payload = validateRoomAppPayload(message.payload)
+    const requestBytes = serializedRoomAppBytes(message)
+    if (
+      !payload.ok ||
+      requestBytes === null ||
+      requestBytes > ROOM_APP_MAX_PAYLOAD_BYTES
+    ) {
+      this.sendRoomAppUnicastResult(socket, message, false, "invalid_request")
+      return
+    }
+    const now = Date.now()
+    const budget = this.consumeRoomAppUnicastBudget(
+      socket,
+      attachment,
+      requestBytes,
+      now
+    )
+    if (budget !== "allowed") {
+      this.sendRoomAppUnicastResult(
+        socket,
+        message,
+        false,
+        budget === "rate_limited" ? "rate_limited" : "delivery_failed"
+      )
+      return
+    }
+    const target = room.participants[message.targetParticipantId]
+    if (
+      !target ||
+      target.kind !== "human" ||
+      !target.connected ||
+      !target.token ||
+      !target.connectionNonce
+    ) {
+      this.sendRoomAppUnicastResult(
+        socket,
+        message,
+        false,
+        "target_unavailable"
+      )
+      return
+    }
+    let targetSocket: WebSocket | null = null
+    for (const candidate of this.ctx.getWebSockets()) {
+      if (this.deserializeAgentEventAttachment(candidate)) continue
+      let targetAttachment: Partial<ConnectionAttachment> | null = null
+      try {
+        targetAttachment =
+          candidate.deserializeAttachment() as Partial<ConnectionAttachment> | null
+      } catch {
+        continue
+      }
+      if (
+        targetAttachment?.participantId === target.id &&
+        targetAttachment.token === target.token &&
+        targetAttachment.connectionNonce === target.connectionNonce &&
+        candidate.readyState === 1
+      ) {
+        targetSocket = candidate
+        break
+      }
+    }
+    if (!targetSocket) {
+      this.sendRoomAppUnicastResult(
+        socket,
+        message,
+        false,
+        "target_unavailable"
+      )
+      return
+    }
+    const delivery = {
+      type: "room-app-unicast",
+      protocolVersion: ROOM_APP_PROTOCOL_VERSION,
+      appInstanceId: message.appInstanceId,
+      sourceParticipantId: sender.id,
+      payload: payload.payload,
+    }
+    const deliveryBytes = serializedRoomAppBytes(delivery)
+    if (deliveryBytes === null || deliveryBytes > ROOM_APP_MAX_PAYLOAD_BYTES) {
+      this.sendRoomAppUnicastResult(socket, message, false, "invalid_request")
+      return
+    }
+    try {
+      targetSocket.send(JSON.stringify(delivery))
+    } catch {
+      this.sendRoomAppUnicastResult(socket, message, false, "delivery_failed")
+      return
+    }
+    this.sendRoomAppUnicastResult(socket, message, true)
+  }
+
   private async handleClientMessage(
     socket: WebSocket,
     attachment: ConnectionAttachment,
@@ -5186,6 +5402,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     )
     if (!participant || participant.kind !== "human" || !participant.media) {
       socket.close(4003, "Unauthorized")
+      return
+    }
+    if (message.type === "room-app-unicast") {
+      await this.handleRoomAppUnicast(socket, attachment, room, message)
       return
     }
     participant.lastSeenAt = Date.now()

--- a/app/src/do/roomSessionRoomAppUnicast.test.ts
+++ b/app/src/do/roomSessionRoomAppUnicast.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+import { roomAppInstanceId } from "../common/roomApp"
+
+const FAR_FUTURE = Date.now() + 365 * 24 * 60 * 60 * 1000
+const ROOM_NAME = "room-app-unicast-test"
+const APP_INSTANCE_ID = roomAppInstanceId(ROOM_NAME, "whiteboard")
+
+function participant(
+  id: string,
+  kind: "human" | "agent",
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id,
+    name: id,
+    kind,
+    connected: true,
+    joinedAt: 1,
+    lastSeenAt: Date.now(),
+    token: `token-${id}`,
+    ...(kind === "human"
+      ? {
+          connectionNonce: `nonce-${id}`,
+          media: {
+            sessionId: `session-${id}`,
+            muted: false,
+            fileChannelReady: false,
+            tracks: [],
+          },
+        }
+      : {}),
+    ...overrides,
+  }
+}
+
+function buildStoredRoom() {
+  return {
+    createdAt: Date.now(),
+    expiresAt: FAR_FUTURE,
+    participants: {
+      "human-a": participant("human-a", "human"),
+      "human-b": participant("human-b", "human"),
+      "human-c": participant("human-c", "human"),
+      "agent-c": participant("agent-c", "agent"),
+    },
+    messages: [],
+    nextMessageSequence: 1,
+    meetingNotes: { active: false },
+    agentVoice: {},
+    liveTranscript: { active: false },
+    liveTranscriptSegments: [],
+    nextLiveTranscriptEpoch: 1,
+    nextTranscriptSequence: 1,
+    attachments: [],
+    pendingMediaCleanup: [],
+  }
+}
+
+class FakeSocket {
+  readyState = 1
+  sent: string[] = []
+  send = vi.fn((raw: string) => this.sent.push(raw))
+  close = vi.fn()
+
+  constructor(private attachment: Record<string, unknown>) {}
+
+  deserializeAttachment() {
+    return this.attachment
+  }
+
+  serializeAttachment(attachment: Record<string, unknown>) {
+    this.attachment = structuredClone(attachment)
+  }
+
+  messages() {
+    return this.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>)
+  }
+}
+
+function makeRoomSession() {
+  const store = new Map<string, unknown>([
+    ["room", buildStoredRoom()],
+    [
+      "live-transcript",
+      {
+        liveTranscript: { active: false },
+        liveTranscriptSegments: [],
+        nextLiveTranscriptEpoch: 1,
+        nextTranscriptSequence: 1,
+      },
+    ],
+  ])
+  const sockets: FakeSocket[] = []
+  const ctx = {
+    storage: {
+      get: async (key: string) => {
+        const value = store.get(key)
+        return value === undefined ? undefined : structuredClone(value)
+      },
+      put: async (key: string, value: unknown) =>
+        void store.set(key, structuredClone(value)),
+      delete: async (key: string) => void store.delete(key),
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+      list: async () => new Map(),
+    },
+    getWebSockets: () => sockets as unknown as WebSocket[],
+    waitUntil: (promise: Promise<unknown>) => void promise,
+    id: { name: ROOM_NAME, toString: () => ROOM_NAME },
+  }
+  const session = new RoomSession(
+    ctx as never,
+    { SFU_ROOM: {}, ROOM_APPS_ENABLED: "true" } as never
+  )
+  const addHumanSocket = (
+    participantId: string,
+    nonce = `nonce-${participantId}`
+  ) => {
+    const socket = new FakeSocket({
+      participantId,
+      token: `token-${participantId}`,
+      connectionNonce: nonce,
+    })
+    sockets.push(socket)
+    return socket
+  }
+  const addAgentSocket = (participantId: string) => {
+    const socket = new FakeSocket({
+      kind: "agent-event",
+      participantId,
+      connectionNonce: `nonce-${participantId}`,
+      cursor: 0,
+    })
+    sockets.push(socket)
+    return socket
+  }
+  const sendFrom = async (
+    socket: FakeSocket,
+    participantId: string,
+    requestId: string,
+    targetParticipantId: string,
+    payload: Record<string, unknown>
+  ) => {
+    const message = JSON.stringify({
+      type: "room-app-unicast",
+      requestId,
+      targetParticipantId,
+      appInstanceId: APP_INSTANCE_ID,
+      payload,
+    })
+    return (
+      session as unknown as {
+        webSocketMessage: (socket: WebSocket, raw: string) => Promise<void>
+      }
+    ).webSocketMessage(socket as unknown as WebSocket, message)
+  }
+  return { session, store, sockets, addHumanSocket, addAgentSocket, sendFrom }
+}
+
+describe("RoomSession reliable participant unicast (#377)", () => {
+  it("delivers only to the target Human socket without storing or broadcasting the payload", async () => {
+    const { store, addHumanSocket, addAgentSocket, sendFrom } =
+      makeRoomSession()
+    const sender = addHumanSocket("human-a")
+    const target = addHumanSocket("human-b")
+    const otherHuman = addHumanSocket("human-c")
+    const agent = addAgentSocket("agent-c")
+    const secretPayload = { type: "secret_word", word: "otter" }
+
+    await sendFrom(sender, "human-a", "request_1", "human-b", secretPayload)
+
+    expect(target.messages()).toEqual([
+      {
+        type: "room-app-unicast",
+        protocolVersion: 1,
+        appInstanceId: APP_INSTANCE_ID,
+        sourceParticipantId: "human-a",
+        payload: secretPayload,
+      },
+    ])
+    expect(sender.messages()).toEqual([
+      {
+        type: "room-app-unicast-result",
+        requestId: "request_1",
+        appInstanceId: APP_INSTANCE_ID,
+        ok: true,
+      },
+    ])
+    expect(otherHuman.messages()).toEqual([])
+    expect(agent.messages()).toEqual([])
+    expect(JSON.stringify(store.get("room"))).not.toContain("otter")
+    expect(JSON.stringify(store.get("live-transcript"))).not.toContain("otter")
+  })
+
+  it("does not queue for a disconnected target and delivers once to its current reconnect socket", async () => {
+    const { store, addHumanSocket, sendFrom } = makeRoomSession()
+    const sender = addHumanSocket("human-a")
+    const staleTargetSocket = addHumanSocket("human-b", "old-nonce-human-b")
+    const room = store.get("room") as ReturnType<typeof buildStoredRoom>
+    room.participants["human-b"].connected = false
+    room.participants["human-b"].connectionNonce = undefined
+    store.set("room", room)
+
+    await sendFrom(sender, "human-a", "request_offline", "human-b", {
+      type: "secret_word",
+      word: "otter",
+    })
+    expect(staleTargetSocket.messages()).toEqual([])
+    expect(sender.messages().at(-1)).toMatchObject({
+      type: "room-app-unicast-result",
+      requestId: "request_offline",
+      ok: false,
+      error: "target_unavailable",
+    })
+
+    const reconnectedRoom = store.get("room") as ReturnType<
+      typeof buildStoredRoom
+    >
+    reconnectedRoom.participants["human-b"].connected = true
+    reconnectedRoom.participants["human-b"].connectionNonce = "new-nonce"
+    store.set("room", reconnectedRoom)
+    const currentTargetSocket = addHumanSocket("human-b", "new-nonce")
+
+    await sendFrom(sender, "human-a", "request_reconnected", "human-b", {
+      type: "secret_word",
+      word: "otter",
+    })
+
+    expect(staleTargetSocket.messages()).toEqual([])
+    expect(currentTargetSocket.messages()).toHaveLength(1)
+    expect(currentTargetSocket.messages()[0].payload).toEqual({
+      type: "secret_word",
+      word: "otter",
+    })
+  })
+
+  it("rejects stale senders, non-Human targets, invalid payloads, and disabled Room Apps", async () => {
+    const { session, store, addHumanSocket, addAgentSocket, sendFrom } =
+      makeRoomSession()
+    const sender = addHumanSocket("human-a", "stale-sender-nonce")
+    const target = addHumanSocket("human-b")
+    const agent = addAgentSocket("agent-c")
+
+    await sendFrom(sender, "human-a", "request_stale", "human-b", {
+      type: "private",
+    })
+    expect(target.messages()).toEqual([])
+    expect(sender.messages().at(-1)).toMatchObject({
+      ok: false,
+      error: "invalid_request",
+    })
+
+    const validSender = addHumanSocket("human-a")
+    await sendFrom(validSender, "human-a", "request_agent", "agent-c", {
+      type: "private",
+    })
+    expect(agent.messages()).toEqual([])
+    expect(validSender.messages().at(-1)).toMatchObject({
+      ok: false,
+      error: "target_unavailable",
+    })
+
+    await sendFrom(validSender, "human-a", "request_spoof", "human-b", {
+      sourceParticipantId: "human-a",
+      type: "private",
+    })
+    expect(target.messages()).toEqual([])
+    expect(validSender.messages().at(-1)).toMatchObject({
+      ok: false,
+      error: "invalid_request",
+    })
+    ;(
+      session as unknown as { env: { ROOM_APPS_ENABLED: string } }
+    ).env.ROOM_APPS_ENABLED = "false"
+    await sendFrom(validSender, "human-a", "request_disabled", "human-b", {
+      type: "private",
+    })
+    expect(target.messages()).toEqual([])
+    expect(validSender.messages().at(-1)).toMatchObject({
+      ok: false,
+      error: "app_unavailable",
+    })
+    expect(JSON.stringify(store.get("room"))).not.toContain("private")
+  })
+
+  it("enforces per-sender message and byte limits without falling back to broadcast", async () => {
+    const { addHumanSocket, sendFrom } = makeRoomSession()
+    const sender = addHumanSocket("human-a")
+    const target = addHumanSocket("human-b")
+    for (let index = 0; index < 10; index += 1)
+      await sendFrom(sender, "human-a", `request_${index}`, "human-b", {
+        index,
+      })
+    await sendFrom(sender, "human-a", "request_limited", "human-b", {
+      index: 10,
+    })
+    expect(target.messages()).toHaveLength(10)
+    expect(sender.messages().at(-1)).toMatchObject({
+      type: "room-app-unicast-result",
+      requestId: "request_limited",
+      ok: false,
+      error: "rate_limited",
+    })
+  })
+
+  it("rejects aggregate unicast bytes above the per-sender budget", async () => {
+    const { addHumanSocket, sendFrom } = makeRoomSession()
+    const sender = addHumanSocket("human-a")
+    const target = addHumanSocket("human-b")
+    const largePayload = { value: "x".repeat(13_000) }
+    for (let index = 0; index < 5; index += 1)
+      await sendFrom(
+        sender,
+        "human-a",
+        `large_${index}`,
+        "human-b",
+        largePayload
+      )
+
+    expect(target.messages()).toHaveLength(4)
+    expect(sender.messages().at(-1)).toMatchObject({
+      type: "room-app-unicast-result",
+      requestId: "large_4",
+      ok: false,
+      error: "rate_limited",
+    })
+  })
+})

--- a/app/src/do/roomSessionRoomAppUnicast.test.ts
+++ b/app/src/do/roomSessionRoomAppUnicast.test.ts
@@ -254,6 +254,15 @@ describe("RoomSession reliable participant unicast (#377)", () => {
     })
 
     const validSender = addHumanSocket("human-a")
+    await sendFrom(validSender, "human-a", "request_self", "human-a", {
+      type: "private",
+    })
+    expect(validSender.messages().at(-1)).toMatchObject({
+      type: "room-app-unicast-result",
+      requestId: "request_self",
+      ok: false,
+      error: "invalid_target",
+    })
     await sendFrom(validSender, "human-a", "request_agent", "agent-c", {
       type: "private",
     })

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -109,6 +109,7 @@ function localTrackResponse(init?: RequestInit) {
 let lastFakeWebSocket: {
   onopen: (() => void) | null
   onmessage: ((event: { data: string }) => void) | null
+  send: ReturnType<typeof vi.fn>
 } | null = null
 
 describe("useSfuChatRoom — Turnstile boundary", () => {
@@ -141,10 +142,10 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
       onmessage: ((event: { data: string }) => void) | null = null
       onerror: (() => void) | null = null
       onclose: (() => void) | null = null
+      send = vi.fn()
       constructor(public url: string) {
         lastFakeWebSocket = this
       }
-      send() {}
       close() {}
     }
     ;(global as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket
@@ -307,7 +308,20 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
       useSfuChatRoom("room-app", "alice", "audio", {})
     )
 
+    const privateMessages: unknown[] = []
+    const privateResults: unknown[] = []
+
     await waitFor(() => expect(result.current.roomAppsEnabled).toBe(true))
+    await waitFor(() => expect(lastFakeWebSocket).not.toBeNull())
+    act(() => {
+      lastFakeWebSocket?.onopen?.()
+      result.current.subscribeRoomAppUnicast((message) =>
+        privateMessages.push(message)
+      )
+      result.current.subscribeRoomAppUnicastResults((response) =>
+        privateResults.push(response)
+      )
+    })
     await waitFor(() =>
       expect(
         FakePeerConnection.dataChannels.filter((channel) =>
@@ -327,7 +341,53 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
           type: "cursor",
         })
       ).toBe(true)
+      expect(
+        result.current.sendRoomAppUnicast(
+          "request_1",
+          "participant-2",
+          appInstanceId,
+          { type: "secret_word", word: "otter" }
+        )
+      ).toBe("sent")
     })
+
+    expect(JSON.parse(lastFakeWebSocket!.send.mock.calls.at(-1)![0])).toEqual({
+      type: "room-app-unicast",
+      requestId: "request_1",
+      targetParticipantId: "participant-2",
+      appInstanceId,
+      payload: { type: "secret_word", word: "otter" },
+    })
+    act(() => {
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "room-app-unicast",
+          protocolVersion: 1,
+          appInstanceId,
+          sourceParticipantId: "participant-2",
+          payload: { type: "secret_word", word: "otter" },
+        }),
+      })
+      lastFakeWebSocket?.onmessage?.({
+        data: JSON.stringify({
+          type: "room-app-unicast-result",
+          requestId: "request_1",
+          appInstanceId,
+          ok: true,
+        }),
+      })
+    })
+    expect(privateMessages).toEqual([
+      {
+        protocolVersion: 1,
+        appInstanceId,
+        sourceParticipantId: "participant-2",
+        payload: { type: "secret_word", word: "otter" },
+      },
+    ])
+    expect(privateResults).toEqual([
+      { requestId: "request_1", appInstanceId, ok: true },
+    ])
 
     const channels = FakePeerConnection.dataChannels.filter((channel) =>
       channel.label.startsWith("room-app-")

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -6,11 +6,17 @@ import {
   reconcileCanonicalRoomMessages,
 } from "@common/messageReconciliation"
 import {
+  decodeRoomAppUnicastEnvelope,
+  decodeRoomAppUnicastResult,
   decodeRoomAppEnvelope,
+  encodeRoomAppUnicastRequest,
   encodeRoomAppEnvelope,
   isRoomAppInstanceForRoom,
   roomAppRateGuard,
+  roomAppUnicastRateGuard,
   type RoomAppLane,
+  type RoomAppUnicastEnvelope,
+  type RoomAppUnicastResult,
   type RoomAppTransportEnvelope,
 } from "@common/roomApp"
 import { validateRoomAttachmentRead } from "@common/roomAttachments"
@@ -478,6 +484,8 @@ interface SfuServerMessage {
     | "error"
     | "runtime-provider-claim-created"
     | "agentActivity"
+    | "room-app-unicast"
+    | "room-app-unicast-result"
   state?: SfuRoomState
   attachment?: RoomAttachmentProjection
   participant?: Partial<SfuParticipant> & {
@@ -494,6 +502,11 @@ interface SfuServerMessage {
   activity?: AgentActivityProjection | null
   agentParticipantId?: string
   scopeId?: string
+  protocolVersion?: number
+  appInstanceId?: string
+  sourceParticipantId?: string
+  payload?: Record<string, unknown>
+  ok?: boolean
 }
 
 const roomMessageToMessage = (
@@ -648,8 +661,15 @@ export function useSfuChatRoom(
   const roomAppListenersRef = useRef(
     new Set<(message: RoomAppTransportEnvelope) => void>()
   )
+  const roomAppUnicastListenersRef = useRef(
+    new Set<(message: RoomAppUnicastEnvelope) => void>()
+  )
+  const roomAppUnicastResultListenersRef = useRef(
+    new Set<(result: RoomAppUnicastResult) => void>()
+  )
   const roomAppOutboundRateRef = useRef(roomAppRateGuard())
   const roomAppInboundRateRef = useRef(roomAppRateGuard())
+  const roomAppUnicastRateRef = useRef(roomAppUnicastRateGuard())
   const roomAppStatsRef = useRef<RoomAppTransportStats>({
     reliableMessages: 0,
     realtimeMessages: 0,
@@ -2874,6 +2894,16 @@ export function useSfuChatRoom(
       const message = JSON.parse(event.data) as SfuServerMessage
       if (message.type === "state" && message.state) {
         applyRoomState(message.state)
+      } else if (message.type === "room-app-unicast") {
+        const envelope = decodeRoomAppUnicastEnvelope(message, roomName)
+        if (!envelope) return
+        for (const listener of roomAppUnicastListenersRef.current)
+          listener(envelope)
+      } else if (message.type === "room-app-unicast-result") {
+        const result = decodeRoomAppUnicastResult(message, roomName)
+        if (!result) return
+        for (const listener of roomAppUnicastResultListenersRef.current)
+          listener(result)
       } else if (message.type === "agentActivity") {
         if (message.activity) {
           const next = [
@@ -3113,6 +3143,7 @@ export function useSfuChatRoom(
     rebuildParticipants,
     resetRemoteParticipant,
     resetRemoteTrackSubscription,
+    roomName,
     sendSocketMessage,
     subscribeFileChannel,
     subscribeRoomAppChannel,
@@ -3530,10 +3561,62 @@ export function useSfuChatRoom(
     [roomName]
   )
 
+  const sendRoomAppUnicast = useCallback(
+    (
+      requestId: string,
+      targetParticipantId: string,
+      appInstanceId: string,
+      payload: Record<string, unknown>
+    ):
+      | "sent"
+      | "rate_limited"
+      | "payload_too_large"
+      | "delivery_unavailable" => {
+      if (
+        !roomAppsEnabledRef.current ||
+        !isRoomAppInstanceForRoom(roomName, appInstanceId)
+      )
+        return "delivery_unavailable"
+      const encoded = encodeRoomAppUnicastRequest({
+        requestId,
+        targetParticipantId,
+        appInstanceId,
+        payload,
+      })
+      if (!encoded) return "payload_too_large"
+      const bytes = new TextEncoder().encode(encoded).byteLength
+      if (!roomAppUnicastRateRef.current.allow(bytes)) return "rate_limited"
+      let message: object
+      try {
+        message = JSON.parse(encoded) as object
+      } catch {
+        return "payload_too_large"
+      }
+      return sendSocketMessage(message) ? "sent" : "delivery_unavailable"
+    },
+    [roomName, sendSocketMessage]
+  )
+
   const subscribeRoomAppMessages = useCallback(
     (listener: (message: RoomAppTransportEnvelope) => void) => {
       roomAppListenersRef.current.add(listener)
       return () => roomAppListenersRef.current.delete(listener)
+    },
+    []
+  )
+
+  const subscribeRoomAppUnicast = useCallback(
+    (listener: (message: RoomAppUnicastEnvelope) => void) => {
+      roomAppUnicastListenersRef.current.add(listener)
+      return () => roomAppUnicastListenersRef.current.delete(listener)
+    },
+    []
+  )
+
+  const subscribeRoomAppUnicastResults = useCallback(
+    (listener: (result: RoomAppUnicastResult) => void) => {
+      roomAppUnicastResultListenersRef.current.add(listener)
+      return () => roomAppUnicastResultListenersRef.current.delete(listener)
     },
     []
   )
@@ -4015,6 +4098,9 @@ export function useSfuChatRoom(
     roomAppsEnabled,
     sendRoomAppMessage,
     subscribeRoomAppMessages,
+    sendRoomAppUnicast,
+    subscribeRoomAppUnicast,
+    subscribeRoomAppUnicastResults,
     getRoomAppStats,
     sendTextMessage,
     sendFileMessage,

--- a/docs/room-app-phase0-contract.md
+++ b/docs/room-app-phase0-contract.md
@@ -42,6 +42,7 @@ The iframe may request:
 ```text
 sendReliable(payload)
 sendRealtime(payload)
+sendReliableTo(targetParticipantId, payload)
 ```
 
 The host validates the current curated Room instance, payload shape, serialized
@@ -59,38 +60,66 @@ Free4Chat reliable or realtime lane
 other participant's instance of the same App
 ```
 
+`sendReliableTo` is an additive, low-frequency control-plane path for
+participant-specific messages. It crosses the existing authenticated Room
+WebSocket and RoomSession, where the sender is derived from that socket's
+attachment, the App instance is checked against the current Room's curated
+catalog, and the target must be a current connected Human. The RoomSession
+sends the bounded payload only to that Human's current authenticated browser
+socket. The target host receives `unicast` with a server-derived
+`sourceParticipantId`; the sender receives a bounded `unicast_result`.
+
+This is private from other Room participants, not end-to-end encrypted: the
+Free4Chat server handles the payload while relaying it. Unicast payloads are
+ephemeral and are not written to Room state, message history, Agent event
+streams, analytics, or logs. There is no broadcast fallback or offline queue;
+an unavailable target returns an explicit result, and a later reconnect gets
+only newly sent messages. Reliable/realtime DataChannels remain the transport
+for broadcasts such as strokes, transforms, pointers, CRDT updates, and other
+frequent App traffic.
+
 Free4Chat does not know whether a payload is a stroke, CRDT update, transform,
 card move, chess action, document edit, game command, or something else.
 
 Join/leave notifications are generated from the current Room participant
-projection. The App cannot choose arbitrary relay destinations and receives no
-Room message history or private participant context.
+projection. Participant addressing is limited to the one-recipient unicast
+operation above; the App receives no Room message history or private
+participant context.
 
 ## Transport
 
-Free4Chat reuses the existing Human PeerConnection and Cloudflare Realtime SFU
-DataChannel substrate. Each Human publishes one named channel per lane; the
-`appInstanceId` multiplexes bounded App messages over those channels.
+Broadcast Room App traffic reuses the existing Human PeerConnection and
+Cloudflare Realtime SFU DataChannel substrate. Each Human publishes one named
+channel per lane; the `appInstanceId` multiplexes bounded App messages over
+those channels. Participant-private unicast uses the existing authenticated
+Room WebSocket as a separate, low-frequency path and does not change the
+DataChannel topology.
 
 - `reliable`: ordered, fully reliable DataChannel;
 - `realtime`: unordered, `maxRetransmits: 0`, deliberately stale-droppable;
-- no Durable Object message/history/storage write is created for normal App
-  traffic;
+- no Durable Object Room state, message, history, or payload storage write is
+  created for broadcast App traffic or private unicast; the sender socket
+  attachment retains at most 10 recent unicast timestamp/byte-count samples
+  for rate limiting across socket hibernation;
 - no PeerConnection is created per App;
 - the host keeps coarse in-memory counters for messages, bytes, and drops only.
+- reliable unicast is bounded to 10 messages/sec and 64 KiB/sec per sender;
+  each request, like the existing lanes, is at most 16 KiB serialized UTF-8.
 
-The choice of DataChannel is an implementation/economic fit, not a requirement
-that App state be WebRTC-specific. An equivalent App could use its own WebSocket
-or other backend. The value of the Free4Chat seam is that a Room already has a
-participant-aware realtime substrate, so a simple App does not need a second
-realtime service merely to exchange bounded messages.
+The choice of DataChannel is an implementation/economic fit for broadcast
+traffic, not a requirement that App state be WebRTC-specific. An equivalent
+App could use its own WebSocket or other backend. The Room's authenticated
+participant WebSocket also supports bounded private control messages, so a
+simple App can address one current Human without adding a second identity and
+relay service.
 
 Transport delivery and state convergence are different responsibilities.
-`reliable` means the underlying established DataChannel is reliable; it does
-not turn Free4Chat into an App operation log, replay system, CRDT provider, or
-persistent state service. App code must still handle its own bootstrap,
-reconnect/convergence, duplicate/stale operations, and any recovery semantics it
-requires.
+DataChannel `reliable` means the underlying established DataChannel is reliable;
+it does not turn Free4Chat into an App operation log, replay system, CRDT
+provider, or persistent state service. Unicast is a one-shot send to a current
+socket, not a replay or acknowledgement of application processing. App code
+must still handle its own bootstrap, reconnect/convergence, duplicate/stale
+operations, and any recovery semantics it requires.
 
 ## Stage and browser-session lifecycle
 
@@ -138,6 +167,7 @@ Current bounds remain:
 - reliable: at most 20 messages/sec;
 - realtime: at most 60 messages/sec;
 - combined transport budget: at most 256 KiB/sec;
+- reliable unicast: at most 10 messages/sec and 64 KiB/sec per sender;
 - Phase 0 curated catalog: at most two resident Apps per browser Room session.
 
 ## State ownership and persistence

--- a/docs/room-app-phase0-contract.md
+++ b/docs/room-app-phase0-contract.md
@@ -70,7 +70,10 @@ socket. The target host receives `unicast` with a server-derived
 `sourceParticipantId`; the sender receives a bounded `unicast_result` with the
 same App-provided `requestId`. The request ID is only a correlation key: it
 does not affect identity, authorization, or routing. The host rejects an ID
-that is already pending, and self-targeted sends return `invalid_target`.
+that is already pending, and self-targeted sends return `invalid_target`. Any
+host-local rejection of a valid `sendReliableTo` request also includes that
+request's ID, so local errors and asynchronous server results share one
+correlation contract. Errors for broadcast sends remain uncorrelated.
 
 This is private from other Room participants, not end-to-end encrypted: the
 Free4Chat server handles the payload while relaying it. Unicast payloads are

--- a/docs/room-app-phase0-contract.md
+++ b/docs/room-app-phase0-contract.md
@@ -42,7 +42,7 @@ The iframe may request:
 ```text
 sendReliable(payload)
 sendRealtime(payload)
-sendReliableTo(targetParticipantId, payload)
+sendReliableTo({ requestId, targetParticipantId, payload })
 ```
 
 The host validates the current curated Room instance, payload shape, serialized
@@ -67,7 +67,10 @@ attachment, the App instance is checked against the current Room's curated
 catalog, and the target must be a current connected Human. The RoomSession
 sends the bounded payload only to that Human's current authenticated browser
 socket. The target host receives `unicast` with a server-derived
-`sourceParticipantId`; the sender receives a bounded `unicast_result`.
+`sourceParticipantId`; the sender receives a bounded `unicast_result` with the
+same App-provided `requestId`. The request ID is only a correlation key: it
+does not affect identity, authorization, or routing. The host rejects an ID
+that is already pending, and self-targeted sends return `invalid_target`.
 
 This is private from other Room participants, not end-to-end encrypted: the
 Free4Chat server handles the payload while relaying it. Unicast payloads are


### PR DESCRIPTION
Adds an additive `sendReliableTo(targetParticipantId, payload)` Room App control path over the existing authenticated Room WebSocket.

RoomSession derives the sender from the socket attachment, validates the current curated App instance and current connected Human target, bounds each request to 16 KiB and each sender to 10 messages/sec and 64 KiB/sec, then sends only to that target's current authenticated browser socket. Unavailable targets get an explicit result; messages are not queued and never fall back to broadcast.

Unicast payloads are not written to Room state or history, analytics, logs, or Agent event streams. Other Room participants do not receive them; the relay is server-readable and is not E2EE. Existing broadcast reliable/realtime DataChannel topology remains unchanged, and no App-owned backend is added.

Validation: `yarn type-check`, `yarn test` (91 files / 854 tests), `yarn cf-build`, `yarn docs:check`, and two consecutive `yarn e2e:room` passes.

Closes #377.
