### PR TITLE
feat(discovery): add Apps hub and deepen Whiteboard landing

### DIFF
--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -4,6 +4,9 @@
     <loc>https://www.free4.chat/</loc>
   </url>
   <url>
+    <loc>https://www.free4.chat/apps</loc>
+  </url>
+  <url>
     <loc>https://www.free4.chat/apps/whiteboard</loc>
   </url>
   <url>

--- a/app/scripts/generate-docs-assets.mjs
+++ b/app/scripts/generate-docs-assets.mjs
@@ -28,6 +28,7 @@ const PUBLIC_DIR = join(appRoot, "public")
 /** Sitemap URLs that exist independently of the docs library, in order. */
 const BASE_SITEMAP_PATHS = [
   "/",
+  "/apps",
   "/apps/whiteboard",
   "/temporary-chat-room",
   "/ai-agent-room",

--- a/app/src/__tests__/discovery/copy-accuracy.test.ts
+++ b/app/src/__tests__/discovery/copy-accuracy.test.ts
@@ -75,13 +75,17 @@ describe("/apps/whiteboard copy accuracy", () => {
   const source = read("src/pages/apps/whiteboard.tsx")
 
   it("states the V1 collaboration, mobile, and temporary-state boundaries", () => {
-    expect(source).toMatch(/Excalidraw-powered drawing and editing/)
-    expect(source).toMatch(/without an account or sign-up/)
-    expect(source).toMatch(/voice, text, and file sharing/)
+    expect(source).toMatch(/free online whiteboard powered by Excalidraw/)
+    expect(source).toMatch(/No account or login is required/)
+    expect(source).toMatch(/voice, text, and\s+file sharing/)
     expect(source).toMatch(/touch input/)
-    expect(source).toMatch(/does not\s+save a permanent board/)
-    expect(source).toMatch(/replica disappears or reloads/)
-    expect(source).toMatch(/Image and file import is not supported/)
+    expect(source).toMatch(/does not save a permanent board/)
+    expect(source).toMatch(/every replica disappears\s+or reloads/)
+    expect(source).toMatch(
+      /Image and file import into the board is\s+not supported/
+    )
+    expect(source).toMatch(/New board/)
+    expect(source).toMatch(/Whiteboard FAQ/)
     expect(source).not.toMatch(/Agent/)
   })
 })

--- a/app/src/__tests__/discovery/crawl-surface.test.ts
+++ b/app/src/__tests__/discovery/crawl-surface.test.ts
@@ -56,6 +56,7 @@ describe("sitemap.xml", () => {
     expect(new Set(locs)).toEqual(
       new Set([
         "https://www.free4.chat/",
+        "https://www.free4.chat/apps",
         "https://www.free4.chat/apps/whiteboard",
         "https://www.free4.chat/temporary-chat-room",
         "https://www.free4.chat/ai-agent-room",

--- a/app/src/__tests__/discovery/pages-cta.test.tsx
+++ b/app/src/__tests__/discovery/pages-cta.test.tsx
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const router = vi.hoisted(() => ({ push: vi.fn() }))
 vi.mock("next/router", () => ({ useRouter: () => router }))
 
+import DiscoveryFooter from "../../components/DiscoveryFooter"
 import AiAgentRoomPage from "../../pages/ai-agent-room"
+import AppsPage from "../../pages/apps"
 import WhiteboardPage from "../../pages/apps/whiteboard"
 import MultiAgentCollaborationPage from "../../pages/multi-agent-collaboration"
 import PrivacyPage from "../../pages/privacy"
@@ -116,6 +118,41 @@ describe("Whiteboard direct Room CTA", () => {
     expect(savedRooms[0].nickName).toBeTruthy()
     expect(router.push).toHaveBeenCalledWith(
       `/room?id=${encodeURIComponent(savedRooms[0].roomName)}&app=whiteboard`
+    )
+  })
+})
+
+describe("Room Apps discovery surface", () => {
+  it("lists only the shipped Whiteboard App with a descriptive crawlable link", () => {
+    render(<AppsPage />)
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Apps for temporary Free4Chat Rooms",
+      })
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole("article")).toHaveLength(1)
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Online Whiteboard" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Explore Whiteboard →" })
+    ).toHaveAttribute("href", "/apps/whiteboard")
+    expect(
+      screen.queryByText(/Tiny Arena|Shared Canvas|Coming soon/i)
+    ).toBeNull()
+  })
+
+  it("includes Room Apps in the shared discovery footer", () => {
+    render(<DiscoveryFooter />)
+
+    expect(
+      screen.getByRole("navigation", { name: "Learn more" })
+    ).toContainElement(screen.getByRole("link", { name: "Room Apps" }))
+    expect(screen.getByRole("link", { name: "Room Apps" })).toHaveAttribute(
+      "href",
+      "/apps"
     )
   })
 })

--- a/app/src/__tests__/discovery/pages-seo.test.tsx
+++ b/app/src/__tests__/discovery/pages-seo.test.tsx
@@ -25,11 +25,22 @@ vi.mock("../../components/DiscoveryPageLayout", () => ({
     />
   ),
 }))
+vi.mock("../../components/SeoHead", () => ({
+  default: (props: { title: string; description: string; path: string }) => (
+    <div
+      data-testid="seo-stub"
+      data-title={props.title}
+      data-description={props.description}
+      data-path={props.path}
+    />
+  ),
+}))
 vi.mock("next/router", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 
 import AiAgentRoomPage from "../../pages/ai-agent-room"
+import AppsPage from "../../pages/apps"
 import WhiteboardPage from "../../pages/apps/whiteboard"
 import MultiAgentCollaborationPage from "../../pages/multi-agent-collaboration"
 import PrivacyPage from "../../pages/privacy"
@@ -62,7 +73,7 @@ const PAGES: Array<{
 function renderStub(Component: () => ReactElement) {
   const { container, unmount } = render(<Component />)
   const stub = container.querySelector<HTMLElement>(
-    '[data-testid="layout-stub"]'
+    '[data-testid="layout-stub"], [data-testid="seo-stub"]'
   )
   return { stub, unmount }
 }
@@ -112,5 +123,14 @@ describe("Discovery pages — SEO metadata authored per page", () => {
       ids.add(ctaId)
       unmount()
     }
+  })
+
+  it("/apps authors its own canonical discovery metadata", () => {
+    const { stub, unmount } = renderStub(AppsPage)
+
+    expect(stub?.dataset.title).toMatch(/Free4Chat Apps/)
+    expect(stub?.dataset.description).toMatch(/temporary Free4Chat Rooms/)
+    expect(stub?.dataset.path).toBe("/apps")
+    unmount()
   })
 })

--- a/app/src/__tests__/pages/index.test.tsx
+++ b/app/src/__tests__/pages/index.test.tsx
@@ -49,6 +49,10 @@ describe("Home page", () => {
     expect(
       screen.getByRole("link", { name: "Multi-Agent Collaboration →" })
     ).toHaveAttribute("href", "/multi-agent-collaboration")
+    expect(screen.getByRole("link", { name: "Room Apps →" })).toHaveAttribute(
+      "href",
+      "/apps"
+    )
     expect(screen.getByRole("link", { name: "Documentation" })).toHaveAttribute(
       "href",
       "/docs"

--- a/app/src/components/DiscoveryFooter.tsx
+++ b/app/src/components/DiscoveryFooter.tsx
@@ -5,8 +5,9 @@ const GROUPS: Array<{
   links: Array<{ href: string; label: string }>
 }> = [
   {
-    heading: "Free4Chat",
+    heading: "Explore",
     links: [
+      { href: "/apps", label: "Room Apps" },
       { href: "/temporary-chat-room", label: "Temporary rooms" },
       { href: "/ai-agent-room", label: "AI Agent rooms" },
       {
@@ -37,10 +38,10 @@ export default function DiscoveryFooter() {
   return (
     <nav
       aria-label="Learn more"
-      className="mx-auto flex w-full max-w-3xl flex-none flex-wrap justify-center gap-x-10 gap-y-4 px-4 py-6 font-mono text-xs"
+      className="mx-auto grid w-full max-w-4xl flex-none grid-cols-2 gap-x-6 gap-y-6 border-t border-emerald-900/50 px-4 py-8 font-mono text-xs sm:grid-cols-3 sm:gap-x-10"
     >
       {GROUPS.map((group) => (
-        <div key={group.heading} className="min-w-[8rem]">
+        <div key={group.heading} className="min-w-0">
           <p className="mb-2 font-semibold uppercase tracking-widest text-emerald-600">
             {group.heading}
           </p>

--- a/app/src/pages/apps/index.tsx
+++ b/app/src/pages/apps/index.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link"
+
+import { ROOM_APP_CATALOG } from "../../common/roomApp"
+import DiscoveryFooter from "../../components/DiscoveryFooter"
+import SeoHead from "../../components/SeoHead"
+
+const TITLE = "Free4Chat Apps — Shared Activities for Temporary Rooms"
+const DESCRIPTION =
+  "Explore shared tools and lightweight activities that open inside temporary Free4Chat Rooms. Start without an account, share one Room link, and collaborate or play."
+
+export default function AppsPage() {
+  const whiteboard = ROOM_APP_CATALOG.find((app) => app.id === "whiteboard")
+
+  return (
+    <div className="flex min-h-screen flex-col font-mono text-emerald-100">
+      <SeoHead title={TITLE} description={DESCRIPTION} path="/apps" />
+      <main className="flex-1 px-4 py-16">
+        <div className="mx-auto max-w-3xl">
+          <Link
+            href="/"
+            className="text-sm text-emerald-500 hover:text-emerald-300"
+          >
+            ← Free4Chat
+          </Link>
+          <p className="mt-10 font-mono text-xs tracking-widest text-emerald-500">
+            FREE4CHAT://ROOM_APPS
+          </p>
+          <h1 className="mt-4 text-3xl font-extrabold uppercase tracking-tight text-emerald-200 sm:text-4xl">
+            Apps for temporary Free4Chat Rooms
+          </h1>
+          <p className="mt-5 max-w-2xl text-sm leading-relaxed text-emerald-300/80">
+            Shared tools and lightweight activities that open inside a temporary
+            Room. No account. Open an App, share the Room link, and collaborate
+            or play.
+          </p>
+
+          {whiteboard && (
+            <section aria-label="Production Room Apps" className="mt-10">
+              <article className="border border-emerald-900/70 bg-black/30 p-5 sm:p-6">
+                <p className="text-xs tracking-widest text-emerald-600">
+                  ROOM APP · {whiteboard.id.toUpperCase()}
+                </p>
+                <h2 className="mt-3 text-xl font-bold text-emerald-200">
+                  Online {whiteboard.label}
+                </h2>
+                <p className="mt-3 text-sm leading-relaxed text-emerald-300/80">
+                  A free collaborative whiteboard powered by Excalidraw. Draw
+                  and edit together in a temporary Room, then share one link to
+                  bring other people in.
+                </p>
+                <Link
+                  href={`/apps/${whiteboard.id}`}
+                  className="mt-5 inline-flex text-sm text-emerald-400 underline-offset-4 transition hover:text-white hover:underline focus:outline-none focus:ring focus:ring-emerald-500/40"
+                >
+                  Explore {whiteboard.label} →
+                </Link>
+              </article>
+            </section>
+          )}
+        </div>
+      </main>
+      <DiscoveryFooter />
+    </div>
+  )
+}

--- a/app/src/pages/apps/whiteboard.tsx
+++ b/app/src/pages/apps/whiteboard.tsx
@@ -19,35 +19,106 @@ export default function WhiteboardPage() {
 
   return (
     <DiscoveryPageLayout
-      title="Online Whiteboard — No-Sign-Up Collaborative Whiteboard | Free4Chat"
-      description="Draw together on an Excalidraw-powered whiteboard in a temporary Free4Chat Room. No account or sign-up; share one link and collaborate by voice, text, and files."
+      title="Free Online Collaborative Whiteboard — No Sign-Up | Free4Chat"
+      description="Open a free online collaborative whiteboard in seconds. Draw and edit together in real time, share one Room link, and use it without an account or signup."
       path="/apps/whiteboard"
       ctaId="whiteboard"
       primaryCta={{
         label: "Open Whiteboard Room",
         onClick: openWhiteboardRoom,
       }}
-      h1="A collaborative whiteboard you can open and share instantly"
+      h1="A free collaborative whiteboard you can open and share instantly"
     >
       <p>
-        Whiteboard brings Excalidraw-powered drawing and editing into a
-        temporary Free4Chat Room. Start without an account or sign-up, then
-        invite another person with the Room link.
+        Whiteboard is a free online whiteboard powered by Excalidraw, inside a
+        temporary Free4Chat Room. No account or login is required. Open the
+        board, share the Room link, and invited people enter the same Room with
+        Whiteboard selected on the Stage.
       </p>
 
-      <h2>Work together in the Room</h2>
+      <h2>How it works</h2>
+      <ol>
+        <li>
+          <strong>Open a Whiteboard Room.</strong> The board starts on the
+          Room&apos;s Stage.
+        </li>
+        <li>
+          <strong>Share the Room link.</strong> Invitees join the same Room with
+          Whiteboard selected.
+        </li>
+        <li>
+          <strong>Draw together.</strong> Add ideas and edit the shared scene in
+          real time.
+        </li>
+      </ol>
+
+      <h2>What you can do</h2>
+      <ul>
+        <li>
+          Sketch freehand; add text, rectangles, ellipses, diamonds, arrows, and
+          lines.
+        </li>
+        <li>
+          Select, move, and edit objects, adjust drawing styles, and zoom or pan
+          around the board.
+        </li>
+        <li>
+          Draw with a mouse or trackpad, or use touch input on a phone or
+          tablet.
+        </li>
+        <li>
+          Collaborate with multiple people while keeping Room voice, text, and
+          file sharing alongside the board.
+        </li>
+        <li>
+          Use <strong>New board</strong> to clear the shared scene for everyone
+          and start fresh.
+        </li>
+      </ul>
+
+      <h2>Useful for quick shared thinking</h2>
       <p>
-        Keep the board beside the Room&apos;s voice, text, and file sharing. The
-        Whiteboard supports touch input on phones and tablets as well as a mouse
-        or trackpad.
+        Use a shared whiteboard for remote brainstorming, a quick team meeting,
+        a visual explanation while teaching, or a temporary architecture or flow
+        sketch. It gives people one place to shape an idea together without
+        setting up a permanent workspace.
       </p>
 
       <h2>Temporary by design</h2>
       <p>
-        Whiteboard V1 keeps board state in active browser replicas; it does not
-        save a permanent board. If every browser replica disappears or reloads,
-        the board may reset. Image and file import is not supported in V1.
+        No account is needed, and Whiteboard V1 does not save a permanent board.
+        The scene lives in active browser replicas; if every replica disappears
+        or reloads, the board may reset. Image and file import into the board is
+        not supported in V1. Room file sharing remains available separately.
       </p>
+
+      <h2>Whiteboard FAQ</h2>
+      <h3>Is the online whiteboard free?</h3>
+      <p>Yes. You can open and use the current Whiteboard App for free.</p>
+
+      <h3>Do I need an account or login?</h3>
+      <p>No account or login is required to start a Whiteboard Room.</p>
+
+      <h3>Can multiple people draw on the same whiteboard?</h3>
+      <p>
+        Yes. People in the Room can draw and edit the shared board together in
+        real time.
+      </p>
+
+      <h3>Can I use it on a phone or tablet?</h3>
+      <p>
+        Yes. The embedded drawing surface supports touch input, including on
+        phones and tablets.
+      </p>
+
+      <h3>Is the whiteboard saved permanently?</h3>
+      <p>
+        No. Whiteboard V1 has no permanent board storage. The board may reset if
+        every active browser replica reloads or disappears.
+      </p>
+
+      <h3>Can I import images or files into the board?</h3>
+      <p>Not in V1. Room file sharing is available outside the board.</p>
     </DiscoveryPageLayout>
   )
 }

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -378,7 +378,19 @@ export default function Home() {
               <p className="text-center font-mono text-xs font-bold uppercase tracking-widest text-emerald-600">
                 {"// explore_free4chat"}
               </p>
-              <div className="mt-4 grid gap-6 font-mono sm:grid-cols-3">
+              <div className="mt-4 grid gap-6 font-mono sm:grid-cols-2">
+                <div>
+                  <Link
+                    href="/apps"
+                    className="text-sm text-emerald-300 transition hover:text-white"
+                  >
+                    Room Apps →
+                  </Link>
+                  <p className="mt-1 text-xs leading-relaxed text-emerald-600">
+                    Open shared tools and lightweight activities inside a
+                    temporary Room.
+                  </p>
+                </div>
                 <div>
                   <Link
                     href="/temporary-chat-room"


### PR DESCRIPTION
## Summary

- Add a curated `/apps` discovery page for the production Whiteboard app.
- Add a Room Apps entry to the homepage and shared discovery footer while preserving the Room-first homepage CTA.
- Expand the Whiteboard landing page with accurate capabilities, temporary-board limits, and FAQs; retain direct Room launch.
- Add `/apps` to the sitemap and cover discovery links, metadata, and truthful copy with tests.

## Scope

This is discovery and landing-page work for `i365dev/free4chat#380`. It adds no analytics or tracking and does not change the Room App host contract, Room transport, or state semantics. No SEO page for `/apps/whiteboard` beyond the existing landing page was added.

## Validation

- Focused discovery tests: 6 files, 53 tests passed.
- Full Vitest suite: 90 files, 850 tests passed.
- `yarn type-check`, full `eslint src`, changed-file Prettier checks, `yarn docs:check`, and `git diff --check` passed.
- `yarn cf-build` passed and generated `/apps` and `/apps/whiteboard` routes. OpenNext emitted the existing Durable Object configuration and `react-markdown` copy warnings, but completed successfully.
- Playwright smoke checked homepage, `/apps`, and `/apps/whiteboard` at desktop and 390px mobile widths; no horizontal overflow. The Whiteboard CTA resolved to `/room?id=…&app=whiteboard`.

No product screenshot is attached: the meaningful Whiteboard view is an actual live Room board, and a fabricated empty/mock board would misrepresent production dogfood. Browser smoke was performed against the local app.

## Base

- `cf-sfu`: `96ed5babcc849a5aef285de201a186c2535f6fd8`
- Head: `89e317f1a17c8b7a1b3805cab95ecd0862c1a205`

Closes #380
