### PR TITLE
fix(room-ui): align Room actions with Room Apps and add fullscreen mode

### DIFF
--- a/app/src/components/RoomAppHost.test.tsx
+++ b/app/src/components/RoomAppHost.test.tsx
@@ -38,6 +38,13 @@ const app = {
   origin: "https://room-apps.free4.chat",
 } as const
 
+const sharedCanvasApp = {
+  id: "shared-canvas",
+  label: "Shared Canvas",
+  url: "http://localhost:8787/shared-canvas",
+  origin: "http://localhost:8787",
+} as const
+
 const self: RoomAppParticipantProjection = {
   participantId: "human-a",
   name: "Alice",
@@ -55,6 +62,55 @@ afterEach(() => {
 })
 
 describe("RoomAppHost", () => {
+  it("toggles generic host layout without replacing the iframe or MessagePort", () => {
+    vi.stubGlobal("MessageChannel", TestMessageChannel)
+    const onToggleFullscreen = vi.fn()
+    const props = {
+      app: sharedCanvasApp,
+      appInstanceId: "shared-canvas:room",
+      self,
+      participants,
+      subscribe: () => () => undefined,
+      send: () => true,
+      subscribeUnicast: () => () => undefined,
+      subscribeUnicastResults: () => () => undefined,
+      sendUnicast: () => "sent" as const,
+      onClose: () => undefined,
+      onToggleFullscreen,
+    }
+    const rendered = render(<RoomAppHost {...props} isFullscreen={false} />)
+    const iframe = screen.getByTestId("room-app-iframe") as HTMLIFrameElement
+    const frameWindow = { postMessage: vi.fn() }
+    Object.defineProperty(iframe, "contentWindow", { value: frameWindow })
+    fireEvent.load(iframe)
+    const port = lastChannel!.port1
+
+    fireEvent.click(screen.getByRole("button", { name: "Fullscreen" }))
+    expect(onToggleFullscreen).toHaveBeenCalledTimes(1)
+    rendered.rerender(<RoomAppHost {...props} isFullscreen />)
+
+    expect(screen.getByTestId("room-app-host")).toHaveAttribute(
+      "data-layout",
+      "fullscreen"
+    )
+    expect(
+      screen.getByRole("button", { name: "Exit fullscreen" })
+    ).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByTestId("room-app-iframe")).toBe(iframe)
+    expect(lastChannel!.port1).toBe(port)
+    expect(port.close).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Exit fullscreen" }))
+    rendered.rerender(<RoomAppHost {...props} isFullscreen={false} />)
+    expect(screen.getByTestId("room-app-host")).toHaveAttribute(
+      "data-layout",
+      "stage"
+    )
+    expect(screen.getByTestId("room-app-iframe")).toBe(iframe)
+    expect(lastChannel!.port1).toBe(port)
+    expect(port.close).not.toHaveBeenCalled()
+  })
+
   it("sandboxes an allowlisted App and establishes an owned MessagePort", () => {
     vi.stubGlobal("MessageChannel", TestMessageChannel)
     const onReady = vi.fn()

--- a/app/src/components/RoomAppHost.tsx
+++ b/app/src/components/RoomAppHost.tsx
@@ -41,6 +41,9 @@ interface RoomAppHostProps {
   ) => "sent" | "rate_limited" | "payload_too_large" | "delivery_unavailable"
   onClose: () => void
   onReady?: (appId: string) => void
+  isFullscreen?: boolean
+  onToggleFullscreen?: () => void
+  onUnavailable?: (appId: string) => void
 }
 
 function handshakeToken(): string {
@@ -63,12 +66,16 @@ export default function RoomAppHost({
   sendUnicast,
   onClose,
   onReady,
+  isFullscreen = false,
+  onToggleFullscreen,
+  onUnavailable,
 }: RoomAppHostProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const portRef = useRef<MessagePort | null>(null)
   const tokenRef = useRef(handshakeToken())
   const readyRef = useRef(false)
   const readyNotifiedRef = useRef(false)
+  const unavailableNotifiedRef = useRef(false)
   const previousParticipantsRef = useRef<RoomAppParticipantProjection[]>([])
   const sendRef = useRef(send)
   sendRef.current = send
@@ -77,6 +84,12 @@ export default function RoomAppHost({
   const pendingUnicastRequestsRef = useRef(new Map<string, number>())
   const [ready, setReady] = useState(false)
   const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    if (!failed || unavailableNotifiedRef.current) return
+    unavailableNotifiedRef.current = true
+    onUnavailable?.(app.id)
+  }, [app.id, failed, onUnavailable])
 
   const post = useCallback((message: RoomAppHostMessage) => {
     try {
@@ -283,15 +296,28 @@ export default function RoomAppHost({
   return (
     <section
       aria-label={app.label}
-      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-gray-950"
+      className={`flex min-h-0 flex-col overflow-hidden bg-gray-950 ${
+        isFullscreen ? "room-app-host--fullscreen" : "flex-1"
+      }`}
+      data-layout={isFullscreen ? "fullscreen" : "stage"}
       data-testid="room-app-host"
     >
-      <div className="flex flex-none items-center justify-between border-b border-gray-800 px-3 py-2 text-xs text-gray-300">
-        <span>{app.label}</span>
-        <div className="flex items-center gap-2">
+      <div className="flex flex-none items-center justify-between gap-2 border-b border-gray-800 px-3 py-2 text-xs text-gray-300">
+        <span className="min-w-0 truncate">{app.label}</span>
+        <div className="flex flex-none items-center gap-2">
           <span aria-live="polite">
             {failed ? "unavailable" : ready ? "ready" : "connecting…"}
           </span>
+          <button
+            type="button"
+            onClick={onToggleFullscreen}
+            aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            aria-pressed={isFullscreen}
+            title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            className="rounded px-2 py-1 text-gray-400 hover:bg-gray-800 hover:text-white"
+          >
+            {isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+          </button>
           <button
             type="button"
             onClick={onClose}
@@ -315,7 +341,7 @@ export default function RoomAppHost({
           allow=""
           onLoad={sendBootstrap}
           onError={() => setFailed(true)}
-          className="min-h-0 flex-1 border-0"
+          className="min-h-0 w-full min-w-0 flex-1 border-0"
           data-testid="room-app-iframe"
         />
       )}

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1372,6 +1372,147 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect(send).not.toHaveBeenCalled()
     })
 
+    it("uses a generic fullscreen layout without replacing the resident host", async () => {
+      renderAppRoom()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      const host = slotHost("shared-canvas")
+      expect(host).toHaveAttribute("data-layout", "stage")
+      expect(
+        within(host).getByRole("button", { name: "Fullscreen" })
+      ).toHaveAttribute("aria-pressed", "false")
+
+      fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+
+      expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(host).toHaveClass("room-app-host--fullscreen")
+      expect(
+        within(host).getByRole("button", { name: "Exit fullscreen" })
+      ).toHaveAttribute("aria-pressed", "true")
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+
+      fireEvent.click(
+        within(host).getByRole("button", { name: "Exit fullscreen" })
+      )
+
+      expect(host).toHaveAttribute("data-layout", "stage")
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+    })
+
+    it("exits focus mode with Escape or Close while keeping the App resident", async () => {
+      renderAppRoom()
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      const host = slotHost("shared-canvas")
+
+      fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+      fireEvent.keyDown(window, { key: "Escape" })
+      expect(host).toHaveAttribute("data-layout", "stage")
+
+      fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+      fireEvent.click(within(host).getByRole("button", { name: "Close" }))
+      expect(host).toHaveAttribute("data-layout", "stage")
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(slotHidden("shared-canvas")).toBe(false)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+    })
+
+    it("does not expand an inactive resident App and clears focus when Stage changes", async () => {
+      renderAppRoom()
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      fireEvent.click(screen.getByTestId("stage-app-tiny-arena"))
+
+      const hiddenCanvasHost = slotHost("shared-canvas")
+      const inactiveFullscreenButton = hiddenCanvasHost.querySelector(
+        'button[aria-label="Fullscreen"]'
+      ) as HTMLButtonElement
+      fireEvent.click(inactiveFullscreenButton)
+      expect(hiddenCanvasHost).toHaveAttribute("data-layout", "stage")
+
+      const arenaHost = slotHost("tiny-arena")
+      fireEvent.click(
+        within(arenaHost).getByRole("button", { name: "Fullscreen" })
+      )
+      expect(arenaHost).toHaveAttribute("data-layout", "fullscreen")
+
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      expect(arenaHost).toHaveAttribute("data-layout", "stage")
+      expect(slotHidden("tiny-arena")).toBe(true)
+      expect(slotHidden("shared-canvas")).toBe(false)
+    })
+
+    it("keeps focus mode and the same iframe through a transient transport reconnect", async () => {
+      const view = renderAppRoom()
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      const host = slotHost("shared-canvas")
+      fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "reconnecting",
+        roomAppsEnabled: false,
+        participants: [localParticipant],
+      })
+      view.rerender(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+      expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(slotHidden("shared-canvas")).toBe(false)
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+
+      mockUseSfuChatRoom.mockReturnValue({
+        ...baseHookReturn,
+        connectionStatus: "connected",
+        roomAppsEnabled: true,
+        participants: [localParticipant],
+      })
+      view.rerender(
+        <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
+      )
+      expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels).toHaveLength(1)
+      expect(channels[0].port1.close).not.toHaveBeenCalled()
+    })
+
+    it("leaves focus mode if the active App becomes unavailable", async () => {
+      renderAppRoom()
+      fireEvent.click(screen.getByTestId("stage-app-shared-canvas"))
+      const iframe = slotIframe("shared-canvas")
+      loadAppIframe(iframe)
+      const host = slotHost("shared-canvas")
+      fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+
+      act(() => {
+        channels[0].port1.emit({
+          type: "ready",
+          appInstanceId: roomAppInstanceId("test-room", "shared-canvas"),
+          handshakeToken: "wrong-handshake",
+        })
+      })
+
+      await waitFor(() => expect(host).toHaveAttribute("data-layout", "stage"))
+      expect(slotHidden("shared-canvas")).toBe(true)
+      expect(slotHost("shared-canvas")).toHaveTextContent(
+        "This Room App is unavailable"
+      )
+    })
+
     it("treats visual Close as Hide and restores the same session on reopen", async () => {
       renderAppRoom()
 

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -130,6 +130,9 @@ export default function RoomContent({
   const [taskError, setTaskError] = useState("")
   const [activeInteraction, setActiveInteraction] = useState("room")
   const [activeRoomAppId, setActiveRoomAppId] = useState<string | null>(null)
+  const [expandedRoomAppId, setExpandedRoomAppId] = useState<string | null>(
+    null
+  )
   // Browser-local resident App sessions, bounded by the curated catalog size.
   const [launchedRoomAppIds, setLaunchedRoomAppIds] = useState<string[]>([])
   const [readyRoomAppIds, setReadyRoomAppIds] = useState<string[]>([])
@@ -387,11 +390,35 @@ export default function RoomContent({
     const hostIsGone = (id: string) =>
       stablyUnavailable || !curatedRoomApps.some((app) => app.id === id)
     if (activeRoomAppId && hostIsGone(activeRoomAppId)) setActiveRoomAppId(null)
+    if (expandedRoomAppId && hostIsGone(expandedRoomAppId))
+      setExpandedRoomAppId(null)
     setLaunchedRoomAppIds((previous) => {
       const next = previous.filter((id) => !hostIsGone(id))
       return next.length === previous.length ? previous : next
     })
-  }, [activeRoomAppId, connectionStatus, curatedRoomApps, roomAppsEnabled])
+  }, [
+    activeRoomAppId,
+    connectionStatus,
+    curatedRoomApps,
+    expandedRoomAppId,
+    roomAppsEnabled,
+  ])
+
+  useEffect(() => {
+    if (!expandedRoomAppId) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      event.preventDefault()
+      setExpandedRoomAppId(null)
+    }
+    window.addEventListener("keydown", onKeyDown, true)
+    return () => window.removeEventListener("keydown", onKeyDown, true)
+  }, [expandedRoomAppId])
+
+  useEffect(() => {
+    if (expandedRoomAppId && expandedRoomAppId !== activeRoomAppId)
+      setExpandedRoomAppId(null)
+  }, [activeRoomAppId, expandedRoomAppId])
 
   const launchRoomApp = useCallback((appId: string) => {
     setLaunchedRoomAppIds((previous) =>
@@ -399,6 +426,19 @@ export default function RoomContent({
         ? previous
         : [...previous, appId].slice(-ROOM_APP_MAX_INSTANCES)
     )
+  }, [])
+
+  const toggleRoomAppFullscreen = useCallback(
+    (appId: string) => {
+      if (activeRoomAppId !== appId) return
+      setExpandedRoomAppId((current) => (current === appId ? null : appId))
+    },
+    [activeRoomAppId]
+  )
+
+  const hideRoomApp = useCallback((appId: string) => {
+    setActiveRoomAppId((current) => (current === appId ? null : current))
+    setExpandedRoomAppId((current) => (current === appId ? null : current))
   }, [])
 
   useEffect(() => {
@@ -1044,9 +1084,11 @@ export default function RoomContent({
                         if (selected) {
                           // Hide, do not destroy: the resident host keeps its
                           // iframe, MessagePort and App-local state.
+                          setExpandedRoomAppId(null)
                           setActiveRoomAppId(null)
                           return
                         }
+                        setExpandedRoomAppId(null)
                         launchRoomApp(app.id)
                         setActiveRoomAppId(app.id)
                       }}
@@ -1065,6 +1107,7 @@ export default function RoomContent({
                     type="button"
                     data-testid="stage-view-screen"
                     onClick={() => {
+                      setExpandedRoomAppId(null)
                       setStageView("screen")
                       setActiveRoomAppId(null)
                     }}
@@ -1083,6 +1126,7 @@ export default function RoomContent({
                     type="button"
                     data-testid="stage-view-live-view"
                     onClick={() => {
+                      setExpandedRoomAppId(null)
                       setStageView("live-view")
                       setActiveRoomAppId(null)
                     }}
@@ -1106,7 +1150,9 @@ export default function RoomContent({
                 keep receiving the bounded App messages. */}
             {roomAppSelf &&
               residentRoomApps.map((app) => {
-                const visible = visibleRoomApp?.id === app.id
+                const isFullscreen =
+                  expandedRoomAppId === app.id && activeRoomAppId === app.id
+                const visible = visibleRoomApp?.id === app.id || isFullscreen
                 return (
                   <div
                     key={app.id}
@@ -1128,7 +1174,10 @@ export default function RoomContent({
                       subscribeUnicast={subscribeRoomAppUnicast}
                       subscribeUnicastResults={subscribeRoomAppUnicastResults}
                       sendUnicast={sendRoomAppUnicast}
-                      onClose={() => setActiveRoomAppId(null)}
+                      isFullscreen={isFullscreen}
+                      onToggleFullscreen={() => toggleRoomAppFullscreen(app.id)}
+                      onClose={() => hideRoomApp(app.id)}
+                      onUnavailable={hideRoomApp}
                     />
                   </div>
                 )

--- a/app/src/components/TextChatCard.composer.test.tsx
+++ b/app/src/components/TextChatCard.composer.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { Message, UserInfo } from "@common/types"
@@ -234,15 +241,49 @@ describe("composer keyboard semantics", () => {
     expect(onSendText).toHaveBeenCalledWith("@Age", [])
   })
 
-  it("keeps the / command picker working from the textarea", () => {
-    const { composer, onSendAction } = renderCard()
-    typeMessage(composer, "/")
-    fireEvent.keyDown(composer, { key: "Enter" })
-    expect(onSendAction).toHaveBeenCalledWith(
-      "whiteboard",
-      expect.objectContaining({
-        url: expect.stringContaining("excalidraw.com"),
-      })
+  it("only suggests current Room action slash commands", () => {
+    const { composer } = renderCard()
+    act(() => typeMessage(composer, "/"))
+    expect(screen.getByRole("button", { name: /\/poll/ })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /\/draw/ })).toBeNull()
+    expect(screen.queryByRole("button", { name: /\/games/ })).toBeNull()
+
+    act(() => typeMessage(composer, "/draw"))
+    expect(screen.queryByRole("button", { name: /\/draw/ })).toBeNull()
+    act(() => typeMessage(composer, "/games"))
+    expect(screen.queryByRole("button", { name: /\/games/ })).toBeNull()
+  })
+
+  it("continues to render historical Whiteboard and game action messages", () => {
+    renderCard({
+      messages: [
+        {
+          peerId: "human-legacy",
+          name: "Earlier Human",
+          kind: "human",
+          type: "action",
+          actionType: "whiteboard",
+          actionPayload: { url: "https://excalidraw.com/#room=old,key" },
+          sequence: 1,
+        },
+        {
+          peerId: "human-legacy",
+          name: "Earlier Human",
+          kind: "human",
+          type: "action",
+          actionType: "game",
+          actionPayload: { gameId: "skribbl" },
+          sequence: 2,
+        },
+      ],
+    })
+
+    expect(
+      screen.getByRole("link", { name: /Open Whiteboard/ })
+    ).toHaveAttribute("href", "https://excalidraw.com/#room=old,key")
+    expect(screen.getByRole("link", { name: /skribbl\.io/ })).toHaveAttribute(
+      "href",
+      "https://skribbl.io"
     )
   })
 })
@@ -342,37 +383,21 @@ describe("markdown rendering", () => {
 })
 
 describe("secondary action menu", () => {
-  it("moves Whiteboard/Poll/Games/Attach into the + menu and keeps them wired", () => {
+  it("keeps only Attach file and Poll in the Room actions menu", () => {
     const { onSendAction } = renderCard()
 
     // The legacy first-class pills are gone from the composer.
     expect(screen.queryByText("Draw")).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText("More actions"))
-    expect(screen.getByText("Attach file")).toBeInTheDocument()
-    expect(screen.getByText("Whiteboard")).toBeInTheDocument()
-    expect(screen.getByText("Poll")).toBeInTheDocument()
-    expect(screen.getByText("Games")).toBeInTheDocument()
-
-    fireEvent.click(screen.getByText("Whiteboard"))
-    expect(onSendAction).toHaveBeenCalledWith(
-      "whiteboard",
-      expect.objectContaining({
-        url: expect.stringContaining("excalidraw.com"),
-      })
-    )
-    expect(screen.queryByText("Attach file")).not.toBeInTheDocument()
-  })
-
-  it("opens the Games list from the + menu", () => {
-    const { onSendAction } = renderCard()
-    fireEvent.click(screen.getByLabelText("More actions"))
-    fireEvent.click(screen.getByText("Games"))
-    fireEvent.click(screen.getByText("skribbl.io"))
-    expect(onSendAction).toHaveBeenCalledWith(
-      "game",
-      expect.objectContaining({ gameId: "skribbl" })
-    )
+    const menu = screen.getByText("Room actions").parentElement
+    expect(menu).not.toBeNull()
+    expect(within(menu!).getAllByRole("button")).toHaveLength(2)
+    expect(within(menu!).getByText("Attach file")).toBeInTheDocument()
+    expect(within(menu!).getByText("Poll")).toBeInTheDocument()
+    expect(screen.queryByText("Whiteboard")).not.toBeInTheDocument()
+    expect(screen.queryByText("Games")).not.toBeInTheDocument()
+    expect(onSendAction).not.toHaveBeenCalled()
   })
 
   it("opens the Poll creator from the + menu and still sends polls", () => {

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -107,7 +107,9 @@ interface TextChatCardProps {
   taskAvailable?: boolean
 }
 
-const GAMES = [
+// These details are retained only to render historical `game` action
+// messages. New external-game actions are no longer created from the composer.
+const LEGACY_GAME_CARDS = [
   {
     id: "skribbl",
     emoji: "✏️",
@@ -378,27 +380,6 @@ function attachmentErrorMessage(error: unknown): string {
   return detail || "Couldn't send this attachment. Try again or remove it."
 }
 
-function getOrCreateWhiteboardUrl(room: string): string {
-  const storageKey = `wb-key-${room}`
-  let key = localStorage.getItem(storageKey)
-  if (!key) {
-    const bytes = new Uint8Array(16)
-    crypto.getRandomValues(bytes)
-    key = btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(""))
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=/g, "")
-      .slice(0, 22)
-    localStorage.setItem(storageKey, key)
-  }
-  const roomId = room
-    .split("")
-    .reduce((acc, c) => (acc * 31 + c.charCodeAt(0)) & 0xffffff, 0)
-    .toString(16)
-    .padStart(6, "0")
-  return `https://excalidraw.com/#room=${roomId},${key}`
-}
-
 function PollCard({
   msg,
   isSelf,
@@ -481,7 +462,7 @@ function GameCard({ msg, isSelf }: { msg: Message; isSelf: boolean }) {
     : "ml-2 rounded-br-3xl rounded-tr-3xl rounded-tl-xl px-4 py-3"
 
   const gameId = msg.actionPayload?.gameId ?? ""
-  const game = GAMES.find((g) => g.id === gameId)
+  const game = LEGACY_GAME_CARDS.find((g) => g.id === gameId)
   if (!game) return null
 
   return (
@@ -1466,49 +1447,6 @@ function PollCreator({
   )
 }
 
-function GamesMenu({
-  onSelect,
-  onBack,
-  menuRef,
-}: {
-  onSelect: (gameId: string) => void
-  onBack: () => void
-  menuRef?: React.RefObject<HTMLDivElement>
-}) {
-  return (
-    <>
-      <div className="fixed inset-0 z-20 md:hidden" onClick={onBack} />
-      <div
-        ref={menuRef}
-        className="fixed bottom-0 left-0 right-0 z-30 max-h-[60vh] overflow-y-auto rounded-t-xl border-t border-gray-600 bg-gray-800 py-1 shadow-xl md:absolute md:bottom-full md:left-0 md:right-auto md:mb-1 md:max-h-72 md:w-52 md:rounded-lg md:border md:border-gray-600"
-      >
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex w-full items-center gap-1 px-3 py-1.5 text-xs text-gray-400 hover:bg-gray-700"
-        >
-          ← Back
-        </button>
-        <div className="mx-2 my-1 border-t border-gray-700" />
-        {GAMES.map((g) => (
-          <button
-            key={g.id}
-            type="button"
-            onClick={() => onSelect(g.id)}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-700"
-          >
-            <span>{g.emoji}</span>
-            <div>
-              <p className="text-sm text-gray-200">{g.name}</p>
-              <p className="text-xs text-gray-500">{g.desc}</p>
-            </div>
-          </button>
-        ))}
-      </div>
-    </>
-  )
-}
-
 const TextChatCard = memo(function TextChatCard({
   room,
   nickName,
@@ -1538,7 +1476,7 @@ const TextChatCard = memo(function TextChatCard({
   const [draftAttachmentError, setDraftAttachmentError] = useState<string>("")
   const [sendingDraft, setSendingDraft] = useState(false)
   const sendingRef = useRef(false)
-  const [submenu, setSubmenu] = useState<"more" | "games" | null>(null)
+  const [submenu, setSubmenu] = useState<"more" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
   const [pickerIndex, setPickerIndex] = useState(0)
   const [artifactId, setArtifactId] = useState<string | null>(null)
@@ -1555,7 +1493,6 @@ const TextChatCard = memo(function TextChatCard({
   const textRef = useRef<HTMLTextAreaElement>(null)
   const moreBtnRef = useRef<HTMLDivElement>(null)
   const moreMenuRef = useRef<HTMLDivElement>(null)
-  const gamesMenuRef = useRef<HTMLDivElement>(null)
   const isComposingRef = useRef(false)
   const handlePreviewArtifact = useCallback((attachmentId: string) => {
     setArtifactId(attachmentId)
@@ -1588,10 +1525,7 @@ const TextChatCard = memo(function TextChatCard({
       const target = e.target as Node
       const inBtn = moreBtnRef.current?.contains(target)
       const inMoreMenu = moreMenuRef.current?.contains(target)
-      const inGamesMenu = gamesMenuRef.current?.contains(target)
-      if (!inBtn && !inMoreMenu && !inGamesMenu) {
-        setSubmenu(null)
-      }
+      if (!inBtn && !inMoreMenu) setSubmenu(null)
     }
     if (submenu) document.addEventListener("mousedown", handleClickOutside)
     return () => document.removeEventListener("mousedown", handleClickOutside)
@@ -1713,13 +1647,6 @@ const TextChatCard = memo(function TextChatCard({
     setDraftAttachmentError("")
   }
 
-  const handleWhiteboard = () => {
-    closeMenu()
-    const url = getOrCreateWhiteboardUrl(room)
-    umamiEvent("ChatAction", { type: "whiteboard", roomHash: hashRoom(room) })
-    onSendAction("whiteboard", { url })
-  }
-
   const handlePoll = () => {
     closeMenu()
     setShowPollCreator(true)
@@ -1735,12 +1662,6 @@ const TextChatCard = memo(function TextChatCard({
     })
   }
 
-  const handleGameSelect = (gameId: string) => {
-    closeMenu()
-    umamiEvent("ChatAction", { type: "game", gameId, roomHash: hashRoom(room) })
-    onSendAction("game", { gameId })
-  }
-
   const handleVote = useCallback(
     (pollId: string, option: string) => {
       umamiEvent("ChatAction", { type: "vote", roomHash: hashRoom(room) })
@@ -1751,30 +1672,12 @@ const TextChatCard = memo(function TextChatCard({
 
   const slashCommands = [
     {
-      icon: "🎨",
-      label: "/draw",
-      desc: "Open whiteboard",
-      action: () => {
-        setMessage("")
-        handleWhiteboard()
-      },
-    },
-    {
       icon: "📊",
       label: "/poll",
       desc: "Create a poll",
       action: () => {
         setMessage("")
         handlePoll()
-      },
-    },
-    {
-      icon: "🎮",
-      label: "/games",
-      desc: "Share a game link",
-      action: () => {
-        setMessage("")
-        setSubmenu("games")
       },
     },
   ]
@@ -1988,7 +1891,7 @@ const TextChatCard = memo(function TextChatCard({
                   className="rounded-full bg-gray-700 p-2.5 text-gray-300 transition hover:bg-gray-600 hover:text-white"
                   title="More actions"
                   aria-label="More actions"
-                  aria-expanded={submenu === "more" || submenu === "games"}
+                  aria-expanded={submenu === "more"}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -2032,34 +1935,13 @@ const TextChatCard = memo(function TextChatCard({
                       </button>
                       <button
                         type="button"
-                        onClick={handleWhiteboard}
-                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                      >
-                        <span>🎨</span> Whiteboard
-                      </button>
-                      <button
-                        type="button"
                         onClick={handlePoll}
                         className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
                       >
                         <span>📊</span> Poll
                       </button>
-                      <button
-                        type="button"
-                        onClick={() => setSubmenu("games")}
-                        className="flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-gray-200 hover:bg-gray-700"
-                      >
-                        <span>🎮</span> Games
-                      </button>
                     </div>
                   </>
-                )}
-                {submenu === "games" && (
-                  <GamesMenu
-                    onSelect={handleGameSelect}
-                    onBack={() => setSubmenu(null)}
-                    menuRef={gamesMenuRef}
-                  />
                 )}
               </div>
             )}

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -6,6 +6,21 @@ html {
   @apply antialiased;
 }
 
+/* Room App focus mode changes only the host layout. The resident host and its
+   iframe remain in place, while safe-area padding keeps its controls reachable
+   on phones using edge-to-edge viewports. */
+.room-app-host--fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  box-sizing: border-box;
+  height: 100vh;
+  height: 100dvh;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+  overscroll-behavior: contain;
+}
+
 /* --- Retro terminal scope (homepage only) --- */
 
 .retro-scope {


### PR DESCRIPTION
## Summary

- Remove the legacy Excalidraw creation path and external Games menu from the Room composer, including `/draw`, `/games`, their action handlers, and their ChatAction analytics.
- Keep the historical `whiteboard` and `game` action renderers so existing messages remain readable.
- Leave the `ROOM ACTIONS` menu with only **Attach file** and **Poll**, preserving both existing behaviors.
- Add generic Room App fullscreen/focus mode to the active Stage App.

## Fullscreen design

`RoomContent` owns the expanded Room App id and clears it when the host document receives Escape, on Close, Stage changes, host failure, stable Room App unavailability, or catalog removal. Transient Room transport reconnects retain focus state. `RoomAppHost` toggles a host-only fixed viewport layout (`100dvh`, safe-area padding) around its existing resident component; it does not use browser-native fullscreen.

Fullscreen is presentation-only. The resident iframe and its MessagePort remain the same DOM/runtime instances across entry, exit, Close/reopen, and reconnect. No Room App protocol, transport, Room state, backend, catalog, or Whiteboard implementation changed.

## Validation

- Focused tests: 3 files, 67 tests passed.
- Full Vitest suite: 91 files, 864 tests passed.
- `yarn eslint src`, `yarn type-check`, changed-file Prettier checks, `yarn docs:check`, and `yarn cf-build` passed. OpenNext reported its existing Durable Object local-binding and package-copy warnings; the build exited successfully.
- Playwright against the local Room Worker with the deployed Whiteboard iframe: desktop Enter/Escape/Close/reopen passed with the iframe identity unchanged; 390×844 mobile passed with the Exit/Close toolbar reachable, a touch delivered to the Whiteboard canvas, 390px host/iframe width, 844px host height, 803px iframe height, and no horizontal overflow.

## Remaining keyboard edge

Room Apps are sandboxed cross-origin iframes. The host cannot observe Escape keystrokes while focus is inside the iframe with the current unchanged MessagePort contract. The visible **Exit fullscreen** toolbar button remains available; Escape was browser-smoked while the host document had focus. Supporting Escape from inside the iframe would require app/protocol cooperation or native fullscreen, which this PR intentionally does not add.

## Base and head

- Base `cf-sfu`: `de45975a06978844cf94c1118c4a154a89dc8df4`
- Head: `78a8ce6dbd64bca433aec534441e51eb44b4b69d`

Refs #375
