### PR TITLE
fix(room-app): hide Room UI during fullscreen focus

### DIFF
--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1379,7 +1379,22 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       const iframe = slotIframe("shared-canvas")
       loadAppIframe(iframe)
       const host = slotHost("shared-canvas")
+      const port = channels[0].port1
+      const chatPanel = screen
+        .getByTestId("interaction-chat")
+        .closest(".room-chat-panel")
+      const composer = screen.getByPlaceholderText(
+        "Message the room or @ an Agent…"
+      )
+      const stage = screen.getByTestId("room-stage")
+      const roomShell = screen.getByRole("main")
+      const roomHeader = screen
+        .getByTestId("room-header-identity")
+        .closest("header")
       expect(host).toHaveAttribute("data-layout", "stage")
+      expect(chatPanel).toBeVisible()
+      expect(composer).toBeVisible()
+      expect(stage).toHaveStyle({ width: "75%" })
       expect(
         within(host).getByRole("button", { name: "Fullscreen" })
       ).toHaveAttribute("aria-pressed", "false")
@@ -1387,22 +1402,44 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
 
       expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(roomShell).toHaveAttribute("data-room-app-focus", "true")
       expect(host).toHaveClass("room-app-host--fullscreen")
       expect(
         within(host).getByRole("button", { name: "Exit fullscreen" })
       ).toHaveAttribute("aria-pressed", "true")
+      expect(roomHeader).not.toBeVisible()
+      expect(roomHeader).toHaveAttribute("aria-hidden", "true")
+      expect(roomHeader).toHaveAttribute("inert")
+      expect(screen.getByTestId("stage-switcher")).not.toBeVisible()
+      expect(screen.getByTestId("stage-switcher")).toHaveAttribute("inert")
+      expect(chatPanel).not.toBeVisible()
+      expect(chatPanel).toHaveAttribute("aria-hidden", "true")
+      expect(chatPanel).toHaveAttribute("inert")
+      expect(composer).not.toBeVisible()
+      expect(composer.closest("[inert]")).toBe(chatPanel)
       expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1).toBe(port)
       expect(channels).toHaveLength(1)
-      expect(channels[0].port1.close).not.toHaveBeenCalled()
+      expect(port.close).not.toHaveBeenCalled()
 
       fireEvent.click(
         within(host).getByRole("button", { name: "Exit fullscreen" })
       )
 
       expect(host).toHaveAttribute("data-layout", "stage")
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(roomShell).not.toHaveAttribute("data-room-app-focus")
+      expect(roomHeader).toBeVisible()
+      expect(roomHeader).not.toHaveAttribute("inert")
+      expect(chatPanel).toBeVisible()
+      expect(chatPanel).not.toHaveAttribute("inert")
+      expect(composer).toBeVisible()
+      expect(stage).toHaveStyle({ width: "75%" })
       expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1).toBe(port)
       expect(channels).toHaveLength(1)
-      expect(channels[0].port1.close).not.toHaveBeenCalled()
+      expect(port.close).not.toHaveBeenCalled()
     })
 
     it("exits focus mode with Escape or Close while keeping the App resident", async () => {
@@ -1420,6 +1457,12 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       fireEvent.click(within(host).getByRole("button", { name: "Close" }))
       expect(host).toHaveAttribute("data-layout", "stage")
       expect(slotHidden("shared-canvas")).toBe(true)
+      expect(
+        screen.getByTestId("interaction-chat").closest(".room-chat-panel")
+      ).toBeVisible()
+      expect(
+        screen.getByPlaceholderText("Message the room or @ an Agent…")
+      ).toBeVisible()
       expect(slotIframe("shared-canvas")).toBe(iframe)
       expect(channels).toHaveLength(1)
       expect(channels[0].port1.close).not.toHaveBeenCalled()
@@ -1461,6 +1504,7 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       loadAppIframe(iframe)
       const host = slotHost("shared-canvas")
       fireEvent.click(within(host).getByRole("button", { name: "Fullscreen" }))
+      const port = channels[0].port1
 
       mockUseSfuChatRoom.mockReturnValue({
         ...baseHookReturn,
@@ -1472,8 +1516,17 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
         <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
       )
       expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(screen.getByRole("main")).toHaveAttribute(
+        "data-room-app-focus",
+        "true"
+      )
       expect(slotHidden("shared-canvas")).toBe(false)
+      expect(
+        screen.getByTestId("interaction-chat").closest(".room-chat-panel")
+      ).not.toBeVisible()
       expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1).toBe(port)
 
       mockUseSfuChatRoom.mockReturnValue({
         ...baseHookReturn,
@@ -1485,7 +1538,16 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
         <RoomContent roomName="test-room" nickName="Alice" roomType="audio" />
       )
       expect(host).toHaveAttribute("data-layout", "fullscreen")
+      expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(screen.getByRole("main")).toHaveAttribute(
+        "data-room-app-focus",
+        "true"
+      )
+      expect(
+        screen.getByTestId("interaction-chat").closest(".room-chat-panel")
+      ).not.toBeVisible()
       expect(slotIframe("shared-canvas")).toBe(iframe)
+      expect(channels[0].port1).toBe(port)
       expect(channels).toHaveLength(1)
       expect(channels[0].port1.close).not.toHaveBeenCalled()
     })

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1517,6 +1517,14 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       )
       expect(host).toHaveAttribute("data-layout", "fullscreen")
       expect(screen.getByTestId("room-app-host")).toBe(host)
+      const slot = screen.getByTestId("room-app-slot-shared-canvas")
+      const reconnectGuard = screen.getByTestId("room-reconnect-guard")
+      expect(reconnectGuard).toBeVisible()
+      expect(reconnectGuard).toHaveAttribute("role", "alert")
+      expect(reconnectGuard).not.toHaveAttribute("inert")
+      expect(reconnectGuard).not.toHaveAttribute("aria-hidden", "true")
+      expect(slot).toHaveAttribute("inert")
+      expect(slot).toHaveAttribute("aria-hidden", "true")
       expect(screen.getByRole("main")).toHaveAttribute(
         "data-room-app-focus",
         "true"
@@ -1525,8 +1533,12 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect(
         screen.getByTestId("interaction-chat").closest(".room-chat-panel")
       ).not.toBeVisible()
+      expect(
+        screen.getByPlaceholderText("Message the room or @ an Agent…")
+      ).not.toBeVisible()
       expect(slotIframe("shared-canvas")).toBe(iframe)
       expect(channels[0].port1).toBe(port)
+      expect(port.close).not.toHaveBeenCalled()
 
       mockUseSfuChatRoom.mockReturnValue({
         ...baseHookReturn,
@@ -1539,6 +1551,11 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       )
       expect(host).toHaveAttribute("data-layout", "fullscreen")
       expect(screen.getByTestId("room-app-host")).toBe(host)
+      expect(
+        screen.queryByTestId("room-reconnect-guard")
+      ).not.toBeInTheDocument()
+      expect(slot).not.toHaveAttribute("inert")
+      expect(slot).not.toHaveAttribute("aria-hidden", "true")
       expect(screen.getByRole("main")).toHaveAttribute(
         "data-room-app-focus",
         "true"
@@ -1549,7 +1566,7 @@ describe("RoomContent — Turnstile widget lifecycle", () => {
       expect(slotIframe("shared-canvas")).toBe(iframe)
       expect(channels[0].port1).toBe(port)
       expect(channels).toHaveLength(1)
-      expect(channels[0].port1.close).not.toHaveBeenCalled()
+      expect(port.close).not.toHaveBeenCalled()
     })
 
     it("leaves focus mode if the active App becomes unavailable", async () => {

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -277,6 +277,16 @@ export default function RoomContent({
   const whiteboardReady = readyRoomAppIds.includes("whiteboard")
   const visibleRoomApp =
     activeRoomApp && roomAppSelf ? activeRoomApp : undefined
+  // Focus mode is a Room layout state, not just a larger host. The resident
+  // host remains in its Stage subtree; all surrounding Room UI is made inert
+  // and removed from layout so nested stacking contexts cannot paint over or
+  // intercept input from the fixed host.
+  const isRoomAppFullscreen = Boolean(
+    roomAppSelf &&
+      expandedRoomAppId &&
+      expandedRoomAppId === activeRoomAppId &&
+      residentRoomApps.some((app) => app.id === expandedRoomAppId)
+  )
   const activeTask = taskProjections.find(
     (task) => task.requestId === activeInteraction
   )
@@ -905,15 +915,36 @@ export default function RoomContent({
   }
 
   return (
-    <main className="room-shell flex h-screen flex-col overflow-hidden bg-gray-900 text-white">
+    <main
+      className="room-shell flex h-screen flex-col overflow-hidden bg-gray-900 text-white"
+      data-room-app-focus={isRoomAppFullscreen ? "true" : undefined}
+    >
       {connectionStatus === "reconnecting" && (
-        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60">
+        <div
+          className={`fixed inset-0 z-50 bg-black/60 ${
+            isRoomAppFullscreen
+              ? "hidden"
+              : "flex flex-col items-center justify-center"
+          }`}
+          hidden={isRoomAppFullscreen}
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
+        >
           <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-gray-700 border-t-yellow-400" />
           <p className="text-sm text-gray-400">Reconnecting...</p>
         </div>
       )}
 
-      <header className="room-header flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center">
+      <header
+        className={`room-header ${
+          isRoomAppFullscreen
+            ? "hidden"
+            : "flex flex-none flex-col gap-2 border-b border-gray-800 px-4 py-3 lg:flex-row lg:items-center"
+        }`}
+        hidden={isRoomAppFullscreen}
+        aria-hidden={isRoomAppFullscreen}
+        inert={isRoomAppFullscreen}
+      >
         <div
           data-testid="room-header-identity"
           className="flex min-w-0 items-center gap-2"
@@ -997,8 +1028,15 @@ export default function RoomContent({
 
       {error !== "" && (
         <div
-          className="flex flex-none items-center gap-4 bg-gray-900 px-4 py-2 text-white"
+          className={`${
+            isRoomAppFullscreen
+              ? "hidden"
+              : "flex flex-none items-center gap-4 bg-gray-900 px-4 py-2 text-white"
+          }`}
+          hidden={isRoomAppFullscreen}
           role="alert"
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1017,11 +1055,23 @@ export default function RoomContent({
           <strong className="text-sm font-normal"> {error} </strong>
         </div>
       )}
-      <LiveTranscriptSegments segments={liveTranscriptSegments} />
+      <div
+        className={isRoomAppFullscreen ? "hidden" : undefined}
+        hidden={isRoomAppFullscreen}
+        aria-hidden={isRoomAppFullscreen}
+        inert={isRoomAppFullscreen}
+      >
+        <LiveTranscriptSegments segments={liveTranscriptSegments} />
+      </div>
       {screenShareWarning !== "" && (
         <div
-          className="mx-4 mt-1 flex flex-none items-center gap-4 rounded border border-amber-700/50 bg-amber-900/40 px-4 py-2 text-amber-200"
+          className={`mx-4 mt-1 flex-none items-center gap-4 rounded border border-amber-700/50 bg-amber-900/40 px-4 py-2 text-amber-200 ${
+            isRoomAppFullscreen ? "hidden" : "flex"
+          }`}
+          hidden={isRoomAppFullscreen}
           role="alert"
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1052,10 +1102,17 @@ export default function RoomContent({
         >
           {/* #111: Agent workspace snapshots — observation only, available in
               every room type; Human screen share is untouched below. */}
-          <WorkspaceSnapshots
-            participants={participants}
-            getLocalRoomAuth={getLocalRoomAuth}
-          />
+          <div
+            className={isRoomAppFullscreen ? "hidden" : undefined}
+            hidden={isRoomAppFullscreen}
+            aria-hidden={isRoomAppFullscreen}
+            inert={isRoomAppFullscreen}
+          >
+            <WorkspaceSnapshots
+              participants={participants}
+              getLocalRoomAuth={getLocalRoomAuth}
+            />
+          </div>
           <div className="relative flex flex-1 flex-col overflow-hidden">
             {/* The Stage entry: curated Room Apps plus the existing Screen /
                 Live View preference. Stage selection is independent from the
@@ -1070,7 +1127,12 @@ export default function RoomContent({
                 role="tablist"
                 aria-label="Stage"
                 data-testid="stage-switcher"
-                className="scrollbar-thin z-10 flex flex-none gap-1 overflow-x-auto border-b border-gray-800 bg-gray-950/80 p-2"
+                className={`scrollbar-thin z-10 flex-none gap-1 overflow-x-auto border-b border-gray-800 bg-gray-950/80 p-2 ${
+                  isRoomAppFullscreen ? "hidden" : "flex"
+                }`}
+                hidden={isRoomAppFullscreen}
+                aria-hidden={isRoomAppFullscreen}
+                inert={isRoomAppFullscreen}
               >
                 {roomApps.map((app) => {
                   const selected = activeRoomAppId === app.id
@@ -1183,6 +1245,7 @@ export default function RoomContent({
                 )
               })}
             {!visibleRoomApp &&
+              !isRoomAppFullscreen &&
               (activeScreenShares.length > 0 ? (
                 <>
                   <div
@@ -1299,27 +1362,42 @@ export default function RoomContent({
                 </div>
               ))}
 
-            {floatingReactions.map((r) => (
-              <div
-                key={r.id}
-                className="pointer-events-none absolute bottom-4 animate-float-up text-2xl"
-                style={{ left: `${r.x}%` }}
-              >
-                {r.emoji}
-              </div>
-            ))}
+            {!isRoomAppFullscreen &&
+              floatingReactions.map((r) => (
+                <div
+                  key={r.id}
+                  className="pointer-events-none absolute bottom-4 animate-float-up text-2xl"
+                  style={{ left: `${r.x}%` }}
+                >
+                  {r.emoji}
+                </div>
+              ))}
           </div>
         </div>
 
         <div
-          className="hidden w-1 cursor-col-resize bg-gray-800 transition-colors hover:bg-blue-500/50 active:bg-blue-500 md:block"
+          className={`w-1 cursor-col-resize bg-gray-800 transition-colors hover:bg-blue-500/50 active:bg-blue-500 ${
+            isRoomAppFullscreen ? "hidden" : "hidden md:block"
+          }`}
+          hidden={isRoomAppFullscreen}
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
           onMouseDown={(e) => {
             isDragging.current = true
             e.preventDefault()
           }}
         />
 
-        <div className="room-panel room-chat-panel flex flex-1 flex-col overflow-hidden">
+        <div
+          className={`room-panel room-chat-panel ${
+            isRoomAppFullscreen
+              ? "hidden"
+              : "flex flex-1 flex-col overflow-hidden"
+          }`}
+          hidden={isRoomAppFullscreen}
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
+        >
           <div
             role="tablist"
             aria-label="Room interactions"
@@ -1433,10 +1511,15 @@ export default function RoomContent({
       </div>
       {taskAgent && (
         <div
-          className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 px-4"
+          className={`fixed inset-0 z-40 bg-black/60 px-4 ${
+            isRoomAppFullscreen ? "hidden" : "flex items-center justify-center"
+          }`}
+          hidden={isRoomAppFullscreen}
           role="dialog"
           aria-modal="true"
           aria-labelledby="start-task-title"
+          aria-hidden={isRoomAppFullscreen}
+          inert={isRoomAppFullscreen}
         >
           <form
             onSubmit={submitTask}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -921,14 +921,10 @@ export default function RoomContent({
     >
       {connectionStatus === "reconnecting" && (
         <div
-          className={`fixed inset-0 z-50 bg-black/60 ${
-            isRoomAppFullscreen
-              ? "hidden"
-              : "flex flex-col items-center justify-center"
-          }`}
-          hidden={isRoomAppFullscreen}
-          aria-hidden={isRoomAppFullscreen}
-          inert={isRoomAppFullscreen}
+          data-testid="room-reconnect-guard"
+          role="alert"
+          aria-live="assertive"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60"
         >
           <div className="mb-4 h-10 w-10 animate-spin rounded-full border-4 border-gray-700 border-t-yellow-400" />
           <p className="text-sm text-gray-400">Reconnecting...</p>
@@ -1215,12 +1211,14 @@ export default function RoomContent({
                 const isFullscreen =
                   expandedRoomAppId === app.id && activeRoomAppId === app.id
                 const visible = visibleRoomApp?.id === app.id || isFullscreen
+                const reconnectBlocked =
+                  isFullscreen && connectionStatus === "reconnecting"
                 return (
                   <div
                     key={app.id}
                     data-testid={`room-app-slot-${app.id}`}
-                    aria-hidden={!visible}
-                    inert={!visible}
+                    aria-hidden={!visible || reconnectBlocked}
+                    inert={!visible || reconnectBlocked}
                     className={
                       visible ? "flex min-h-0 flex-1 flex-col" : "hidden"
                     }

--- a/app/src/styles/tailwind.css
+++ b/app/src/styles/tailwind.css
@@ -6,9 +6,9 @@ html {
   @apply antialiased;
 }
 
-/* Room App focus mode changes only the host layout. The resident host and its
-   iframe remain in place, while safe-area padding keeps its controls reachable
-   on phones using edge-to-edge viewports. */
+/* Room App focus positioning stays on the resident host node. RoomContent
+   removes its sibling Room UI from layout while focused; safe-area padding
+   keeps the host controls reachable in edge-to-edge phone viewports. */
 .room-app-host--fullscreen {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
The fullscreen Room App host is fixed inside the Stage subtree, whose `.room-participants-panel` creates an isolated stacking context. The sibling Room chat can therefore paint over the host even though the host is fixed to the viewport.

RoomContent now treats fullscreen as a Room layout state: surrounding Room chrome is hidden and inert while the resident App stays in the same Stage subtree. Focus follows the resident host through transient reconnect availability changes. Exiting or closing focus restores the existing layout and split ratio without replacing the host, iframe, or MessagePort.

Validation:
- `yarn test` — 91 files, 864 tests passed.
- `yarn type-check`, `yarn eslint src`, `yarn docs:check`, and Prettier check passed.
- `NEXT_PUBLIC_TURNSTILE_DISABLED=1 yarn cf-build` completed.
- Real Chrome smoke against the production Whiteboard iframe and a local production Worker/RoomSession harness passed at desktop 1280×900 and mobile 390×844. The host covered the viewport, chat/composer were hidden and inert, bottom hit-testing landed on the App, mobile touch input reached the Whiteboard, and host/iframe/ready MessagePort identity survived enter/exit.
